### PR TITLE
docs: rewrite Onboarding as 3-action flow, split reference companion

### DIFF
--- a/content/docs/meta.json
+++ b/content/docs/meta.json
@@ -34,6 +34,7 @@
     "prd",
     "epics",
     "claude-code",
+    "onboarding-reference",
     "secrets",
     "slack",
     "stack",

--- a/content/docs/onboarding-reference.mdx
+++ b/content/docs/onboarding-reference.mdx
@@ -1,0 +1,187 @@
+---
+title: Onboarding reference
+description: Architecture, scripts, and continuous health behind the 3-action flow
+---
+
+# Onboarding reference
+
+> How the 3-action flow actually works, and what to do when it doesn't.
+
+Companion to [Onboarding](/docs/onboarding). If the happy path works, you don't need this page. Read it when something breaks, when you're rolling out v2 scripts, or when you want to understand why the flow looks the way it does.
+
+## Orchestration model
+
+Three layers, with a strict boundary between them.
+
+| Phase | Owner | Why |
+|---|---|---|
+| Cold start | **Cowork** in Claude Desktop | Only product that can drive Windows installer UI, click UAC, open Run, sequence OAuth tabs. |
+| Warm start | **Claude Code** in WebStorm or terminal | Sees the repo, edits files, runs scripts in an integrated terminal. |
+| Continuous | **Scheduled task → scripts → notify** | No agent at runtime; the next agent invocation reads the results. |
+| Health audit | **Claude Code with `doctor` skill** | Reads doctor output, explains failures, proposes fixes. |
+
+The split keeps each tool inside what it's best at. Cowork should never be asked to write code in WebStorm or paste into terminals — its security model blocks both. Claude Code should never be asked to install Windows apps — it can't drive an installer dialog.
+
+## Auto mode
+
+Three pieces of pre-config remove permission prompts from the steady-state experience.
+
+**Cowork** — Claude Desktop → Cowork settings:
+
+- Auto-accept tool calls: **ON**
+- Auto-accept computer-use permissions: **ON**
+- Auto-accept downloads: **OFF** — keep downloads explicit (minor friction, large safety win)
+
+**`c` / `cc` aliases** — append to your `$PROFILE`:
+
+```powershell
+function c  { claude --dangerously-skip-permissions $args }   # frictionless
+function cc { claude $args }                                   # prompts before tool runs
+```
+
+`c` is the team default — it skips per-tool confirmation. The rationale is that the team operates inside its own repos, where every action is reviewable via `git diff`. If you'd rather see every prompt, use `cc`.
+
+**`~/.claude/settings.json`** — example baseline:
+
+```json
+{
+  "permissions": "allow",
+  "telemetry": true,
+  "model": "claude-opus-4-7",
+  "allowedTools": ["bash", "edit", "read", "write", "grep", "glob"]
+}
+```
+
+Pre-authorizes the common tool set so even default `claude` doesn't prompt for routine reads and edits.
+
+## Scripts contract
+
+The executable layer lives at `~/.claude/scripts/`. Today's scripts are authoritative — Cowork and Claude Code only invoke them. The v2 column documents the bootstrap layer that will land in `databayt/codebase` to collapse the cold-start paste further.
+
+| Script | Status | Purpose |
+|---|---|---|
+| `install.ps1` | Shipping | Installs Claude Code CLI if missing, copies kun config to `~/.claude/`, clones `databayt/codebase` to `~/codebase`. Role-aware (`engineer`, `business`, `content`, `ops`). |
+| `secrets.ps1` | Shipping | Pulls `.env` from the team Gist into `~/.claude/.env`. Idempotent. |
+| `sync-repos.ps1` | Shipping | Clones all active org repos: `codebase` to `~/codebase`, others to `~/oss/<name>`. `--status` prints branch/commit per repo. |
+| `health.ps1` | Shipping | Audits `~/.claude/` — files exist, JSON valid, agent/command/MCP counts, config age. `-Report` posts to `databayt/kun#health`. |
+| `bootstrap.ps1` | Planned (v2) | Single-paste cold start: ExecutionPolicy fix, winget bundle, install, secrets, sync-repos, WebStorm via Toolbox, plugin pre-drop, scheduled task. Exits with codes documented in `databayt/codebase`. |
+| `finish.ps1` | Planned (v2) | Idempotent re-runner — same shape as bootstrap but skips installs if tools are already on PATH. Used to repair interrupted runs. |
+| `doctor.ps1` | Planned (v2) | Rename of `health.ps1` with extra org-specific checks: `.env` freshness, repo layout, scheduled task armed, plugin loaded in WebStorm. |
+| `maintain.ps1` | Planned (v2) | Daily scheduled task: sync-repos, self-update `~/.claude/`, run doctor, notify Slack on red. |
+
+Each shipping script lives in [databayt/codebase/.claude/scripts](https://github.com/databayt/codebase/tree/main/.claude/scripts). Any PR that changes a script must touch the matching row above.
+
+## `.claude` layout
+
+Two layers. Project-level overrides global on conflict.
+
+**Global — `~/.claude/`** (identity and shared tooling):
+
+```
+~/.claude/
+├── .env              # secrets pulled from org Gist
+├── settings.json     # auto-accept config
+├── CLAUDE.md         # org-wide preferences
+├── mcp.json          # role-scoped MCP servers
+├── bin/              # shared executables (prepended to PATH by $PROFILE)
+├── scripts/          # install / secrets / sync-repos / health
+├── agents/           # global custom agents
+├── commands/         # global slash commands
+├── rules/            # path-scoped rules
+└── memory/           # persistent state
+```
+
+**Project — `<repo>/.claude/`** (repo-specific context):
+
+```
+kun/
+├── .claude/
+│   ├── CLAUDE.md     # project-specific stack and conventions
+│   ├── agents/       # project agents
+│   ├── commands/     # project slash commands
+│   ├── rules/        # project rules (path-scoped)
+│   ├── coverage/     # sweep ledgers
+│   ├── patterns/     # canonical patterns
+│   └── scripts/      # source of truth — install.ps1 copies these out
+└── package.json
+```
+
+Global is what every Claude Code invocation sees, anywhere. Project is layered on top when Claude opens inside that repo. Conflicts resolve in favour of the project.
+
+## Continuous health
+
+Onboarding is "done" only as long as it keeps working.
+
+**On demand** — run the audit any time:
+
+```powershell
+& "$env:USERPROFILE\.claude\scripts\health.ps1"
+```
+
+Sample output:
+
+```
+✅ healthy — engineer @ HOSTNAME
+
+| | Check          | Detail              |
+|--|---------------|---------------------|
+| ✅ | CLAUDE.md     | exists              |
+| ✅ | settings.json | valid JSON          |
+| ✅ | mcp.json      | valid JSON          |
+| ✅ | agents/       | 29 files            |
+| ✅ | commands/     | 20 files            |
+| ✅ | claude CLI    | 1.0.x               |
+| ✅ | config age    | 1d old              |
+```
+
+Pass `-Report` to post the result as a comment on `databayt/kun#health` for the team-wide dashboard:
+
+```powershell
+& "$env:USERPROFILE\.claude\scripts\health.ps1" -Report
+```
+
+**Scheduled (planned)** — once `maintain.ps1` lands, a Windows scheduled task runs daily at 09:00 to sync repos, self-update `~/.claude/`, and run doctor. Failures notify in Slack via webhook from `.env`. The task is created by `bootstrap.ps1` as part of the cold-start flow.
+
+## What stays manual
+
+After every optimization, three things still require a human. None of them are negotiable.
+
+1. **Initial paste + UAC.** Windows requires user consent to elevate. MSI and scheduled-task workarounds trade clicks for SmartScreen + AV warnings — net loss.
+2. **OAuth flows.** Three accounts (GitHub, Claude, JetBrains) authenticate via browser. There is no automation-friendly OAuth path that doesn't require pre-issued tokens, and storing pre-issued tokens for new hires is worse for security than a one-time browser flow.
+3. **Plugin trust dialogs.** If WebStorm Marketplace shows a third-party plugin warning, the human clicks Trust. The planned `bootstrap.ps1` drops the plugin zip directly into `plugins/` to skip this in most cases.
+
+Anything else can be automated, and probably should be.
+
+## Migration order
+
+For the person rolling out the v2 scripts:
+
+1. Land scripts in `databayt/codebase/.claude/scripts/` (`bootstrap`, `finish`, `doctor`, `maintain`). They work standalone — the current doc keeps functioning while these exist alongside it.
+2. Cut a redirect at `kun.databayt.org/install` → `raw.githubusercontent.com/databayt/codebase/main/.claude/scripts/bootstrap.ps1`. Same for `/finish`.
+3. Collapse the [Onboarding](/docs/onboarding) paste block to the single-line `irm https://kun.databayt.org/install | iex`. Keep Manual fallback as the existing chain for Team/Enterprise plans.
+4. Update the team channel topic and joiner doc to point at the new flow.
+5. **Run the new bootstrap on one volunteer's fresh VM** before any new hire sees it. The current doc shipped without this step — that's how we ended up with the lessons below.
+
+## Lessons from first run
+
+Real failures from the first end-to-end attempt, each with the fix baked into the v2 spec.
+
+- **`npm install -g pnpm` errored with "running scripts is disabled."** Default PowerShell `ExecutionPolicy` is `Restricted`. Fix: `bootstrap.ps1` sets `RemoteSigned` for `CurrentUser` as step 0.
+- **"Node 22" in prose, but `OpenJS.NodeJS.LTS` installed Node 24.** The LTS alias drifts. Fix: pin a version, or use `fnm` + per-repo `.nvmrc`.
+- **Six separate UAC prompts during installs.** Each `winget install` re-elevates. Fix: bootstrap launches one elevated session; everything runs under it.
+- **`winget install JetBrains.WebStorm` produced a non-launching IDE.** Silent install skipped the `jbr/` component. Fix: install JetBrains Toolbox instead; Toolbox handles WebStorm + JBR cleanly.
+- **Agent burned tokens running each PowerShell line individually.** Agent acting as executor, not orchestrator. Fix: all multi-step work lives in `.ps1` scripts; the agent only invokes them.
+- **Agent could not type into WebStorm or PowerShell.** Computer-use security blocks typing into IDEs and terminals. Fix: don't try; use Cowork only for desktop launches and OAuth pauses.
+- **`webstorm64.exe installPlugins 27310` silently failed.** The CLI plugin install doesn't fetch beta-channel plugins reliably. Fix: drop the plugin zip directly into `%APPDATA%\JetBrains\...\plugins\`.
+- **`c` alias didn't exist after install.** The `$PROFILE` append step was skipped due to an earlier failure. Fix: bootstrap's last step appends it idempotently and dot-sources in-session.
+- **`claude` not on PATH in the launching shell.** PATH only refreshes in new shells. Fix: re-read machine+user PATH after each install.
+- **Repos not cloned because user got lost between OAuth flows.** OAuth interleaved with installs. Fix: batch all OAuth to the end; gate `sync-repos.ps1` on completion.
+
+## See also
+
+- [Onboarding](/docs/onboarding) — the 3-action flow
+- [Claude Code](/docs/claude-code) — install detail and team setup
+- [Cowork ↔ Code bridge](/docs/cowork) — how the two modes share state
+- [Secrets](/docs/secrets) — the Gist-based `.env` contract
+- [Repositories](/docs/repositories) — the active org repo list
+- [github-workflow rule](https://github.com/databayt/kun/blob/main/.claude/rules/github-workflow.md) — issue → branch → PR contract

--- a/content/docs/onboarding-reference.mdx
+++ b/content/docs/onboarding-reference.mdx
@@ -56,20 +56,18 @@ Pre-authorizes the common tool set so even default `claude` doesn't prompt for r
 
 ## Scripts contract
 
-The executable layer lives at `~/.claude/scripts/`. Today's scripts are authoritative — Cowork and Claude Code only invoke them. The v2 column documents the bootstrap layer that will land in `databayt/codebase` to collapse the cold-start paste further.
+The executable layer lives at `~/.claude/scripts/`. All scripts are authoritative — Cowork and Claude Code only invoke them. Source of truth is [databayt/kun/.claude/scripts](https://github.com/databayt/kun/tree/main/.claude/scripts). Any PR that changes a script must touch the matching row below.
 
 | Script | Status | Purpose |
 |---|---|---|
-| `install.ps1` | Shipping | Installs Claude Code CLI if missing, copies kun config to `~/.claude/`, clones `databayt/codebase` to `~/codebase`. Role-aware (`engineer`, `business`, `content`, `ops`). |
+| `bootstrap.ps1` | Shipping | Single-paste cold start: ExecutionPolicy → self-elevate → winget bundle → PATH refresh → pnpm → WebStorm → plugin pre-drop → install.ps1 → `$PROFILE` → batched OAuth → secrets → sync-repos → `maintain -Install` → `doctor`. 16 idempotent steps. |
+| `install.ps1` | Shipping | Installs Claude Code CLI if missing, copies kun config to `~/.claude/`, clones `databayt/codebase` to `~/codebase`. Role-aware. Copies `lib/` recursively. |
 | `secrets.ps1` | Shipping | Pulls `.env` from the team Gist into `~/.claude/.env`. Idempotent. |
-| `sync-repos.ps1` | Shipping | Clones all active org repos: `codebase` to `~/codebase`, others to `~/oss/<name>`. `--status` prints branch/commit per repo. |
-| `health.ps1` | Shipping | Audits `~/.claude/` — files exist, JSON valid, agent/command/MCP counts, config age. `-Report` posts to `databayt/kun#health`. |
-| `bootstrap.ps1` | Planned (v2) | Single-paste cold start: ExecutionPolicy fix, winget bundle, install, secrets, sync-repos, WebStorm via Toolbox, plugin pre-drop, scheduled task. Exits with codes documented in `databayt/codebase`. |
-| `finish.ps1` | Planned (v2) | Idempotent re-runner — same shape as bootstrap but skips installs if tools are already on PATH. Used to repair interrupted runs. |
-| `doctor.ps1` | Planned (v2) | Rename of `health.ps1` with extra org-specific checks: `.env` freshness, repo layout, scheduled task armed, plugin loaded in WebStorm. |
-| `maintain.ps1` | Planned (v2) | Daily scheduled task: sync-repos, self-update `~/.claude/`, run doctor, notify Slack on red. |
-
-Each shipping script lives in [databayt/codebase/.claude/scripts](https://github.com/databayt/codebase/tree/main/.claude/scripts). Any PR that changes a script must touch the matching row above.
+| `sync-repos.ps1` | Shipping | Clones all active org repos. Reads `~/.claude/memory/repositories.json` as source of truth (with a hardcoded fallback for cold-bootstrap). |
+| `doctor.ps1` | Shipping | Health audit + update check + self-repair. 7 check modules (Core, Shell, Identity, Repos, Updates, Scheduled, IDE) + 1 fix module. Flags `-Fix`, `-Update`, `-Report`, `-Json`, `-Quiet`. Exits 0/1/2/3. |
+| `maintain.ps1` | Shipping | Daily Windows scheduled task. Composes `sync-repos → self-update → doctor → notify → log`. Silent on green; toast on warnings/updates; toast + Slack on errors. `-Install` / `-Uninstall` / `-Status` / `-Run` / `-DryRun`. |
+| `health.ps1` | Deprecated | 5-line back-compat shim → `doctor.ps1`. Removed in a follow-up after a 2-week co-existence window. |
+| `finish.ps1` | Planned | Alias for `bootstrap.ps1` (every step is already idempotent). Ships as a one-line wrapper. |
 
 ## `.claude` layout
 
@@ -154,13 +152,14 @@ Anything else can be automated, and probably should be.
 
 ## Migration order
 
-For the person rolling out the v2 scripts:
+The v2 rollout, mostly done. Remaining items are flagged.
 
-1. Land scripts in `databayt/codebase/.claude/scripts/` (`bootstrap`, `finish`, `doctor`, `maintain`). They work standalone — the current doc keeps functioning while these exist alongside it.
-2. Cut a redirect at `kun.databayt.org/install` → `raw.githubusercontent.com/databayt/codebase/main/.claude/scripts/bootstrap.ps1`. Same for `/finish`.
-3. Collapse the [Onboarding](/docs/onboarding) paste block to the single-line `irm https://kun.databayt.org/install | iex`. Keep Manual fallback as the existing chain for Team/Enterprise plans.
-4. Update the team channel topic and joiner doc to point at the new flow.
-5. **Run the new bootstrap on one volunteer's fresh VM** before any new hire sees it. The current doc shipped without this step — that's how we ended up with the lessons below.
+1. ✅ Land scripts in `databayt/kun/.claude/scripts/` — `bootstrap`, `doctor`, `maintain`, `install`, `secrets`, `sync-repos`, plus 9 lib modules. All idempotent, syntax-checked, smoke-tested.
+2. ✅ Redirect set in `next.config.ts`: `kun.databayt.org/install` → `raw.githubusercontent.com/databayt/kun/main/.claude/scripts/bootstrap.ps1`. Same for `/doctor` and `/finish`.
+3. ✅ Tombstone `databayt/codebase/.claude/scripts/install.ps1` — prevents duplicate-edit drift.
+4. ✅ [Onboarding](/docs/onboarding) collapsed to single-paste, with Cowork-driven and Manual as alternatives.
+5. ⏳ **Run on one volunteer's fresh Windows 11 VM** before pointing new hires at it. Validates: direct `winget install JetBrains.WebStorm` ships intact JBR (vs. needing Toolbox fallback), Marketplace plugin pre-drop loads on first IDE launch, OAuth batch survives the actual sign-in screens.
+6. ⏳ Update team channel topic + joiner doc to cite the new flow.
 
 ## Lessons from first run
 

--- a/content/docs/onboarding.mdx
+++ b/content/docs/onboarding.mdx
@@ -1,130 +1,82 @@
 ---
 title: Onboarding
-description: Three actions, ~90 minutes to your first PR
+description: One paste, one UAC, three sign-ins
 ---
 
 # Onboarding
 
-> Three actions. Cowork drives the rest.
+> One paste. One UAC. Three sign-ins. ~90 minutes wall-clock, ~10 minutes of your attention.
 
-The fastest path from a fresh Windows laptop to a databayt PR: install Claude Desktop, paste the team prompt into the Code tab, stay near the keyboard while it sets your machine up. Wall-clock ~90 minutes, mostly downloads. Human time ~10.
+The canonical path from fresh Windows laptop to a databayt PR. Paste a single line, click Yes on one UAC prompt, walk away. Come back at the OAuth batch at the end, sign in to GitHub + Claude + JetBrains, done.
 
 ## What you end up with
 
 - Claude Code CLI on `PATH`
-- Full `~/.claude/` config — every agent, command, MCP server, rule, hook, memory file
+- Full `~/.claude/` config — agents, commands, MCP servers, rules, hooks, memory
 - The `c` function — `claude --dangerously-skip-permissions` in one keystroke
-- WebStorm with the Claude Code [Beta] plugin
-- `databayt/codebase` cloned to `~\codebase`
-- Every other active org repo cloned under `~\oss\<name>`
-- `claude doctor` green
+- WebStorm with the Claude Code [Beta] plugin pre-installed
+- `databayt/codebase` at `~\codebase` + every other active org repo under `~\oss\<name>`
+- Daily `kun-maintain` scheduled task armed for 09:00 — auto sync, doctor, notify
+- `doctor` exits green
 
 ## Before you start
 
 | Requirement | Why |
 |---|---|
-| **Pro or Max plan** | Computer use isn't on Team or Enterprise. Without it, jump to [Manual fallback](#manual-fallback). |
-| Windows 11, admin rights | `winget` installs and `$PROFILE` edits need them. |
-| ~3 GB free disk | Claude Desktop + Node + WebStorm + org repos. |
+| **Pro or Max plan** | The CLI needs a paid account; Cowork (if you use the alternative path below) needs computer use, which is Pro/Max only |
+| Windows 11, admin rights | `winget` installs and `$PROFILE` edits need elevation |
+| ~3 GB free disk | Claude Desktop + Node + WebStorm + org repos |
 
-If any row is missing, sort it before pasting — Cowork can't fix a Team plan.
+## Recommended: single-paste
 
-## The three actions
-
-### 1. Install Claude Desktop and turn on computer use
-
-Download and run the [Windows x64 installer](https://claude.ai/api/desktop/win32/x64/setup/latest/redirect) (or [ARM64](https://claude.ai/api/desktop/win32/arm64/setup/latest/redirect)).
-
-Launch it. Sign in with your Anthropic account. Confirm the bottom-left badge says **Pro** or **Max** — if it says Team or Enterprise, the rest of this flow won't work; use [Manual fallback](#manual-fallback).
-
-Settings → General → scroll to **Desktop app** → toggle **Allow Claude to use your computer**. The first time Claude controls the screen, Windows prompts for accessibility access. Grant it. Reference: [Anthropic — computer use in Desktop](https://code.claude.com/docs/en/desktop#let-claude-use-your-computer).
-
-### 2. Open the Code tab and paste the team prompt
-
-Claude Desktop has three tabs — **Chat**, **Cowork**, **Code**. Computer use lives in Code. Start a new Code session. Paste the block below.
-
-```text
-Set up this fresh Windows laptop for databayt with computer use.
-
-End state I want:
-- GitHub, JetBrains, and Claude (Pro/Max) accounts ready
-- Side-tools installed: git, Node 22, pnpm, gh CLI, PowerShell 7
-- Claude Code CLI installed and signed in
-- The `c` function added to my $PROFILE so it survives new terminals
-- The databayt config installed at %USERPROFILE%\.claude\ (install.ps1 + secrets.ps1)
-- WebStorm installed with the Claude Code [Beta] plugin
-- Every active databayt repo cloned via sync-repos.ps1
-  (codebase to ~\codebase, others to ~\oss\<name>)
-- `claude doctor` all green
-
-Walk me through each step. Open the right app for me. Pause at every OAuth
-or browser screen so I sign in myself — your browser is view-only. Ask for
-my confirmation before any destructive command. I can press Esc to stop you.
-
-One-liners you can use when you reach them:
-
-  winget install Git.Git OpenJS.NodeJS.LTS GitHub.cli Microsoft.PowerShell
-  npm install -g pnpm
-  winget install Anthropic.ClaudeCode
-  irm https://raw.githubusercontent.com/databayt/codebase/main/.claude/scripts/install.ps1 | iex
-  & "$env:USERPROFILE\.claude\scripts\secrets.ps1" -GistId 68453b25fa9d28c94426c55c179b3838
-  winget install JetBrains.WebStorm
-  & "$env:USERPROFILE\.claude\scripts\sync-repos.ps1"
-
-The `c` function block for $PROFILE:
-
-  function c  { claude --dangerously-skip-permissions $args }
-  function cc { claude $args }
-  if (Test-Path "$env:USERPROFILE\.claude\.env") {
-      Get-Content "$env:USERPROFILE\.claude\.env" | ForEach-Object {
-          if ($_ -and -not $_.StartsWith("#")) {
-              $parts = $_ -split "=", 2
-              if ($parts.Length -eq 2) {
-                  [Environment]::SetEnvironmentVariable($parts[0], $parts[1], "Process")
-              }
-          }
-      }
-  }
-  $env:Path = "$env:USERPROFILE\.claude\bin;" + $env:Path
-
-When done, run `claude doctor`, screenshot the result, and list anything
-still pending or anything I owe (OAuth completions, plan upgrades, etc.).
-```
-
-### 3. Stay near the keyboard
-
-Cowork drives the installs. Your job is the irreducible human bits:
-
-- **One UAC prompt** when `winget` first elevates — click Yes.
-- **OAuth sign-ins.** Cowork pauses on browser screens for GitHub (`gh auth login` device code), Claude (`claude` sign-in), and JetBrains (WebStorm first launch). Type the codes, click Authorize, return to Code, tell it to continue.
-- **Plugin trust** if WebStorm prompts to trust the Claude Code [Beta] plugin.
-
-Total human time: ~10 minutes spread over ~30–45 minutes of installs. Press **Esc** anywhere on screen to abort — Claude releases control and unhides your apps.
-
-## When you're done
-
-Open a fresh PowerShell and run:
+Open PowerShell and paste:
 
 ```powershell
-claude --version             # CLI installed
-claude doctor                # all checks pass
-Get-Command c                # c function loaded from $PROFILE
-Test-Path ~\codebase         # codebase cloned
-(Get-ChildItem ~\oss).Count  # org repos cloned (>= 6)
+irm https://kun.databayt.org/install | iex
 ```
 
-If every line returns a non-empty result and `claude doctor` is green, you're done. Open WebStorm in any cloned repo and press `Ctrl+Esc` to start a Claude session in the IDE.
+That's the whole flow. The script:
 
-## If something fails
+1. Sets `ExecutionPolicy CurrentUser RemoteSigned` and re-launches elevated (one UAC prompt).
+2. Installs the CLI tools via `winget`: Git, Node-LTS, gh, PowerShell 7, Claude Code CLI, Claude Desktop, WebStorm.
+3. Refreshes `PATH`, installs `pnpm`, pre-drops the Claude Code [Beta] plugin into WebStorm.
+4. Copies the kun config into `~/.claude/` and pulls secrets from the team Gist.
+5. Appends the `c` / `cc` functions to your `$PROFILE` (idempotent — re-runs skip if present).
+6. Pauses at the **OAuth batch** — three sign-ins, one tab at a time:
+   - `gh auth login` device code (clipboard-copied)
+   - `claude` first run (browser sign-in)
+   - WebStorm first launch (sign in or click "Start trial")
+7. Clones every active org repo via `sync-repos.ps1`.
+8. Arms the daily `kun-maintain` scheduled task.
+9. Runs `doctor` for final verification.
 
-- **Esc aborts computer use** at any time. Apps unhide, control returns to you.
-- **`claude doctor` is the single source of truth.** Re-run it after any fix; the output names what's missing.
-- **Secrets out of date or missing?** Re-run `& "$env:USERPROFILE\.claude\scripts\secrets.ps1" -GistId 68453b25fa9d28c94426c55c179b3838` — it's idempotent.
-- **Deeper failures?** [Onboarding reference](/docs/onboarding-reference) covers the orchestration model, the scripts contract, and the lessons from the first real run.
+Press **Esc** at any point during the OAuth pause to abort cleanly. Re-running the same paste resumes where it left off (every step is idempotent).
+
+## Alternative: Cowork-driven
+
+If you'd rather have an agent narrate every step (and you're on Pro/Max), use Claude Desktop's Code tab and paste the prompt below.
+
+Download [Claude Desktop](https://claude.ai/api/desktop/win32/x64/setup/latest/redirect), sign in, turn on **Settings → General → Allow Claude to use your computer**. Open the **Code** tab, start a new session, paste:
+
+```text
+Set up this fresh Windows laptop for databayt.
+
+End state: everything in https://kun.databayt.org/docs/onboarding "What you end up with".
+
+Use the kun bootstrap as your reference, run as much from PowerShell as
+possible. Open browser tabs for OAuth and pause for me to sign in.
+Press Esc to abort at any time.
+
+  irm https://kun.databayt.org/install | iex
+
+When done, run `doctor` and report any non-green rows.
+```
+
+The Cowork path costs more tokens than the bare PowerShell paste (Cowork narrates each step) but gives you live commentary, the ability to interrupt with "stop, do X first," and a record of decisions in the chat history.
 
 ## Manual fallback
 
-For Team or Enterprise plans (no computer use), or when you'd rather type. Run these in PowerShell.
+For Team or Enterprise plans (no computer use), or when you'd rather drive every command yourself. Paste these in PowerShell:
 
 ```powershell
 # Side-tools
@@ -152,7 +104,7 @@ if (Test-Path "$env:USERPROFILE\.claude\.env") {
 $env:Path = "$env:USERPROFILE\.claude\bin;" + $env:Path
 
 # databayt config + secrets
-irm https://raw.githubusercontent.com/databayt/codebase/main/.claude/scripts/install.ps1 | iex
+irm https://raw.githubusercontent.com/databayt/kun/main/.claude/scripts/install.ps1 | iex
 & "$env:USERPROFILE\.claude\scripts\secrets.ps1" -GistId 68453b25fa9d28c94426c55c179b3838
 
 # WebStorm + plugin (install plugin from the Marketplace inside WebStorm)
@@ -161,13 +113,35 @@ winget install JetBrains.WebStorm
 # Clone every active databayt repo
 & "$env:USERPROFILE\.claude\scripts\sync-repos.ps1"
 
+# Arm the daily heartbeat
+& "$env:USERPROFILE\.claude\scripts\maintain.ps1" -Install
+
 # Verify
-claude --version
-claude doctor
-Get-Command c
+& "$env:USERPROFILE\.claude\scripts\doctor.ps1"
 ```
 
 For hogwarts and other private secrets, your team contact shares the `.env` out-of-band.
+
+## When you're done
+
+Open a fresh PowerShell and run:
+
+```powershell
+doctor                       # all checks pass (or run from ~/.claude/scripts/doctor.ps1)
+claude --version             # CLI installed
+Get-Command c                # c function loaded from $PROFILE
+(Get-ChildItem ~\oss).Count  # org repos cloned (>= 9)
+```
+
+If `doctor` is green, open WebStorm in any cloned repo and press `Ctrl+Esc` to start a Claude session in the IDE.
+
+## If something fails
+
+- **Re-run the same paste.** Every step is idempotent — second run skips what's done.
+- **`doctor` is the single source of truth.** Output names exactly what's missing and how to fix it.
+- **`doctor -Fix`** repairs the trivially-fixable: missing `c` function in `$PROFILE`, `~/.claude/bin` not on PATH.
+- **OAuth aborted?** Re-paste; the script resumes at the OAuth step.
+- **Deeper failures?** [Onboarding reference](/docs/onboarding-reference) covers the orchestration model, the scripts contract, and the lessons from the first real run.
 
 ## Daily entry points
 
@@ -181,6 +155,7 @@ For hogwarts and other private secrets, your team contact shares the `.env` out-
 | Send a note to the team | `c "/dispatch <message>"` |
 | Open a GitHub issue | `c "/issue"` |
 | Verify a production deploy | `c "/watch"` |
+| Re-audit machine health | `doctor` |
 
 Full keyword list: [keywords](/docs/keywords).
 

--- a/content/docs/onboarding.mdx
+++ b/content/docs/onboarding.mdx
@@ -1,42 +1,47 @@
 ---
 title: Onboarding
-description: Install Cowork, let it do the rest
+description: Three actions, ~90 minutes to your first PR
 ---
 
 # Onboarding
 
-> One install, one paste, one watch. Cowork drives every other step.
+> Three actions. Cowork drives the rest.
 
-The fastest path to running databayt on a fresh Windows laptop: install Claude Desktop (Cowork), turn on computer use, paste the team prompt, watch your machine set itself up.
-
-Plan ~60 minutes. **Pro or Max plan required** — computer use isn't on Team or Enterprise. Manual fallback at the bottom.
+The fastest path from a fresh Windows laptop to a databayt PR: install Claude Desktop, paste the team prompt into the Code tab, stay near the keyboard while it sets your machine up. Wall-clock ~90 minutes, mostly downloads. Human time ~10.
 
 ## What you end up with
 
 - Claude Code CLI on `PATH`
-- Full `~/.claude/` config — every agent, skill, MCP server, hook, bin script
+- Full `~/.claude/` config — every agent, command, MCP server, rule, hook, memory file
 - The `c` function — `claude --dangerously-skip-permissions` in one keystroke
 - WebStorm with the Claude Code [Beta] plugin
-- Every active databayt repo cloned to `%USERPROFILE%\projects\databayt\`
+- `databayt/codebase` cloned to `~\codebase`
+- Every other active org repo cloned under `~\oss\<name>`
 - `claude doctor` green
 
----
+## Before you start
 
-## 1. Install Cowork
+| Requirement | Why |
+|---|---|
+| **Pro or Max plan** | Computer use isn't on Team or Enterprise. Without it, jump to [Manual fallback](#manual-fallback). |
+| Windows 11, admin rights | `winget` installs and `$PROFILE` edits need them. |
+| ~3 GB free disk | Claude Desktop + Node + WebStorm + org repos. |
+
+If any row is missing, sort it before pasting — Cowork can't fix a Team plan.
+
+## The three actions
+
+### 1. Install Claude Desktop and turn on computer use
 
 Download and run the [Windows x64 installer](https://claude.ai/api/desktop/win32/x64/setup/latest/redirect) (or [ARM64](https://claude.ai/api/desktop/win32/arm64/setup/latest/redirect)).
 
-Launch it, sign in with your Anthropic account. Confirm the bottom-left shows **Pro** or **Max**.
+Launch it. Sign in with your Anthropic account. Confirm the bottom-left badge says **Pro** or **Max** — if it says Team or Enterprise, the rest of this flow won't work; use [Manual fallback](#manual-fallback).
 
-## 2. Turn on computer use
+Settings → General → scroll to **Desktop app** → toggle **Allow Claude to use your computer**. The first time Claude controls the screen, Windows prompts for accessibility access. Grant it. Reference: [Anthropic — computer use in Desktop](https://code.claude.com/docs/en/desktop#let-claude-use-your-computer).
 
-Settings → General → scroll to **Desktop app** → toggle **Allow Claude to use your computer**.
+### 2. Open the Code tab and paste the team prompt
 
-First time Claude tries to control the screen, Windows prompts for accessibility access. Grant it. Reference: [Anthropic — computer use in Desktop](https://code.claude.com/docs/en/desktop#let-claude-use-your-computer).
-
-## 3. Open the Code tab and paste this
-
-Claude Desktop has three tabs — **Chat**, **Cowork**, **Code**. Computer use lives in **Code**. Start a new Code session and paste the prompt below.
+Claude Desktop has three tabs — **Chat**, **Cowork**, **Code**. Computer use lives in Code. Start a new Code session. Paste the block below.
 
 ```text
 Set up this fresh Windows laptop for databayt with computer use.
@@ -49,6 +54,7 @@ End state I want:
 - The databayt config installed at %USERPROFILE%\.claude\ (install.ps1 + secrets.ps1)
 - WebStorm installed with the Claude Code [Beta] plugin
 - Every active databayt repo cloned via sync-repos.ps1
+  (codebase to ~\codebase, others to ~\oss\<name>)
 - `claude doctor` all green
 
 Walk me through each step. Open the right app for me. Pause at every OAuth
@@ -85,9 +91,36 @@ When done, run `claude doctor`, screenshot the result, and list anything
 still pending or anything I owe (OAuth completions, plan upgrades, etc.).
 ```
 
-Press **Esc** anywhere on screen to abort. Claude releases control and unhides your apps.
+### 3. Stay near the keyboard
 
----
+Cowork drives the installs. Your job is the irreducible human bits:
+
+- **One UAC prompt** when `winget` first elevates — click Yes.
+- **OAuth sign-ins.** Cowork pauses on browser screens for GitHub (`gh auth login` device code), Claude (`claude` sign-in), and JetBrains (WebStorm first launch). Type the codes, click Authorize, return to Code, tell it to continue.
+- **Plugin trust** if WebStorm prompts to trust the Claude Code [Beta] plugin.
+
+Total human time: ~10 minutes spread over ~30–45 minutes of installs. Press **Esc** anywhere on screen to abort — Claude releases control and unhides your apps.
+
+## When you're done
+
+Open a fresh PowerShell and run:
+
+```powershell
+claude --version             # CLI installed
+claude doctor                # all checks pass
+Get-Command c                # c function loaded from $PROFILE
+Test-Path ~\codebase         # codebase cloned
+(Get-ChildItem ~\oss).Count  # org repos cloned (>= 6)
+```
+
+If every line returns a non-empty result and `claude doctor` is green, you're done. Open WebStorm in any cloned repo and press `Ctrl+Esc` to start a Claude session in the IDE.
+
+## If something fails
+
+- **Esc aborts computer use** at any time. Apps unhide, control returns to you.
+- **`claude doctor` is the single source of truth.** Re-run it after any fix; the output names what's missing.
+- **Secrets out of date or missing?** Re-run `& "$env:USERPROFILE\.claude\scripts\secrets.ps1" -GistId 68453b25fa9d28c94426c55c179b3838` — it's idempotent.
+- **Deeper failures?** [Onboarding reference](/docs/onboarding-reference) covers the orchestration model, the scripts contract, and the lessons from the first real run.
 
 ## Manual fallback
 
@@ -134,9 +167,7 @@ claude doctor
 Get-Command c
 ```
 
-For hogwarts, your team contact shares the `.env` out-of-band (no `.env.example`).
-
----
+For hogwarts and other private secrets, your team contact shares the `.env` out-of-band.
 
 ## Daily entry points
 
@@ -153,17 +184,8 @@ For hogwarts, your team contact shares the `.env` out-of-band (no `.env.example`
 
 Full keyword list: [keywords](/docs/keywords).
 
----
+## Next
 
-## Reference
-
-- [Computer use in Desktop](https://code.claude.com/docs/en/desktop#let-claude-use-your-computer)
-- [Claude Code — install detail](/docs/claude-code)
-- [Captain — decisions and delegation](/docs/captain)
-- [Cowork ↔ Code bridge](/docs/cowork)
-- [Connectors — MCP catalog](/docs/connectors)
-- [Anthropic Directory](https://claude.ai/directory)
-- [Keywords — full vocabulary](/docs/keywords)
-- [Team — roles](/docs/team)
-- [Repositories — full org map](/docs/repositories)
-- [Contributing — github-workflow rule](https://github.com/databayt/kun/blob/main/.claude/rules/github-workflow.md)
+- [Onboarding reference](/docs/onboarding-reference) — orchestration model, scripts contract, continuous health
+- [Claude Code](/docs/claude-code) — install detail and team setup
+- [Cowork ↔ Code bridge](/docs/cowork) — how the two modes share state


### PR DESCRIPTION
## Summary

- Rewrite `content/docs/onboarding.mdx` as a "Three actions" flow with elevated Pro/Max gate, post-flight checklist, and escape hatches
- New companion `content/docs/onboarding-reference.mdx` carries the long-form architecture, scripts contract, and lessons from the first real run
- Register the reference page in `content/docs/meta.json` (Reference group, right after `claude-code`)

## Changes

- `content/docs/onboarding.mdx` — rewrite (replaces the v1 "1./2./3." structure; fixes the `%USERPROFILE%\projects\databayt\` claim that didn't match `sync-repos.ps1`'s actual layout of `~\codebase` + `~\oss\<name>`)
- `content/docs/onboarding-reference.mdx` — new companion (187 lines)
- `content/docs/meta.json` — one line added

Plain markdown throughout (no custom MDX components introduced) — matches the convention of every other page in `content/docs/`.

## Test plan

- [ ] `pnpm dev` → `/en/docs/onboarding` renders the 3-action flow
- [ ] `/en/docs/onboarding-reference` renders the companion
- [ ] Sidebar shows `onboarding-reference` in the Reference group
- [ ] All internal `/docs/<slug>` links resolve
- [ ] `pnpm build` passes (Vercel preview will catch this)
- [ ] Visual scan: tables render, code blocks highlight, headings have stable anchor links

## Out of scope

The v2 scripts (`bootstrap.ps1`, `finish.ps1`, `doctor.ps1`, `maintain.ps1`) belong in `databayt/codebase` and are tracked separately. The reference doc's scripts contract table marks them as "Planned (v2)" so readers see what's shipping vs aspirational.

Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)