### PR TITLE
feat(scripts): bootstrap.ps1 — single-paste cold-start with batched OAuth

### DIFF
--- a/.claude/memory/repositories.json
+++ b/.claude/memory/repositories.json
@@ -2,6 +2,20 @@
   "$schema": "repository-registry-schema",
   "description": "Track all databayt organization repositories for deep reference",
   "lastUpdated": "2026-01-17T00:00:00Z",
+  "_comment": "The flat 'repos' map below is consumed by doctor.ps1 and sync-repos.ps1. The richer 'repositories' object is for other tooling.",
+  "repos": {
+    "codebase": "$env:USERPROFILE\\codebase",
+    "kun": "$env:USERPROFILE\\kun",
+    "shadcn": "$env:USERPROFILE\\oss\\shadcn",
+    "radix": "$env:USERPROFILE\\oss\\radix",
+    "hogwarts": "$env:USERPROFILE\\oss\\hogwarts",
+    "souq": "$env:USERPROFILE\\oss\\souq",
+    "mkan": "$env:USERPROFILE\\oss\\mkan",
+    "shifa": "$env:USERPROFILE\\oss\\shifa",
+    "swift-app": "$env:USERPROFILE\\oss\\swift-app",
+    "distributed-computer": "$env:USERPROFILE\\oss\\distributed-computer",
+    "marketing": "$env:USERPROFILE\\oss\\marketing"
+  },
   "organization": {
     "name": "databayt",
     "url": "https://github.com/databayt",

--- a/.claude/scripts/bootstrap.ps1
+++ b/.claude/scripts/bootstrap.ps1
@@ -27,7 +27,7 @@ if (-not (Test-Path $libDir) -or -not (Get-ChildItem $libDir -ErrorAction Silent
     New-Item -ItemType Directory -Force -Path $libDir | Out-Null
     $libUrls = @(
         'Bootstrap-Common', 'Confirm-Admin', 'Install-Winget',
-        'Update-Path', 'Stage-OAuth', 'Fix-Shell'
+        'Update-Path', 'Stage-OAuth', 'Fix-Shell', 'Drop-Plugin'
     )
     foreach ($name in $libUrls) {
         $url = "https://raw.githubusercontent.com/databayt/kun/main/.claude/scripts/lib/$name.ps1"
@@ -40,7 +40,7 @@ if (-not (Test-Path $libDir) -or -not (Get-ChildItem $libDir -ErrorAction Silent
     }
 }
 
-foreach ($mod in 'Bootstrap-Common','Confirm-Admin','Install-Winget','Update-Path','Stage-OAuth','Fix-Shell') {
+foreach ($mod in 'Bootstrap-Common','Confirm-Admin','Install-Winget','Update-Path','Stage-OAuth','Fix-Shell','Drop-Plugin') {
     $p = Join-Path $libDir "$mod.ps1"
     if (Test-Path $p) { . $p }
 }
@@ -171,10 +171,19 @@ if (-not $SkipWebStorm) {
 }
 
 # ── [8] Plugin pre-drop ──────────────────────────────────────────
-# TODO: implement Drop-Plugin.ps1 once stable plugin zip URL is verified.
-# For now, surface as manual step at end.
-Write-Step 8 'Claude Code [Beta] plugin — manual (open WebStorm → Marketplace)' 'warn' \
-    'auto pre-drop pending plugin URL verification'
+Write-Step 8 'Pre-dropping Claude Code [Beta] plugin' 'start'
+if ($SkipWebStorm) {
+    Write-Step 8 'Plugin — skipped (WebStorm skipped)' 'skip'
+} elseif ($DryRun) {
+    Write-Step 8 '[dry-run] would download + extract plugin into WebStorm/plugins/' 'skip'
+} else {
+    $result = Install-ClaudeCodePlugin
+    switch ($result.Status) {
+        'ok'   { Write-Step 8 'Plugin installed' 'ok' $result.Reason }
+        'skip' { Write-Step 8 'Plugin' 'skip' $result.Reason }
+        'fail' { Write-Step 8 'Plugin install failed (install from Marketplace inside WebStorm)' 'warn' $result.Reason }
+    }
+}
 
 # ── [9] Kun config (install.ps1) ─────────────────────────────────
 Write-Step 9 'Installing ~/.claude/ config via install.ps1' 'start'

--- a/.claude/scripts/bootstrap.ps1
+++ b/.claude/scripts/bootstrap.ps1
@@ -1,0 +1,308 @@
+# Kun bootstrap — single-paste cold start.
+# Paste: irm https://kun.databayt.org/install | iex
+# Spec: https://github.com/databayt/kun/issues/28
+
+[CmdletBinding()]
+param(
+    [ValidateSet('engineer','business','content','ops')]
+    [string]$Role = 'engineer',
+    [string]$GistId = '68453b25fa9d28c94426c55c179b3838',
+    [switch]$Track,
+    [switch]$DryRun,
+    [switch]$SkipOAuth,
+    [switch]$SkipWebStorm,
+    [switch]$SkipCowork
+)
+
+$ErrorActionPreference = 'Continue'
+$started = Get-Date
+
+# ── Load helpers ─────────────────────────────────────────────────
+# When fetched via `irm | iex` the lib/ folder isn't beside us yet. Fetch it from
+# the kun repo if missing, then source the helpers.
+$libDir = Join-Path $PSScriptRoot 'lib'
+if (-not (Test-Path $libDir) -or -not (Get-ChildItem $libDir -ErrorAction SilentlyContinue)) {
+    # We're running from `irm | iex`; download lib/ files into a temp dir
+    $libDir = Join-Path $env:TEMP "kun-bootstrap-$(Get-Date -Format 'yyyyMMddHHmmss')\lib"
+    New-Item -ItemType Directory -Force -Path $libDir | Out-Null
+    $libUrls = @(
+        'Bootstrap-Common', 'Confirm-Admin', 'Install-Winget',
+        'Update-Path', 'Stage-OAuth', 'Fix-Shell'
+    )
+    foreach ($name in $libUrls) {
+        $url = "https://raw.githubusercontent.com/databayt/kun/main/.claude/scripts/lib/$name.ps1"
+        try {
+            Invoke-WebRequest -Uri $url -OutFile (Join-Path $libDir "$name.ps1") -ErrorAction Stop
+        } catch {
+            Write-Host "Failed to fetch $name.ps1 — bootstrap can't continue: $_" -ForegroundColor Red
+            exit 1
+        }
+    }
+}
+
+foreach ($mod in 'Bootstrap-Common','Confirm-Admin','Install-Winget','Update-Path','Stage-OAuth','Fix-Shell') {
+    $p = Join-Path $libDir "$mod.ps1"
+    if (Test-Path $p) { . $p }
+}
+
+# ── Banner ───────────────────────────────────────────────────────
+Write-Host ''
+Write-Host '═══════════════════════════════════════════════════════════' -ForegroundColor Cyan
+Write-Host '  KUN BOOTSTRAP — single-paste cold start'                    -ForegroundColor Cyan
+Write-Host "  Role: $Role · $(if ($DryRun) { 'DRY RUN' } else { 'live' })" -ForegroundColor Cyan
+Write-Host '═══════════════════════════════════════════════════════════' -ForegroundColor Cyan
+Write-Host ''
+
+$logFile = Initialize-BootstrapLog
+Write-Host "Log: $logFile" -ForegroundColor Gray
+Write-Host ''
+
+# ── [0] ExecutionPolicy ──────────────────────────────────────────
+Write-Step 0 'Set ExecutionPolicy CurrentUser RemoteSigned' 'start'
+if (-not $DryRun) {
+    try {
+        Set-ExecutionPolicy -Scope CurrentUser -ExecutionPolicy RemoteSigned -Force
+        Write-Step 0 'ExecutionPolicy set' 'ok'
+    } catch {
+        Write-Step 0 'ExecutionPolicy failed' 'fail' $_.Exception.Message
+        exit 1
+    }
+} else {
+    Write-Step 0 '[dry-run] would set RemoteSigned' 'skip'
+}
+
+# ── [1] Self-elevation check ─────────────────────────────────────
+Write-Step 1 'Admin check' 'start'
+if (Test-IsAdmin) {
+    Write-Step 1 'Running elevated' 'ok'
+} elseif ($DryRun) {
+    Write-Step 1 '[dry-run] would prompt for elevation' 'skip'
+} else {
+    Write-Step 1 'Not elevated — re-launching with UAC' 'warn'
+    $cmd = "irm https://kun.databayt.org/install | iex"
+    Start-Process powershell -Verb RunAs -ArgumentList @('-NoExit','-ExecutionPolicy','Bypass','-Command',$cmd)
+    exit 0
+}
+
+# ── [2] OS + PS version check ────────────────────────────────────
+Write-Step 2 'Verify Windows 11 + PowerShell 5.1+' 'start'
+$os = [Environment]::OSVersion.Version
+$psVer = $PSVersionTable.PSVersion
+if ($os.Major -lt 10) {
+    Write-Step 2 "Unsupported OS: $($os.ToString())" 'fail'
+    exit 1
+}
+if ($psVer.Major -lt 5) {
+    Write-Step 2 "PowerShell $psVer too old (need 5.1+)" 'fail'
+    exit 1
+}
+Write-Step 2 "Windows $($os.ToString()) · PowerShell $psVer" 'ok'
+
+# ── [3] Log dir (already created above) ──────────────────────────
+Write-Step 3 'Logs directory ready' 'ok' (Split-Path $logFile -Parent)
+
+# ── [4] winget bundle ────────────────────────────────────────────
+Write-Step 4 'Installing CLI tools via winget' 'start'
+$packages = @(
+    @{ Id = 'Git.Git';                Name = 'Git' }
+    @{ Id = 'OpenJS.NodeJS.LTS';      Name = 'Node.js LTS' }
+    @{ Id = 'GitHub.cli';             Name = 'gh' }
+    @{ Id = 'Microsoft.PowerShell';   Name = 'PowerShell 7' }
+    @{ Id = 'Anthropic.ClaudeCode';   Name = 'Claude Code CLI' }
+)
+if (-not $SkipCowork) {
+    # TODO: verify exact winget package ID for Claude Desktop before merge
+    $packages += @{ Id = 'Anthropic.Claude'; Name = 'Claude Desktop' }
+}
+
+foreach ($pkg in $packages) {
+    if ($DryRun) {
+        Write-Step 4 "  $($pkg.Name)" 'skip' '[dry-run]'
+        continue
+    }
+    $result = Install-WingetPackage -Id $pkg.Id
+    if ($result.Skipped) {
+        Write-Step 4 "  $($pkg.Name)" 'skip' 'already installed'
+    } elseif ($result.Installed) {
+        Write-Step 4 "  $($pkg.Name)" 'ok' 'installed'
+    } else {
+        Write-Step 4 "  $($pkg.Name)" 'warn' "winget exit $($result.ExitCode)"
+    }
+}
+
+# ── [5] PATH refresh ─────────────────────────────────────────────
+Write-Step 5 'Refreshing PATH from registry' 'start'
+if (-not $DryRun) { Update-SessionPath }
+Write-Step 5 'PATH refreshed' 'ok'
+
+# ── [6] pnpm via npm ─────────────────────────────────────────────
+Write-Step 6 'Installing pnpm globally' 'start'
+if (Get-Command pnpm -ErrorAction SilentlyContinue) {
+    Write-Step 6 'pnpm already on PATH' 'skip'
+} elseif ($DryRun) {
+    Write-Step 6 '[dry-run] would npm install -g pnpm' 'skip'
+} else {
+    npm install -g pnpm 2>&1 | Out-Null
+    if (Get-Command pnpm -ErrorAction SilentlyContinue) {
+        Write-Step 6 'pnpm installed' 'ok'
+    } else {
+        Write-Step 6 'pnpm install failed (try again later)' 'warn'
+    }
+}
+
+# ── [7] WebStorm ─────────────────────────────────────────────────
+if (-not $SkipWebStorm) {
+    Write-Step 7 'Installing WebStorm' 'start'
+    if ($DryRun) {
+        Write-Step 7 '[dry-run] would winget install JetBrains.WebStorm' 'skip'
+    } else {
+        $result = Install-WingetPackage -Id 'JetBrains.WebStorm'
+        if ($result.Skipped) {
+            Write-Step 7 'WebStorm already installed' 'skip'
+        } elseif ($result.Installed) {
+            Write-Step 7 'WebStorm installed' 'ok'
+            # TODO: verify JBR present; fall back to JetBrains Toolbox if not
+        } else {
+            Write-Step 7 'WebStorm install failed' 'warn' 'install JetBrains Toolbox manually'
+        }
+    }
+} else {
+    Write-Step 7 'WebStorm — skipped via flag' 'skip'
+}
+
+# ── [8] Plugin pre-drop ──────────────────────────────────────────
+# TODO: implement Drop-Plugin.ps1 once stable plugin zip URL is verified.
+# For now, surface as manual step at end.
+Write-Step 8 'Claude Code [Beta] plugin — manual (open WebStorm → Marketplace)' 'warn' \
+    'auto pre-drop pending plugin URL verification'
+
+# ── [9] Kun config (install.ps1) ─────────────────────────────────
+Write-Step 9 'Installing ~/.claude/ config via install.ps1' 'start'
+$installerUrl = 'https://raw.githubusercontent.com/databayt/kun/main/.claude/scripts/install.ps1'
+if ($DryRun) {
+    Write-Step 9 "[dry-run] would fetch $installerUrl" 'skip'
+} else {
+    try {
+        $installer = Invoke-RestMethod -Uri $installerUrl -ErrorAction Stop
+        $scriptBlock = [scriptblock]::Create($installer)
+        & $scriptBlock -Role $Role
+        Write-Step 9 'install.ps1 done' 'ok'
+    } catch {
+        Write-Step 9 'install.ps1 failed' 'fail' $_.Exception.Message
+        exit 1
+    }
+}
+
+# ── [10] Auto-accept settings.json (informational — install.ps1 already wrote one) ──
+Write-Step 10 'settings.json (handled by install.ps1)' 'ok'
+
+# ── [11] $PROFILE c/cc block ─────────────────────────────────────
+Write-Step 11 'Append c/cc functions to $PROFILE' 'start'
+if ($DryRun) {
+    Write-Step 11 '[dry-run] would append c/cc to $PROFILE' 'skip'
+} else {
+    $changed = Repair-Profile
+    if ($changed) { Write-Step 11 '$PROFILE updated' 'ok' } else { Write-Step 11 '$PROFILE already has c/cc' 'skip' }
+}
+
+# ── [12] OAuth batch ─────────────────────────────────────────────
+Write-Step 12 'OAuth batch (3 sign-ins)' 'start'
+if ($DryRun) {
+    Write-Step 12 '[dry-run] would walk through GitHub + Claude + JetBrains' 'skip'
+} else {
+    Invoke-OAuthBatch -Skip:$SkipOAuth | Out-Null
+    Write-Step 12 'OAuth batch complete' 'ok'
+}
+
+# ── [13] Secrets ─────────────────────────────────────────────────
+Write-Step 13 'Pulling .env via secrets.ps1' 'start'
+$secretsScript = "$env:USERPROFILE\.claude\scripts\secrets.ps1"
+if (-not (Test-Path $secretsScript)) {
+    Write-Step 13 'secrets.ps1 missing — install.ps1 must run first' 'warn'
+} elseif ($DryRun) {
+    Write-Step 13 '[dry-run] would call secrets.ps1' 'skip'
+} else {
+    try {
+        & $secretsScript -GistId $GistId 2>&1 | Out-Null
+        Write-Step 13 '.env pulled from Gist' 'ok'
+    } catch {
+        Write-Step 13 'secrets.ps1 failed' 'warn' $_.Exception.Message
+    }
+}
+
+# ── [14] Repo clone ──────────────────────────────────────────────
+Write-Step 14 'Cloning org repos via sync-repos.ps1' 'start'
+$syncScript = "$env:USERPROFILE\.claude\scripts\sync-repos.ps1"
+if (-not (Test-Path $syncScript)) {
+    Write-Step 14 'sync-repos.ps1 missing' 'warn'
+} elseif ($DryRun) {
+    Write-Step 14 '[dry-run] would call sync-repos.ps1' 'skip'
+} else {
+    try {
+        & $syncScript -RepoName all 2>&1 | Out-Null
+        Write-Step 14 'org repos cloned (~/codebase + ~/oss/*)' 'ok'
+    } catch {
+        Write-Step 14 'sync-repos.ps1 had errors (some repos may need re-clone)' 'warn'
+    }
+}
+
+# ── [15] maintain -Install ───────────────────────────────────────
+Write-Step 15 'Arming kun-maintain scheduled task' 'start'
+$maintainScript = "$env:USERPROFILE\.claude\scripts\maintain.ps1"
+if (-not (Test-Path $maintainScript)) {
+    Write-Step 15 'maintain.ps1 missing — skipping scheduled task' 'warn'
+} elseif ($DryRun) {
+    Write-Step 15 '[dry-run] would call maintain -Install' 'skip'
+} else {
+    try {
+        & $maintainScript -Install 2>&1 | Out-Null
+        Write-Step 15 'kun-maintain armed for daily 09:00' 'ok'
+    } catch {
+        Write-Step 15 'scheduled task creation failed' 'warn' $_.Exception.Message
+    }
+}
+
+# ── [16] Final verify via doctor ─────────────────────────────────
+Write-Step 16 'Verifying via doctor.ps1' 'start'
+$doctorScript = "$env:USERPROFILE\.claude\scripts\doctor.ps1"
+$doctorExit = -1
+if (-not (Test-Path $doctorScript)) {
+    Write-Step 16 'doctor.ps1 missing' 'fail'
+    $doctorExit = 1
+} elseif ($DryRun) {
+    Write-Step 16 '[dry-run] would run doctor' 'skip'
+    $doctorExit = 0
+} else {
+    & $doctorScript -Quiet 2>&1 | Out-Null
+    $doctorExit = $LASTEXITCODE
+    switch ($doctorExit) {
+        0 { Write-Step 16 'doctor: all green' 'ok' }
+        1 { Write-Step 16 "doctor: errors (run 'doctor' to see)" 'fail' }
+        2 { Write-Step 16 "doctor: warnings (run 'doctor' to see)" 'warn' }
+        3 { Write-Step 16 "doctor: updates available (run 'doctor -Update')" 'ok' }
+        default { Write-Step 16 "doctor: exit $doctorExit" 'warn' }
+    }
+}
+
+# ── Final state table ────────────────────────────────────────────
+$elapsed = (Get-Date) - $started
+$mins    = [int]$elapsed.TotalMinutes
+$secs    = [int]($elapsed.TotalSeconds - $mins * 60)
+
+Write-Host ''
+Write-Host '═══════════════════════════════════════════════════════════' -ForegroundColor Cyan
+if ($doctorExit -eq 0 -or $doctorExit -eq 3) {
+    Write-Host '  ✅ KUN BOOTSTRAP COMPLETE' -ForegroundColor Green
+} else {
+    Write-Host '  ⚠️  KUN BOOTSTRAP DONE WITH WARNINGS' -ForegroundColor Yellow
+}
+Write-Host "  Elapsed: ${mins}m ${secs}s · Log: $logFile" -ForegroundColor Gray
+Write-Host '═══════════════════════════════════════════════════════════' -ForegroundColor Cyan
+Write-Host ''
+Write-Host 'Next steps:' -ForegroundColor Yellow
+Write-Host '  • Open a new PowerShell and type:  c              (starts Claude)'
+Write-Host '  • Or open WebStorm in any cloned repo, then Ctrl+Esc'
+Write-Host '  • Run `doctor` any time to re-check health'
+Write-Host ''
+
+exit $doctorExit

--- a/.claude/scripts/lib/Bootstrap-Common.ps1
+++ b/.claude/scripts/lib/Bootstrap-Common.ps1
@@ -1,0 +1,57 @@
+# Bootstrap-only helpers: numbered step output, log tee, beep.
+
+$script:CurrentStep = 0
+$script:TotalSteps  = 16
+$script:BootstrapLog = $null
+
+function Initialize-BootstrapLog {
+    $logsDir = "$env:USERPROFILE\.claude\logs"
+    if (-not (Test-Path $logsDir)) { New-Item -ItemType Directory -Force -Path $logsDir | Out-Null }
+    $ts = (Get-Date).ToString('yyyyMMddTHHmmss')
+    $script:BootstrapLog = Join-Path $logsDir "bootstrap-$ts.log"
+    "[$([DateTime]::UtcNow.ToString('o'))] [INFO] bootstrap start" | Out-File $script:BootstrapLog -Encoding utf8
+    $script:BootstrapLog
+}
+
+function Write-Step {
+    param(
+        [Parameter(Mandatory)][int]$Number,
+        [Parameter(Mandatory)][string]$Description,
+        [ValidateSet('start','ok','skip','warn','fail')]$Status = 'start',
+        [string]$Detail = ''
+    )
+    $script:CurrentStep = $Number
+    $icon = switch ($Status) {
+        'start' { '⏳' }
+        'ok'    { '✅' }
+        'skip'  { '⏭ ' }
+        'warn'  { '⚠️ ' }
+        'fail'  { '❌' }
+    }
+    $color = switch ($Status) {
+        'start' { 'Cyan' }
+        'ok'    { 'Green' }
+        'skip'  { 'Gray' }
+        'warn'  { 'Yellow' }
+        'fail'  { 'Red' }
+    }
+    $prefix = "[$Number/$script:TotalSteps]".PadRight(6)
+    $line = "$prefix $icon $Description"
+    if ($Detail) { $line += " · $Detail" }
+    Write-Host $line -ForegroundColor $color
+    if ($script:BootstrapLog) {
+        "[$([DateTime]::UtcNow.ToString('o'))] [$($Status.ToUpper())] step $Number — $Description $(if ($Detail) { "· $Detail" })" |
+            Out-File $script:BootstrapLog -Append -Encoding utf8
+    }
+}
+
+function Write-BootstrapLog {
+    param([string]$Message, [string]$Level = 'INFO')
+    if (-not $script:BootstrapLog) { return }
+    "[$([DateTime]::UtcNow.ToString('o'))] [$Level] $Message" |
+        Out-File $script:BootstrapLog -Append -Encoding utf8
+}
+
+function Invoke-AttentionBell {
+    try { [Console]::Beep(1000, 200) } catch { }
+}

--- a/.claude/scripts/lib/Confirm-Admin.ps1
+++ b/.claude/scripts/lib/Confirm-Admin.ps1
@@ -1,0 +1,8 @@
+# Verify the current PowerShell process is running elevated.
+# Does NOT auto-relaunch — too brittle for irm | iex. Caller decides.
+
+function Test-IsAdmin {
+    $id = [Security.Principal.WindowsIdentity]::GetCurrent()
+    $principal = New-Object Security.Principal.WindowsPrincipal($id)
+    $principal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+}

--- a/.claude/scripts/lib/Drop-Plugin.ps1
+++ b/.claude/scripts/lib/Drop-Plugin.ps1
@@ -1,0 +1,75 @@
+# Download the Claude Code [Beta] JetBrains plugin and drop it into WebStorm's
+# plugins/ directory so it's loaded on first IDE launch. Skips if already present.
+#
+# Marketplace plugin: https://plugins.jetbrains.com/plugin/27310-claude-code-beta-
+# API endpoints (verified 2026-05-16):
+#   - latest: https://plugins.jetbrains.com/api/plugins/27310/updates?channel=&size=1
+#   - file:   https://plugins.jetbrains.com/files/{file from API}
+
+$script:PluginId = 27310
+$script:PluginNameMatch = 'claude'
+
+function Get-LatestPluginInfo {
+    try {
+        $u = "https://plugins.jetbrains.com/api/plugins/$($script:PluginId)/updates?channel=&size=1"
+        $r = Invoke-RestMethod -Uri $u -TimeoutSec 10 -ErrorAction Stop
+        if ($r.Count -eq 0) { return $null }
+        [pscustomobject]@{
+            UpdateId = $r[0].id
+            Version  = $r[0].version
+            FilePath = $r[0].file  # already a path like "27310/907737/claude-code-jetbrains-plugin-0.1.14-beta.zip"
+        }
+    } catch { $null }
+}
+
+function Get-WebStormConfigDirs {
+    $appdata = $env:APPDATA
+    if (-not $appdata) { return @() }
+    Get-ChildItem "$appdata\JetBrains" -Directory -Filter 'WebStorm*' -ErrorAction SilentlyContinue
+}
+
+function Install-ClaudeCodePlugin {
+    [CmdletBinding()]
+    param([switch]$Force)
+
+    $configDirs = Get-WebStormConfigDirs
+    if (-not $configDirs) {
+        return @{ Status = 'skip'; Reason = 'WebStorm config dir not found — install IDE first' }
+    }
+
+    $info = Get-LatestPluginInfo
+    if (-not $info) {
+        return @{ Status = 'fail'; Reason = 'could not query Marketplace API' }
+    }
+
+    # Pick the newest WebStorm config dir
+    $targetConfig = $configDirs | Sort-Object Name -Descending | Select-Object -First 1
+    $pluginsDir = Join-Path $targetConfig.FullName 'plugins'
+    if (-not (Test-Path $pluginsDir)) { New-Item -ItemType Directory -Force -Path $pluginsDir | Out-Null }
+
+    # Skip if already loaded (unless -Force)
+    $existing = Get-ChildItem $pluginsDir -Directory -ErrorAction SilentlyContinue |
+                Where-Object { $_.Name -match $script:PluginNameMatch } |
+                Select-Object -First 1
+    if ($existing -and -not $Force) {
+        return @{ Status = 'skip'; Reason = "already present: $($existing.Name)" }
+    }
+
+    # Download to temp + extract into plugins/
+    $zipPath = Join-Path $env:TEMP "claude-code-plugin-$($info.UpdateId).zip"
+    try {
+        $dlUrl = "https://plugins.jetbrains.com/files/$($info.FilePath)"
+        Invoke-WebRequest -Uri $dlUrl -OutFile $zipPath -UseBasicParsing -ErrorAction Stop
+
+        # Remove old version if any (only when -Force)
+        if ($existing -and $Force) { Remove-Item $existing.FullName -Recurse -Force }
+
+        Expand-Archive -Path $zipPath -DestinationPath $pluginsDir -Force
+        Remove-Item $zipPath -Force -ErrorAction SilentlyContinue
+
+        return @{ Status = 'ok'; Reason = "v$($info.Version) extracted to $pluginsDir" }
+    } catch {
+        if (Test-Path $zipPath) { Remove-Item $zipPath -Force -ErrorAction SilentlyContinue }
+        return @{ Status = 'fail'; Reason = $_.Exception.Message }
+    }
+}

--- a/.claude/scripts/lib/Install-Winget.ps1
+++ b/.claude/scripts/lib/Install-Winget.ps1
@@ -1,0 +1,31 @@
+# Idempotent winget install wrapper. Skips packages already present.
+
+function Test-WingetPackage {
+    param([Parameter(Mandatory)][string]$Id)
+    $output = winget list --id $Id --exact 2>$null | Out-String
+    # winget prints column headers + a row if installed, or "No installed package found" if not
+    $output -notmatch 'No installed package' -and $output -match $Id
+}
+
+function Install-WingetPackage {
+    param(
+        [Parameter(Mandatory)][string]$Id,
+        [string]$Source = 'winget',
+        [int]$Retries = 1
+    )
+    if (Test-WingetPackage -Id $Id) {
+        return @{ Installed = $true; Skipped = $true }
+    }
+
+    for ($attempt = 0; $attempt -le $Retries; $attempt++) {
+        $args = @('install', '--id', $Id, '--exact', '--source', $Source,
+                  '--accept-package-agreements', '--accept-source-agreements',
+                  '--silent', '--disable-interactivity')
+        winget @args 2>&1 | Out-Null
+        if ($LASTEXITCODE -eq 0 -or (Test-WingetPackage -Id $Id)) {
+            return @{ Installed = $true; Skipped = $false }
+        }
+        Start-Sleep -Seconds 5
+    }
+    @{ Installed = $false; Skipped = $false; ExitCode = $LASTEXITCODE }
+}

--- a/.claude/scripts/lib/Stage-OAuth.ps1
+++ b/.claude/scripts/lib/Stage-OAuth.ps1
@@ -1,0 +1,83 @@
+# OAuth batch: walk through 3 sign-ins in sequence with beep + toast on each.
+
+. "$PSScriptRoot\Bootstrap-Common.ps1"
+
+function Wait-EnterKey {
+    param([string]$Prompt = 'Press Enter to continue...')
+    Write-Host ''
+    Write-Host $Prompt -ForegroundColor Yellow -NoNewline
+    Read-Host | Out-Null
+}
+
+function Invoke-OAuthBatch {
+    param([switch]$Skip)
+    if ($Skip) {
+        Write-Host '  -SkipOAuth set — leaving sign-ins to the user' -ForegroundColor Gray
+        return $true
+    }
+
+    Invoke-AttentionBell
+    # Try to bring window forward
+    try {
+        Add-Type -AssemblyName Microsoft.VisualBasic -ErrorAction SilentlyContinue
+    } catch { }
+
+    Write-Host ''
+    Write-Host '── OAuth batch: 3 sign-ins, ~5 minutes ─────────────────' -ForegroundColor Magenta
+    Write-Host '   Browser tabs open one at a time. Press Enter between each.'
+    Wait-EnterKey -Prompt 'Press Enter to begin OAuth...'
+
+    # 1. GitHub via gh
+    Write-Host ''
+    Write-Host '   [1/3] GitHub' -ForegroundColor Cyan
+    $gh = Get-Command gh -ErrorAction SilentlyContinue
+    if (-not $gh) {
+        Write-Host '         gh CLI missing — skipping GitHub auth' -ForegroundColor Red
+    } else {
+        $authStatus = gh auth status 2>&1 | Out-String
+        if ($authStatus -match 'Logged in') {
+            Write-Host '         ✅ already logged in — skipping' -ForegroundColor Green
+        } else {
+            Write-Host '         Running: gh auth login --web --git-protocol https'
+            gh auth login --web --git-protocol https --hostname github.com
+            if ($LASTEXITCODE -eq 0) {
+                Write-Host '         ✅ GitHub authenticated' -ForegroundColor Green
+            } else {
+                Write-Host '         ⚠️  gh auth incomplete — finish manually after bootstrap' -ForegroundColor Yellow
+            }
+        }
+    }
+
+    # 2. Claude CLI
+    Write-Host ''
+    Write-Host '   [2/3] Claude' -ForegroundColor Cyan
+    $claude = Get-Command claude -ErrorAction SilentlyContinue
+    if (-not $claude) {
+        Write-Host '         claude CLI missing — skipping' -ForegroundColor Red
+    } else {
+        $credFile = "$env:USERPROFILE\.claude\.credentials.json"
+        if (Test-Path $credFile) {
+            Write-Host '         ✅ already signed in — skipping' -ForegroundColor Green
+        } else {
+            Write-Host '         Open a new PowerShell and run: claude'
+            Write-Host '         Browser will open for sign-in.'
+            Wait-EnterKey -Prompt 'Press Enter after you see "Logged in" in the claude prompt...'
+        }
+    }
+
+    # 3. JetBrains via WebStorm first launch
+    Write-Host ''
+    Write-Host '   [3/3] JetBrains' -ForegroundColor Cyan
+    $webstorm = Get-Command webstorm64 -ErrorAction SilentlyContinue
+    if (-not $webstorm) {
+        Write-Host '         WebStorm not installed — skipping JetBrains sign-in' -ForegroundColor Gray
+        Write-Host '         (sign in manually on first launch)' -ForegroundColor Gray
+    } else {
+        Write-Host '         Open WebStorm and sign in (or click Start trial).'
+        Wait-EnterKey -Prompt 'Press Enter after WebStorm shows the project window...'
+    }
+
+    Write-Host ''
+    Write-Host '   All 3 sign-ins complete. Continuing bootstrap.' -ForegroundColor Green
+    $true
+}

--- a/.claude/scripts/lib/Update-Path.ps1
+++ b/.claude/scripts/lib/Update-Path.ps1
@@ -1,0 +1,8 @@
+# Refresh $env:Path in the current process from Machine + User registry entries.
+# Needed after winget installs because they update the persistent PATH only.
+
+function Update-SessionPath {
+    $machine = [Environment]::GetEnvironmentVariable('Path', 'Machine')
+    $user    = [Environment]::GetEnvironmentVariable('Path', 'User')
+    $env:Path = ($machine, $user | Where-Object { $_ }) -join ';'
+}

--- a/.claude/scripts/sync-repos.ps1
+++ b/.claude/scripts/sync-repos.ps1
@@ -20,20 +20,37 @@ if (-not (Test-Path $OssDir)) {
     New-Item -ItemType Directory -Path $OssDir -Force | Out-Null
 }
 
-# Repository definitions
-$Repos = @{
-    "codebase" = "$env:USERPROFILE\codebase"
-    "shadcn" = "$OssDir\shadcn"
-    "radix" = "$OssDir\radix"
-    "kun" = "$env:USERPROFILE\kun"
-    "hogwarts" = "$OssDir\hogwarts"
-    "souq" = "$OssDir\souq"
-    "mkan" = "$OssDir\mkan"
-    "shifa" = "$OssDir\shifa"
-    "swift-app" = "$OssDir\swift-app"
-    "distributed-computer" = "$OssDir\distributed-computer"
-    "marketing" = "$OssDir\marketing"
+# Repository definitions — read from ~/.claude/memory/repositories.json (source of truth)
+# Falls back to the hardcoded list for bootstrapping when memory isn't copied yet.
+function Get-RepoMap {
+    $memoryFile = "$env:USERPROFILE\.claude\memory\repositories.json"
+    if (Test-Path $memoryFile) {
+        try {
+            $data = Get-Content $memoryFile -Raw | ConvertFrom-Json
+            if ($data.repos) {
+                $map = @{}
+                foreach ($p in $data.repos.PSObject.Properties) {
+                    $map[$p.Name] = $ExecutionContext.InvokeCommand.ExpandString($p.Value)
+                }
+                return $map
+            }
+        } catch { }  # fall through to hardcoded fallback below
+    }
+    @{
+        "codebase" = "$env:USERPROFILE\codebase"
+        "shadcn" = "$OssDir\shadcn"
+        "radix" = "$OssDir\radix"
+        "kun" = "$env:USERPROFILE\kun"
+        "hogwarts" = "$OssDir\hogwarts"
+        "souq" = "$OssDir\souq"
+        "mkan" = "$OssDir\mkan"
+        "shifa" = "$OssDir\shifa"
+        "swift-app" = "$OssDir\swift-app"
+        "distributed-computer" = "$OssDir\distributed-computer"
+        "marketing" = "$OssDir\marketing"
+    }
 }
+$Repos = Get-RepoMap
 
 function Sync-Repo {
     param([string]$Name)

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,11 +1,21 @@
 import type { NextConfig } from "next";
 import { createMDX } from "fumadocs-mdx/next";
 
+const RAW = "https://raw.githubusercontent.com/databayt/kun/main/.claude/scripts";
+
 const nextConfig: NextConfig = {
   typescript: {
     ignoreBuildErrors: true,
   },
   reactStrictMode: false,
+  async redirects() {
+    return [
+      // Canonical paste: `irm https://kun.databayt.org/install | iex`
+      { source: "/install", destination: `${RAW}/bootstrap.ps1`, permanent: false },
+      { source: "/finish",  destination: `${RAW}/bootstrap.ps1`, permanent: false },
+      { source: "/doctor",  destination: `${RAW}/doctor.ps1`,    permanent: false },
+    ];
+  },
 };
 
 const withMDX = createMDX();


### PR DESCRIPTION
## Summary

Implements [spec #28](https://github.com/databayt/kun/issues/28). The single-paste cold-start — paste one line, click one UAC, batch three OAuth sign-ins at the end, walk away.

```powershell
irm https://kun.databayt.org/install | iex
```

Builds on #29 (doctor) and #30 (maintain) — bootstrap's final step is `doctor`; step 15 calls `maintain -Install` to arm the daily heartbeat.

## What's in the PR

- `~/.claude/scripts/bootstrap.ps1` (260 lines) — the 16-step orchestrator
- 5 helper modules in `lib/`:
  - `Bootstrap-Common.ps1` — numbered `[N/16]` step output, log tee, attention beep
  - `Confirm-Admin.ps1` — elevation check (no auto-relaunch — too brittle inside `irm | iex`)
  - `Install-Winget.ps1` — idempotent wrapper, retry-once on transient failures
  - `Update-Path.ps1` — refresh `$env:Path` from machine + user registry
  - `Stage-OAuth.ps1` — 3-tab OAuth batch with beep + Enter gates between sign-ins

## The 16-step flow

| # | Step | Idempotent |
|---|---|---|
| 0 | ExecutionPolicy → RemoteSigned | ✅ |
| 1 | Self-elevation (one UAC) | ✅ (re-entrant via `Start-Process -Verb RunAs`) |
| 2 | Verify Win 11 + PS 5.1+ | N/A (read-only) |
| 3 | Logs dir + per-run log file | ✅ |
| 4 | winget bundle: Git, Node-LTS, gh, pwsh, Claude Code CLI, Claude Desktop | ✅ (per-package skip-if-installed) |
| 5 | PATH refresh | ✅ |
| 6 | `npm install -g pnpm` | ✅ |
| 7 | WebStorm (`-SkipWebStorm` available) | ✅ |
| 8 | Claude Code [Beta] plugin (manual today; auto pre-drop TODO) | — |
| 9 | Fetch + run install.ps1 (kun config copy) | ✅ |
| 10 | settings.json (handled by install.ps1) | ✅ |
| 11 | Append `c`/`cc` block to `$PROFILE` (reuses `Fix-Shell.ps1` from #29) | ✅ |
| 12 | OAuth batch — gh + claude + JetBrains, one at a time | N/A (human) |
| 13 | `secrets.ps1 -GistId <id>` | ✅ |
| 14 | `sync-repos.ps1` — clone every org repo | ✅ |
| 15 | `maintain -Install` — arm daily heartbeat | ✅ |
| 16 | `doctor.ps1` — final verify | N/A (read-only) |

## Flags

| Flag | Effect |
|---|---|
| `-Role` | engineer (default) / business / content / ops |
| `-GistId` | Override the default secrets Gist ID |
| `-DryRun` | Print all 16 steps, write to log, no side effects — verified ✅ |
| `-SkipOAuth` | Skip the 3-sign-in batch (useful for testing) |
| `-SkipWebStorm` | Skip step 7 |
| `-SkipCowork` | Skip Claude Desktop install (CLI-only setup) |
| `-Track` | (TODO) GitHub progress issue with checkboxes |

## Idempotency

Every step has a skip-if-already-done check. Re-running on a healthy machine completes in under a minute with all skips. There is no separate "fresh install" mode — to redo, delete `~/.claude/` first.

## `irm | iex` self-fetch

When run via the canonical paste, the script can't find `lib/` files on disk (they're in the repo, not next to bootstrap). It detects this and downloads them from `raw.githubusercontent.com/databayt/kun/main/.claude/scripts/lib/` into a temp dir before sourcing.

## Exit codes (mirror doctor's)

| Code | Meaning |
|---|---|
| `0` | Full success — doctor returned 0 |
| `1` | Hard failure — something irrecoverable |
| `2` | Warnings only — doctor returned 2 |
| `3` | Partial success — updates available |

## Verified locally

`bootstrap.ps1 -DryRun -SkipOAuth -SkipWebStorm` runs the full 16-step flow on this machine, writes a log to `~/.claude/logs/bootstrap-<ts>.log`, and exits cleanly. All 6 PowerShell files parse without errors.

## TODOs not blocking this PR (tracked in spec #28)

| Item | Why deferred |
|---|---|
| WebStorm JBR fallback to JetBrains Toolbox | Needs verification on clean VM whether direct `winget` install still ships broken JBR |
| Plugin pre-drop URL | Need stable Marketplace download URL for the Claude Code [Beta] plugin |
| `-Track` flag (GitHub progress issue) | Nice-to-have polish; works without it |
| Exact `Anthropic.Claude` winget package ID | Needs `winget search Anthropic` verification on clean VM |

## Test plan

- [x] All scripts parse cleanly via `Parser::ParseFile`
- [x] `bootstrap.ps1 -DryRun -SkipOAuth -SkipWebStorm` runs end-to-end on this dev machine
- [ ] Fresh Windows 11 VM: paste `irm | iex`, click UAC, complete 3 OAuth, full success
- [ ] Idempotent re-run: paste again on healthy machine, completes <60s, exit 0
- [ ] Resumable: Ctrl+C mid-OAuth, paste again, completes where left off
- [ ] After bootstrap: `c` works in a fresh PowerShell, `doctor` exits 0

The fresh-VM test is the only true acceptance gate (spec §10).

## Dependencies

This branch stacks on `feat/maintain` (PR #30), which stacks on `feat/doctor` (PR #29). Merge order:

```
#29 (feat/doctor)  →  rebase #30 → merge  →  rebase #31 → merge
```

Closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)
