### PR TITLE
docs: add Samia full-control operator onboarding guide

### DIFF
--- a/content/docs/meta.json
+++ b/content/docs/meta.json
@@ -14,6 +14,7 @@
     "---Operations---",
     "captain",
     "team",
+    "samia",
     "dispatch",
     "context",
     "cowork",

--- a/content/docs/samia.mdx
+++ b/content/docs/samia.mdx
@@ -1,0 +1,760 @@
+---
+title: Samia
+description: Full-control operator onboarding for databayt
+---
+
+# Samia
+
+> Onboarding the new operator — accounts, tools, config, contribution, daily ops.
+
+You hold full operating authority across databayt: **CEO · Captain · Tech · Business · R&D**. This page walks you from a brand-new Windows laptop to running the org by Monday morning.
+
+Every section is a runnable step. Read top to bottom on day one; bookmark and jump to specific sections after.
+
+## Scope
+
+What you decide, where the boundary sits, and what to escalate.
+
+| Domain | You decide | Boundary (dispatch Abdout first) |
+|--------|------------|----------------------------------|
+| **CEO** | Weekly priorities, scope cuts, resource rebalancing | Hiring, license changes, partnership agreements |
+| **Captain** | Cross-agent allocation, sprint plan, deadlines | — |
+| **Tech** | Architecture, cross-repo patterns, deploys | Public API breaking changes |
+| **Business** | Pricing, proposals, customer ops | Anything that moves money (Stripe, AWS billing, payouts) |
+| **R&D** | Share-economy operationalization, revenue framework | Changes to `CONSTITUTION`, `PRINCIPLES`, doctrine |
+
+See [captain](/docs/captain) for the decision matrix and [team](/docs/team) for the roster.
+
+---
+
+## 0. Accounts you need
+
+Create these once. Use your `@databayt.org` email for all three.
+
+### 0.1 GitHub
+
+1. Open [github.com/signup](https://github.com/signup)
+2. Email: `samia@databayt.org`
+3. Username: short, lowercase, no symbols — this becomes your public handle (`github.com/<you>`)
+4. Verify the email
+5. Enable 2FA: Settings → Password and authentication → Two-factor authentication → Authenticator app (use 1Password or Authy). Save the recovery codes in 1Password.
+6. Generate a Personal Access Token: Settings → Developer settings → Personal access tokens → Tokens (classic) → Generate new token (classic). Scopes: `repo`, `read:org`, `workflow`, `gist`. Expiry: 90 days. Save the token in 1Password as `GITHUB_PERSONAL_ACCESS_TOKEN`.
+7. Send your GitHub username to Abdout: `c "/dispatch GitHub username: <yourname>, please add to databayt org with operator role"`
+8. Accept the org invite at the email link, or at [github.com/databayt](https://github.com/databayt)
+
+### 0.2 JetBrains
+
+1. Open [account.jetbrains.com](https://account.jetbrains.com/login) → Sign up
+2. Email: `samia@databayt.org`
+3. Dispatch Abdout to assign you a seat on the team All Products Pack (gives WebStorm + IntelliJ + everything)
+
+### 0.3 Claude (Anthropic)
+
+1. Open [claude.ai](https://claude.ai/login) → Sign up
+2. Email: `samia@databayt.org`
+3. Dispatch Abdout for a paid seat (Pro, Max, Team, Enterprise, or Console API). **Claude Code requires a paid plan — the free `claude.ai` tier won't authenticate the CLI.** Official authentication reference: [Anthropic — Authentication](https://code.claude.com/docs/en/authentication).
+4. The same login works for Claude Code CLI, Claude Desktop, and the WebStorm plugin.
+
+---
+
+## 1. Install the side-tools
+
+Five tools. Order doesn't matter; they're independent.
+
+### 1.1 Git
+
+```powershell
+winget install Git.Git
+```
+
+Reopen PowerShell so `git` is on PATH, then identify yourself (this name shows on every commit):
+
+```powershell
+git config --global user.name "Samia Hamd"
+git config --global user.email "samia@databayt.org"
+git config --global init.defaultBranch main
+git config --global pull.rebase false
+```
+
+### 1.2 Node.js + pnpm
+
+```powershell
+winget install OpenJS.NodeJS.LTS
+# Reopen PowerShell
+node --version          # expect v22.x
+npm install -g pnpm
+pnpm --version
+```
+
+### 1.3 GitHub CLI
+
+```powershell
+winget install GitHub.cli
+gh auth login
+# Choose: GitHub.com → HTTPS → "Login with web browser"
+```
+
+Verify:
+
+```powershell
+gh auth status
+gh repo list databayt --limit 5
+```
+
+### 1.4 PowerShell 7 (recommended)
+
+```powershell
+winget install Microsoft.PowerShell
+```
+
+PS 7 has better Unicode, faster startup, and is the modern target. Set it as Windows Terminal's default: Settings → Default profile → PowerShell.
+
+### 1.5 Enable Developer Mode (for symlinks)
+
+Settings → System → For developers → enable.
+
+Without this, parts of the install fall back to file copies. The install still works but loses live `git pull` updates of the config tree.
+
+---
+
+## 2. Install Claude Code CLI
+
+The CLI is what runs in your terminal and powers the WebStorm plugin. Three install paths — pick one.
+
+### 2.1 Install
+
+**WinGet (recommended on Windows — managed by the system, easy to upgrade):**
+
+```powershell
+winget install Anthropic.ClaudeCode
+```
+
+To upgrade later: `winget upgrade Anthropic.ClaudeCode`.
+
+**Native installer (auto-updates in the background):**
+
+```powershell
+irm https://claude.ai/install.ps1 | iex
+```
+
+**npm (fallback, requires Node 18+):**
+
+```powershell
+npm install -g @anthropic-ai/claude-code
+```
+
+Anthropic recommends installing [Git for Windows](https://git-scm.com/downloads/win) before Claude Code so Bash-tool calls work natively. Without it, Claude Code falls back to PowerShell. Full install reference: [Anthropic — Advanced setup](https://code.claude.com/docs/en/setup).
+
+Verify:
+
+```powershell
+claude --version
+```
+
+### 2.2 Sign in
+
+```powershell
+claude
+```
+
+First run opens a browser. Sign in with your `@databayt.org` Anthropic account. The token is stored at `%USERPROFILE%\.claude\` and persists. For team and enterprise SSO, see [Anthropic — Authentication](https://code.claude.com/docs/en/authentication).
+
+### 2.3 The `c` alias — bypass permission prompts
+
+The default `claude` command prompts for permission on every Bash and Write call. As the operator, you want flow, not prompts. Add this to your PowerShell profile.
+
+```powershell
+notepad $PROFILE
+# If the file doesn't exist, PowerShell offers to create it. Say yes.
+```
+
+Paste at the bottom:
+
+```powershell
+# ── Claude Code — operator config ────────────────────────────────
+function c  { claude --dangerously-skip-permissions $args }   # operator (default)
+function cc { claude $args }                                  # opt back into prompts
+
+# Auto-load secrets from ~/.claude/.env into every session
+if (Test-Path "$env:USERPROFILE\.claude\.env") {
+    Get-Content "$env:USERPROFILE\.claude\.env" | ForEach-Object {
+        if ($_ -and -not $_.StartsWith("#")) {
+            $parts = $_ -split "=", 2
+            if ($parts.Length -eq 2) {
+                [Environment]::SetEnvironmentVariable($parts[0], $parts[1], "Process")
+            }
+        }
+    }
+}
+
+# Add ~/.claude/bin to PATH (custom MCP wrappers)
+$env:Path = "$env:USERPROFILE\.claude\bin;" + $env:Path
+```
+
+Save → reload:
+
+```powershell
+. $PROFILE
+```
+
+Test:
+
+```powershell
+c "list the agents installed in my config"
+```
+
+`--dangerously-skip-permissions` is fine on your own machine where you trust your prompts. Don't use it on a shared machine or with prompts from untrusted sources. Full CLI flag reference: [Anthropic — CLI reference](https://code.claude.com/docs/en/cli-reference). Permission model details: [Anthropic — Permissions](https://code.claude.com/docs/en/permissions).
+
+---
+
+## 3. Install the databayt config — the one-liner
+
+This installs all agents, skills, MCP servers, rules, hooks, and bin scripts that make Claude Code into the databayt OS.
+
+```powershell
+irm https://raw.githubusercontent.com/databayt/codebase/main/.claude/scripts/install.ps1 | iex
+& "$env:USERPROFILE\.claude\scripts\secrets.ps1" -GistId 68453b25fa9d28c94426c55c179b3838
+```
+
+The two commands:
+
+1. **`install.ps1`** — downloads agents, commands, memory, scripts, MCP config to `%USERPROFILE%\.claude\`
+2. **`secrets.ps1`** — pulls the team's secrets gist and writes `~/.claude/.env` with `GITHUB_PERSONAL_ACCESS_TOKEN`, `DATABASE_URL_*`, `ANTHROPIC_API_KEY`, and the rest
+
+Full inventory at [claude-code](/docs/claude-code).
+
+### Verify
+
+Every line below should pass.
+
+```powershell
+claude --version                                                              # CLI on PATH
+claude doctor                                                                  # config + MCP + creds all green
+(Get-ChildItem $env:USERPROFILE\.claude\agents).Count                          # agents installed
+(Get-ChildItem $env:USERPROFILE\.claude\commands).Count                        # commands installed
+Get-Content $env:USERPROFILE\.claude\mcp.json | ConvertFrom-Json | Out-Null    # JSON valid (silent = pass)
+$env:GITHUB_PERSONAL_ACCESS_TOKEN -ne $null                                    # secrets loaded
+Get-Alias c                                                                    # alias resolves to claude
+```
+
+In a new Claude session: `who am i` — the brain should recognize you with full-operator scope.
+
+---
+
+## 4. Install WebStorm + the Claude Code plugin
+
+WebStorm is the IDE for kun and hogwarts. The Claude Code plugin gives you an in-IDE chat panel sharing the same agents as the CLI.
+
+### 4.1 Install WebStorm
+
+```powershell
+winget install JetBrains.WebStorm
+```
+
+Or use Toolbox (recommended if you'll juggle multiple IDEs):
+
+```powershell
+winget install JetBrains.Toolbox
+```
+
+Open Toolbox → install WebStorm from there.
+
+Sign in with your JetBrains account at first launch.
+
+### 4.2 Install the plugin
+
+1. Open WebStorm
+2. File → Settings → Plugins (or `Ctrl+Alt+S` → Plugins)
+3. Click the **Marketplace** tab
+4. Search "Claude Code"
+5. Install **Claude Code [Beta]** (publisher: Anthropic) — direct link: [JetBrains Marketplace](https://plugins.jetbrains.com/plugin/27310-claude-code-beta-)
+6. Restart WebStorm
+
+Full plugin documentation: [Anthropic — JetBrains IDEs](https://code.claude.com/docs/en/jetbrains).
+
+### 4.3 Use it
+
+| Action | Shortcut / path |
+|--------|-----------------|
+| Open Claude panel | `Ctrl+Esc` or `Alt+Shift+C` |
+| Or via menu | View → Tool Windows → Claude |
+| Insert file reference into prompt | `Ctrl+Alt+K` (turns into `@path/to/file#L1-99`) |
+| Run Claude in terminal inside WebStorm | `Alt+F12` → type `c` |
+
+When you run the CLI from WebStorm's terminal, IDE features still work — current selection, open tabs, and diagnostics are shared with Claude automatically.
+
+### 4.4 Fix the ESC-key gotcha
+
+File → Settings → Tools → Terminal → uncheck **"Move focus to the editor with Escape"**.
+
+Without this fix, ESC in the WebStorm terminal jumps you back to the editor instead of interrupting Claude's generation.
+
+---
+
+## 5. Configure Cowork (Claude Desktop)
+
+Cowork is the chat companion to Code. Same brain, different surface. Use it for planning, writing, research, and mobile/voice work — anything that doesn't touch a repo. Official overview: [Anthropic — Desktop app](https://code.claude.com/docs/en/desktop).
+
+### 5.1 Install
+
+Microsoft Store → search "Claude" → install → sign in with your `@databayt.org` Anthropic account.
+
+Or direct downloads from Anthropic:
+- [Windows x64](https://claude.ai/api/desktop/win32/x64/setup/latest/redirect)
+- [Windows ARM64](https://claude.ai/api/desktop/win32/arm64/setup/latest/redirect)
+
+### 5.2 Configure context — filesystem scopes
+
+Claude Desktop reads only what you scope it to. Add the directories you want it to see.
+
+Open the config file (create it if it doesn't exist):
+
+```powershell
+notepad $env:APPDATA\Claude\claude_desktop_config.json
+```
+
+Paste this baseline. Replace `<your-pat>` with your GitHub PAT from §0.1.
+
+```json
+{
+  "mcpServers": {
+    "filesystem": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@modelcontextprotocol/server-filesystem",
+        "%USERPROFILE%\\.claude",
+        "%USERPROFILE%\\projects\\databayt"
+      ]
+    },
+    "github": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-github"],
+      "env": {
+        "GITHUB_PERSONAL_ACCESS_TOKEN": "<your-pat>"
+      }
+    }
+  },
+  "preferences": {
+    "allowAllBrowserActions": true,
+    "coworkScheduledTasksEnabled": true,
+    "ccdScheduledTasksEnabled": true,
+    "sidebarMode": "task",
+    "coworkWebSearchEnabled": true,
+    "keepAwakeEnabled": true,
+    "chicagoEnabled": true
+  }
+}
+```
+
+Save → fully quit and reopen Claude Desktop. The filesystem scope appears under the **Context** pill in the chat input.
+
+### 5.3 Add connectors
+
+Connectors are MCP servers Claude Desktop speaks to. Browse the official catalog at [Anthropic Directory](https://claude.ai/directory) — every server there uses the same MCP infrastructure and works with both Desktop and Code. Full MCP setup reference: [Anthropic — MCP](https://code.claude.com/docs/en/mcp) · Protocol spec: [modelcontextprotocol.io](https://modelcontextprotocol.io).
+
+The ones the team uses:
+
+| Connector | Purpose | Auth |
+|-----------|---------|------|
+| `filesystem` | Read/write inside scoped directories | none (scopes set in JSON) |
+| `github` | Issues, PRs, code search across databayt | PAT in env |
+| `notion` | Team Notion workspace | `NOTION_API_KEY` |
+| `slack` | The `hogwarts-wve9301` workspace | `SLACK_BOT_TOKEN` |
+| `linear` | Issues and projects | OAuth on first call |
+| `figma` | Design files via local Figma desktop | runs at `127.0.0.1:3845` |
+| `playwright` | Browse + screenshot pages | none |
+| `context7` | Latest framework docs lookup | none |
+| `ref` | Internal reference index | `REF_API_KEY` |
+
+Add each block under `mcpServers` in the same `claude_desktop_config.json`. Restart Desktop after every save.
+
+Example — adding the Notion connector:
+
+```json
+"notion": {
+  "command": "npx",
+  "args": ["-y", "@notionhq/notion-mcp-server"],
+  "env": {
+    "OPENAPI_MCP_HEADERS": "{\"Authorization\":\"Bearer <NOTION_API_KEY>\",\"Notion-Version\":\"2022-06-28\"}"
+  }
+}
+```
+
+The full Code-side MCP config at `%USERPROFILE%\.claude\mcp.json` already has all 19 servers configured. Copy any block from there into Desktop.
+
+### 5.4 Plug-in MCPs — what's already running on the Code side
+
+The install one-liner loaded all your Code-side MCPs. Inspect with:
+
+```powershell
+claude doctor
+```
+
+The MCP section lists each server with status:
+
+- `ready` — connected and authenticated
+- `needs auth` — open the relevant MCP and Anthropic's OAuth dialog opens on first call (Vercel, Sentry, Linear, Stripe use this)
+- `error` — check `~/.claude/mcp.json` for the entry and confirm the env var exists
+
+### 5.5 The Cowork ↔ Code bridge
+
+Cowork and Code do NOT share chat history. They share state through two channels:
+
+- **`~/.claude/bridge.md`** — atomic handoff file. Both read and write it.
+- **GitHub issues** — durable, threaded, visible to the whole team.
+
+Typical handoff: you draft a plan in Cowork on your phone over coffee. End the chat with: *"Write the plan as a Handoff section in `~/.claude/bridge.md`."* When you open Code next session, the SessionStart hook reads it and surfaces it to you.
+
+Full team protocol: [cowork](/docs/cowork). Cross-surface session handoff details (Dispatch, `--teleport`, `/desktop`): [Anthropic — Desktop](https://code.claude.com/docs/en/desktop) and [Remote Control](https://code.claude.com/docs/en/remote-control).
+
+---
+
+## 6. The databayt org on your laptop
+
+The install one-liner ran `sync-repos.ps1` and cloned every active repo to `%USERPROFILE%\projects\databayt\` (or `~/oss/` on Mac/Linux). To pull latest at any time:
+
+```powershell
+& "$env:USERPROFILE\.claude\scripts\sync-repos.ps1"
+```
+
+| Repo | What it is | Priority |
+|------|-----------|----------|
+| `kun` | The engine — agents, skills, MCPs, this doc site | 1 |
+| `codebase` | Pattern library — atoms, templates, blocks | 1 |
+| `shadcn` | UI fork — shadcn/ui customized | 1 |
+| `radix` | UI primitives | 1 |
+| `hogwarts` | Education SaaS — multi-tenant, flagship product | 2 |
+| `souq` | E-commerce — multi-vendor | 2 |
+| `mkan` | Rentals — booking + listings | 2 |
+| `shifa` | Medical — appointments + records | 2 |
+| `marketing` | Landing pages | 3 |
+| `swift-app` | iOS companion | 3 |
+| `distributed-computer` | Rust infrastructure | 3 |
+
+Future repos (not yet created): `revenue` — your share-economy framework.
+
+See [repositories](/docs/repositories) for the full org map.
+
+---
+
+## 7. Run kun locally
+
+```powershell
+cd $env:USERPROFILE\projects\databayt\kun
+Copy-Item .env.example .env
+pnpm install
+pnpm dev
+```
+
+Open `http://localhost:3000`. No database needed — kun is the docs + config engine.
+
+---
+
+## 8. Run hogwarts locally
+
+```powershell
+cd $env:USERPROFILE\projects\databayt\hogwarts
+# .env comes from 1Password — Abdout shares it out-of-band. No .env.example exists.
+pnpm install
+pnpm prisma generate
+pnpm dev
+```
+
+Open the URL Next.js prints. Set `PORT=3001` in `.env` if kun is still running on 3000.
+
+Database is **Neon (cloud Postgres)** — no local DB install. Never run `pnpm db:seed` (destructive); use `pnpm db:seed:single <name>` if seeding is needed.
+
+---
+
+## 9. Daily workflow
+
+| Action | Command |
+|--------|---------|
+| Open Claude in WebStorm | `Ctrl+Esc` |
+| Start Claude in terminal | `c` |
+| Synthesize company status | `c "/captain"` |
+| Capture an idea | `c "/idea <description>"` |
+| Spec a feature on an issue | `c "/spec #<issue>"` |
+| Run the full pipeline | `c "/feature <name> [product]"` |
+| Log a formal decision | `c "/decide"` |
+| Premortem a risky move | `c "/premortem"` |
+| Weekly cycle | `c "/weekly"` |
+| Cross-product health | `c "/monitor"` |
+| API + infra spend | `c "/costs"` |
+| Send a note to Abdout | `c "/dispatch <message>"` |
+| Open a GitHub issue | `c "/issue"` |
+| Auto-fix user reports | `c "/report"` |
+| Generate a proposal | `c "/proposal"` |
+| Pricing analysis | `c "/pricing"` |
+
+Full keyword list — 100+ entries — at [keywords](/docs/keywords).
+
+---
+
+## 10. Cowork vs Code — when to use which
+
+You have both. Use them for different jobs.
+
+| Task | Tool |
+|------|------|
+| Plan, think, write, mobile, web research | **Cowork** (Claude Desktop) |
+| Edit files, run scripts, deploy, anything that touches the repo | **Code** (in WebStorm or terminal) |
+| Carry decisions across sessions or surfaces | Both — via `~/.claude/bridge.md` |
+
+**Code-only capabilities**: editing files, running `pnpm`/`git`/`prisma`, hooks (SessionStart, etc.), slash commands like `/feature` and `/dispatch`, the `c` alias.
+
+**Cowork-only capabilities**: native web browsing, scheduled tasks, voice mode, mobile sync.
+
+Neither shares chat history with the other.
+
+---
+
+## 11. Contributing — the team workflow
+
+Every change in databayt follows this cycle. No exceptions, regardless of who made the change.
+
+```
+IDEA → ISSUE → BRANCH → COMMIT → PUSH → PR → REVIEW → MERGE → CLOSE → DEPLOY → VERIFY
+```
+
+Full protocol: `.claude/rules/github-workflow.md` in every repo. The operator's condensed version:
+
+### 11.1 Open a GitHub issue first
+
+```powershell
+gh issue create --repo databayt/<repo> --title "<type>: <description>" --body "<acceptance criteria>" --label "type:<type>,P<n>"
+```
+
+| Type | Label | Branch prefix |
+|------|-------|---------------|
+| Feature | `type:feature` | `feat/` |
+| Bug | `type:bug` | `fix/` |
+| Chore | `type:chore` | `chore/` |
+| Docs | `type:docs` | `docs/` |
+| Refactor | `type:refactor` | `refactor/` |
+
+Priority: `P0` drop-everything · `P1` this week · `P2` this sprint · `P3` backlog.
+
+### 11.2 Branch from fresh main
+
+```powershell
+git checkout main; git pull; git checkout -b feat/<short-name>
+```
+
+One issue = one branch = one PR. Delete the branch after merge.
+
+### 11.3 Atomic conventional commits
+
+```
+<type>: <description under 72 chars, present tense>
+
+<body — explain WHY, not what. The diff already shows what.>
+
+Refs #<N>
+
+Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
+```
+
+Types: `feat`, `fix`, `chore`, `docs`, `refactor`, `test`, `perf`, `style`.
+
+One logical unit per commit. Don't lump three concerns into one.
+
+### 11.4 Push and open a PR
+
+```powershell
+git push -u origin <branch>
+gh pr create --title "<type>: <description>" --body "Closes #<N>"
+```
+
+`Closes #N` auto-closes the issue on merge. PR title matches the primary commit. Body has Summary, Changes, Test plan.
+
+### 11.5 Review with evidence
+
+Respond to **every** comment. Disagree only with evidence. Discussion lives on the PR, not in chat. When you fix a comment, reply "Fixed in `<commit-sha>`".
+
+### 11.6 Squash merge, delete branch
+
+```powershell
+gh pr merge <N> --squash --delete-branch
+```
+
+CI must pass first. Vercel auto-deploys main. Run `c "/watch"` to verify the production deploy.
+
+### Anti-patterns
+
+| Don't | Do |
+|-------|-----|
+| Commit directly to main | Branch + PR |
+| PR without an issue | Issue first |
+| Mega PR (20+ files) | Split into focused PRs |
+| Force-push to main | Never, ever |
+| Merge with red CI | Fix CI first |
+| `fix stuff` commit message | Conventional commit with WHY in the body |
+| Close issue manually | `Closes #N` in the PR body |
+| Discuss on Slack instead of PR | Discussion on the PR |
+| Leave stale branches | Delete after merge |
+
+---
+
+## 12. The pipeline — idea to production
+
+One keyword chains every stage. Each stage is also runnable standalone.
+
+```
+feature <name> [product]
+    ↓
+IDEA → SPEC → SCHEMA → CODE → WIRE → CHECK → SHIP → WATCH
+```
+
+| Stage | Command | Exit gate |
+|-------|---------|-----------|
+| Capture | `/idea` | GitHub issue exists |
+| Specify | `/spec` | Spec on issue, approved |
+| Data | `/schema` | Migration applied, types compile |
+| Logic | `/code` | `tsc --noEmit` passes |
+| UI | `/wire` | `pnpm build` passes |
+| Quality | `/check` | All gates green |
+| Deploy | `/ship` | Vercel deployment Ready |
+| Monitor | `/watch` | No errors, issue closed |
+
+Run a full chain: `/feature billing hogwarts`. Or enter at any stage: `/schema billing`, `/wire #42`, `/check`.
+
+Product scopes activate domain context: `hogwarts`, `souq`, `mkan`, `shifa`.
+
+---
+
+## 13. Weekly rhythm
+
+The captain cycle.
+
+| Day | Action |
+|-----|--------|
+| **Monday** | `c "/weekly"` — review last week, set priorities, allocate the team |
+| **Wednesday** | `c "/weekly check"` — on-track? blockers? adjust |
+| **Friday** | `c "/weekly review"` — what shipped, revenue update, set Monday's plan |
+| **Weekly 1:1** | Wednesday with Abdout — coordinate, raise blocks |
+
+Decisions of consequence: log via `c "/decide"`. Risky moves: pre-check via `c "/premortem"` before committing. Both write to `.claude/memory/decisions/`.
+
+---
+
+## 14. What "full control" looks like
+
+You can:
+
+- Sign deploys to production across all repos
+- Close issues and merge PRs across the org
+- Set weekly priorities — the team allocates against your plan
+- Operationalize the share-economy framework and ship the `databayt/revenue` repo when ready
+- Direct any of the agents, activate any of the skills
+- Run pricing, proposals, and customer ops independently
+
+Boundary calls — dispatch Abdout first:
+
+- Anything that moves money (Stripe, AWS billing, payouts, payroll)
+- Changes to `CONSTITUTION.md`, `PRINCIPLES.md`, share-economy doctrine
+- Hiring, license, partnership decisions
+- Public API breaking changes
+- Sunsetting a product
+
+For boundary calls: `c "/dispatch <decision summary>"` and wait for the green light before executing.
+
+---
+
+## 15. First day, first week, first month
+
+### Day one
+
+- Sections 0 through 5 — accounts, side-tools, CLI, config, WebStorm, Cowork
+- Run `claude doctor` and the verification block — all green
+- Open kun docs at `http://localhost:3000` and read [captain](/docs/captain)
+- `c "/captain"` — confirm the brain knows you
+- `c "/dispatch Day 1 onboarding complete — verification block all green"`
+
+### Week one
+
+- Sections 6 through 10 — clone the org, run kun + hogwarts, daily workflow, Cowork vs Code
+- Read [cowork](/docs/cowork), [dispatch](/docs/dispatch), [credentials](/docs/credentials)
+- Open your first GitHub issue (anything you noticed during setup)
+- Run your first `/weekly` cycle on Monday
+- Wednesday 1:1 with Abdout
+- Read the share-economy doctrine in `docs/SHARE-ECONOMY-MODEL.md` inside the kun repo
+
+### Month one
+
+- Draft the revenue framework: CU pool sizing, mudaraba contract template, waqf-track triggers, needs-fund policy
+- Scaffold `databayt/revenue` and open its first issue
+- Run `/captain` and `/weekly` independently — no founder hand-holding
+- One concrete decision logged via `/decide` per major call
+- Surface cross-repo friction as `chore:` issues against the relevant repo
+
+---
+
+## 16. Help
+
+If you're stuck, in this order:
+
+1. `claude doctor` — run first; copy the output
+2. `c "/dispatch I'm stuck on step <N>. Last output: <last line>. What I tried: <X>"`
+3. `c "/issue"` — open a GitHub issue for any repeatable bug
+4. Email `abdout@databayt.org`, subject: `blocked on <step>`
+
+---
+
+## Reference
+
+### Inside databayt
+
+- [Claude Code — team install one-liner detail](/docs/claude-code)
+- [Captain — decision matrix and delegation](/docs/captain)
+- [Cowork ↔ Code bridge protocol](/docs/cowork)
+- [Voice across surfaces](/docs/voice)
+- [Credentials and secrets](/docs/credentials)
+- [Dispatch protocol](/docs/dispatch)
+- [Connectors — MCP server catalog](/docs/connectors)
+- [Apps — Slack, Figma, Linear surfaces](/docs/apps)
+- [Issue templates](/docs/issue)
+- [Keywords — full vocabulary](/docs/keywords)
+- [Team — roles and configs](/docs/team)
+- [Repositories — full org map](/docs/repositories)
+- [Stack — Next.js, React, Prisma, Tailwind, shadcn versions](/docs/stack)
+- [Self-hosting — optional Tailscale/tmux/Docker setup](/docs/self-hosting)
+
+### Anthropic — official docs (latest)
+
+- [Claude Code overview](https://code.claude.com/docs/en/overview)
+- [Quickstart](https://code.claude.com/docs/en/quickstart)
+- [Advanced setup](https://code.claude.com/docs/en/setup)
+- [Authentication](https://code.claude.com/docs/en/authentication)
+- [CLI reference](https://code.claude.com/docs/en/cli-reference)
+- [Settings](https://code.claude.com/docs/en/settings)
+- [Permissions](https://code.claude.com/docs/en/permissions)
+- [Memory and CLAUDE.md](https://code.claude.com/docs/en/memory)
+- [Skills](https://code.claude.com/docs/en/skills)
+- [Hooks](https://code.claude.com/docs/en/hooks)
+- [Sub-agents](https://code.claude.com/docs/en/sub-agents)
+- [MCP — Model Context Protocol](https://code.claude.com/docs/en/mcp)
+- [Anthropic Directory — connector catalog](https://claude.ai/directory)
+- [JetBrains IDEs](https://code.claude.com/docs/en/jetbrains) · [Marketplace plugin](https://plugins.jetbrains.com/plugin/27310-claude-code-beta-)
+- [VS Code](https://code.claude.com/docs/en/vs-code)
+- [Desktop app](https://code.claude.com/docs/en/desktop) · [Quickstart](https://code.claude.com/docs/en/desktop-quickstart)
+- [Web](https://code.claude.com/docs/en/claude-code-on-the-web)
+- [Remote Control](https://code.claude.com/docs/en/remote-control)
+- [Routines — cron / scheduled tasks](https://code.claude.com/docs/en/routines)
+- [Slack integration](https://code.claude.com/docs/en/slack)
+- [Agent SDK](https://code.claude.com/docs/en/agent-sdk/overview)
+- [Common workflows](https://code.claude.com/docs/en/common-workflows) · [Best practices](https://code.claude.com/docs/en/best-practices)
+- [Troubleshooting](https://code.claude.com/docs/en/troubleshooting)
+- [Anthropic pricing](https://claude.com/pricing) · [Claude Code product page](https://code.claude.com/)
+
+### External
+
+- [MCP protocol spec](https://modelcontextprotocol.io)
+- [Conventional Commits](https://www.conventionalcommits.org/)
+- [GitHub Flow](https://docs.github.com/en/get-started/quickstart/github-flow)
+- [Git for Windows download](https://git-scm.com/downloads/win)
+- [GitHub CLI manual](https://cli.github.com/manual/)
+- [WebStorm — JetBrains](https://www.jetbrains.com/webstorm/)
+- [pnpm docs](https://pnpm.io/installation)
+- [Node.js downloads](https://nodejs.org/en/download)


### PR DESCRIPTION
## Summary

- New `content/docs/samia.mdx` — 760-line operator-grade onboarding guide that walks from a fresh Windows laptop to running the databayt org
- `meta.json` slot under `---Operations---` between `team` and `dispatch`
- Inline references throughout to the latest official Anthropic docs at `code.claude.com/docs/en/`

## Changes

- `content/docs/samia.mdx`: new file
  - §0 Accounts (GitHub, JetBrains, Claude — with PAT setup + 2FA + paid plan note)
  - §1 Side-tools (Git, Node 22 + pnpm, gh CLI, PS 7, Developer Mode)
  - §2 Claude Code CLI — three install paths (WinGet recommended, native, npm), sign-in, **the `c` alias** with `--dangerously-skip-permissions`, secret auto-load, custom `bin/` on PATH
  - §3 The databayt config one-liner + secrets gist
  - §4 WebStorm + Claude Code [Beta] plugin + ESC-key terminal fix
  - §5 **Cowork (Claude Desktop) config** — install, filesystem context, the full connector catalog with example JSON blocks, the Cowork ↔ Code bridge protocol
  - §6 The databayt org cloned via `sync-repos.ps1` with priority table
  - §7 Run kun locally
  - §8 Run hogwarts locally — with the no-`.env.example` caveat
  - §9 Daily slash-command map (`/captain`, `/feature`, `/decide`, `/premortem`, `/weekly`, `/dispatch`, `/report`, `/issue`, etc.)
  - §10 Cowork vs Code — when to use which
  - §11 **Contributing — full IDEA → ISSUE → BRANCH → COMMIT → PUSH → PR → REVIEW → MERGE → CLOSE → DEPLOY → VERIFY cycle**, conventional commits format, anti-patterns table
  - §12 The `/feature` pipeline (IDEA → SPEC → SCHEMA → CODE → WIRE → CHECK → SHIP → WATCH) with exit gates
  - §13 Weekly rhythm — Monday plan, Wednesday check, Friday review
  - §14 What "full control" looks like — authority list + boundary calls (money, doctrine, hiring, license)
  - §15 First day, first week, first month — concrete time-bounded tasks
  - §16 Help — `claude doctor` → `/dispatch` → `/issue` → email
  - §17 Reference — internal docs, **20+ official Anthropic doc links** at `code.claude.com/docs/en/`, external (MCP spec, Conventional Commits, GitHub Flow, etc.)
- `content/docs/meta.json`: insert `"samia"` under `---Operations---` between `team` and `dispatch`

## Test plan

- [x] `pnpm fumadocs-mdx` runs clean
- [x] `.source/server.ts` registers `samia.mdx` as `__fd_glob_26`
- [x] `.source/browser.ts` registers dynamic import for `samia.mdx`
- [x] `meta.json` has `"samia"` entry
- [x] No mention of personal/medical info — purely role-scoped
- [x] All Anthropic refs use the current `code.claude.com/docs/en/` canonical domain
- [x] Operator-grade tone, table-heavy, matches `team.mdx` / `captain.mdx` style
- [ ] Reviewer: pull, `pnpm dev`, walk `/docs/samia` — check headings, code blocks, internal links

## Follow-ups (separate work, not in this PR)

- `databayt/dotfiles` repo to modernize the install pipeline (the current one-liner points at `databayt/codebase/.claude/scripts/install.ps1` which the team uses today but has known drift). Tracked in plan file `/Users/abdout/.claude/plans/for-the-research-and-lazy-wombat.md`.
- Update `team.mdx` Samia line ("R&D & Kun Caretaker" → operator scope) — separate PR so this one stays focused.

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)