### PR TITLE
docs: add resources section + template more engine and ops pages

### DIFF
--- a/content/docs/engine/claude-md.mdx
+++ b/content/docs/engine/claude-md.mdx
@@ -3,22 +3,43 @@ title: CLAUDE.md
 description: Project instructions that shape every response — the 3-layer hierarchy
 ---
 
+> The most powerful configuration primitive. One markdown file shapes every response, every agent, every workflow.
 
-The most powerful configuration primitive in Claude Code. A markdown file that shapes every response, every agent, every workflow. Kun uses a 3-layer hierarchy that cascades from global preferences down to repo-specific operations.
+Claude Code reads three CLAUDE.md files in priority order before each turn. The hierarchy cascades from project-specific (highest priority) down to user-global (lowest). Higher layers override lower ones, so project context always wins over global defaults.
 
-## 3-Layer Hierarchy
+## Hierarchy
 
 ```
-Priority (High → Low):
-1. Project-level  ~/project/CLAUDE.md         — Project context
-2. Repo-level     ~/project/.claude/CLAUDE.md  — Keywords, workflows
-3. User-level     ~/.claude/CLAUDE.md          — Stack, preferences
-4. Pattern library /Users/abdout/codebase/     — Core patterns
+Priority (high → low):
+1. Project-level    ./CLAUDE.md                       — Project context
+2. Repo-level       ./.claude/CLAUDE.md               — Keywords, workflows
+3. User-level       ~/.claude/CLAUDE.md               — Stack, preferences
+4. Pattern library  databayt/codebase                 — Core patterns
 ```
 
-Higher layers override lower ones. This means project-specific context always wins over global defaults.
+## Installation
 
-## Layer 1: User-Level (`~/.claude/CLAUDE.md`)
+Installed by the standard engine install.
+
+```bash
+cd ~/kun && bash .claude/scripts/install.sh
+```
+
+User-level lands at `~/.claude/CLAUDE.md`. Project and repo level land in each cloned repo by `sync-repos`.
+
+## Usage
+
+CLAUDE.md is auto-loaded by Claude Code at the start of every session. No invocation needed. Edit any layer and the next conversation picks up the change.
+
+Test what's loaded:
+
+```bash
+c "What CLAUDE.md files are active right now?"
+```
+
+## Reference
+
+### Layer 1 — User-level (`~/.claude/CLAUDE.md`)
 
 Global preferences that apply to every project and every conversation.
 
@@ -30,33 +51,35 @@ Global preferences that apply to every project and every conversation.
 | Languages | Arabic (RTL default), English (LTR) |
 | Mode | Full Autopilot (100-turn cycles) |
 | Port | Always 3000 |
-| Environment | Single .env only |
+| Environment | Single `.env` only |
 | Component hierarchy | ui, atom, template, block, micro |
 
-## Layer 2: Project-Level (`CLAUDE.md`)
+### Layer 2 — Project-level (`./CLAUDE.md`)
 
-Project-specific context per product:
+Project-specific context per product.
 
 | Product | Context |
 |---------|---------|
 | **Hogwarts** | Multi-tenant education SaaS, school modules, SSPL license |
 | **Mkan** | Rental marketplace, Airbnb-inspired, booking flow |
+| **Souq** | Multi-vendor marketplace, cart, vendor dashboards |
+| **Shifa** | Medical platform, appointments, patient records |
 | **Kun** | Configuration engine, documentation site, 3-phase roadmap |
 
-## Layer 3: Repo-Level (`.claude/CLAUDE.md`)
+### Layer 3 — Repo-level (`./.claude/CLAUDE.md`)
 
-Operational configuration: 100+ keyword-to-action mappings, MCP trigger table, slash command reference, organization repository references, React best practices from Vercel.
+Operational configuration: 100+ keyword-to-action mappings, MCP trigger table, slash command reference, organization repository references, React best practices.
 
-### What It Contains
+Contains:
 
-- **Keyword mappings** — Say `dev` to start server, `push` to commit, `deploy` to ship
+- **Keyword mappings** — say `dev` to start server, `push` to commit, `deploy` to ship
 - **Component hierarchy** — ui, atom, template, block, micro
-- **MCP trigger table** — Which keyword activates which MCP server
-- **Slash command reference** — All available `/` commands
-- **Organization references** — How to reference other databayt repos
-- **React best practices** — Waterfall elimination, bundle optimization, server components
+- **MCP trigger table** — which keyword activates which MCP server
+- **Slash command reference** — all available `/` commands
+- **Organization references** — how to reference other databayt repos
+- **React best practices** — waterfall elimination, bundle optimization, server components
 
-## Writing Effective CLAUDE.md
+## Writing effective CLAUDE.md
 
 ### Do
 
@@ -69,15 +92,40 @@ Operational configuration: 100+ keyword-to-action mappings, MCP trigger table, s
 ### Avoid
 
 - Implementation details (that's what agents and rules are for)
-- Long prose (tables and lists are better)
+- Long prose — tables and lists scan better
 - Duplicating what's in rules or agents
-- Sensitive information (use secrets instead)
+- Sensitive information (use [secrets](/docs/reference/secrets) instead)
 
-## Installation
+## Examples
 
-CLAUDE.md files are installed by the Kun install script:
+### Adding a keyword
 
-```bash
-# Installs ~/.claude/CLAUDE.md and project-level files
-cd ~/kun && bash .claude/scripts/install.sh
+In `~/.claude/CLAUDE.md`:
+
+```markdown
+### Tier 2 — Standalone tools
+
+| Keyword | What it does |
+|---------|-------------|
+| `myflow` | Start the myflow service |
 ```
+
+Then `c "myflow"` triggers it. The skill loader expands the keyword.
+
+### Project-scoped behavior
+
+In a repo's `./CLAUDE.md`:
+
+```markdown
+This is Hogwarts. When generating Prisma models, every model except
+School and User MUST include `schoolId String` and a `@@index([schoolId])`.
+```
+
+That rule only applies in this repo, never leaks to others.
+
+## Related
+
+- [Agents](/docs/engine/agents) — specialists CLAUDE.md routes to
+- [Rules](/docs/engine/rules) — path-scoped rules that CLAUDE.md references
+- [Skills](/docs/engine/skills) — slash commands shaped by CLAUDE.md context
+- [Architecture](/docs/reference/architecture) — engine layering

--- a/content/docs/engine/keywords.mdx
+++ b/content/docs/engine/keywords.mdx
@@ -36,3 +36,10 @@ The magic is not in the words. It is in knowing *which* word, at *which* moment,
 **Learn the words. Understand the intent. Then speak.**
 
 *كن — Be, and it is.*
+
+## Related
+
+- [Commands](/docs/engine/commands) — slash-command form of every keyword
+- [Skills](/docs/engine/skills) — workflow each keyword triggers
+- [Agents](/docs/engine/agents) — specialists keywords route to
+- [CLAUDE.md](/docs/engine/claude-md) — where keyword mappings are declared

--- a/content/docs/engine/mcp.mdx
+++ b/content/docs/engine/mcp.mdx
@@ -1,68 +1,44 @@
 ---
 title: MCP
-description: 18 MCP servers connecting Claude Code to external services
+description: 18 Model Context Protocol servers connecting Claude Code to external services
 ---
 
+> Tools live outside the model. MCP is how Claude reaches them.
 
-18 Model Context Protocol servers that connect Claude Code to external services — from design tools to databases to deployment platforms.
+The Model Context Protocol exposes external systems — design tools, databases, deployment platforms, monitoring — as typed tool servers. Kun ships 18 servers configured for the databayt stack.
 
-## UI and Design (5)
+## Installation
 
-| Server | Purpose | Trigger |
-|--------|---------|---------|
-| **shadcn** | Component registry, install components | `ui`, `component`, `atom` |
-| **figma** | Design file access (127.0.0.1:3845) | `figma`, design URLs |
-| **tailwind** | CSS utilities, documentation | `tailwind`, `css` |
-| **a11y** | Accessibility audits (WCAG 2.1 AA) | `accessibility`, `a11y` |
-| **storybook** | Visual testing | `storybook` |
+Each role gets a tailored MCP config, not all 18.
 
-## Testing (2)
+```bash
+# Engineer — all 18 servers
+cd ~/kun && bash .claude/scripts/install.sh
 
-| Server | Purpose | Trigger |
-|--------|---------|---------|
-| **browser** | Headless Chromium (1920x1080) | `test`, `e2e`, `see` |
-| **browser-headed** | Visible Chromium for auth flows | `see headed` |
+# Business — 8 servers
+cd ~/kun && bash .claude/scripts/install.sh business
 
-## DevOps and Infra (4)
+# Content — 8 servers
+cd ~/kun && bash .claude/scripts/install.sh content
 
-| Server | Purpose | Trigger |
-|--------|---------|---------|
-| **github** | Repos, issues, PRs, Actions | `push`, `pr`, `issue` |
-| **vercel** | Deployments, logs | `deploy`, `ship` |
-| **sentry** | Error monitoring | `error`, `debug` |
-| **gcloud** | Google Cloud CLI | `gcloud` |
+# Ops — 9 servers
+cd ~/kun && bash .claude/scripts/install.sh ops
+```
 
-## Data and Auth (4)
+## Usage
 
-| Server | Purpose | Trigger |
-|--------|---------|---------|
-| **neon** | Neon PostgreSQL branching | `prisma`, `migration`, `db` |
-| **postgres** | Database queries (dbhub) | `sql`, `query` |
-| **stripe** | Payments, subscriptions | `payment`, `billing` |
-| **keychain** | macOS Keychain credentials | `credentials` |
+MCP servers activate automatically when a relevant keyword appears in your prompt, or when you reference a URL the server can fetch.
 
-## Knowledge and PM (3)
-
-| Server | Purpose | Trigger |
-|--------|---------|---------|
-| **ref** | Technical documentation | `docs`, `lookup` |
-| **context7** | Up-to-date library docs | `latest docs` |
-| **linear** | Issue tracking | `linear`, `task` |
-
-## Role-Specific Configs
-
-Not every team member needs all 18 servers. Each role gets a tailored MCP config:
-
-| Role | Config File | Server Count |
-|------|------------|--------------|
-| **engineer** | mcp.json | All 18 |
-| **business** | mcp-business.json | 8 (github, slack, linear, stripe, notion, browser, context7, memory-bank) |
-| **content** | mcp-content.json | 8 (github, slack, notion, browser, figma, context7, memory-bank, ref) |
-| **ops** | mcp-ops.json | 9 (github, slack, vercel, sentry, neon, stripe, browser, posthog, memory-bank) |
+```text
+push                    # → github MCP
+shadcn ui button        # → shadcn MCP
+prisma migration        # → neon MCP
+deploy hogwarts         # → vercel MCP
+```
 
 ## Configuration
 
-MCP servers are configured in `~/.claude/mcp.json`:
+Servers live in `~/.claude/mcp.json`:
 
 ```json
 {
@@ -78,18 +54,93 @@ MCP servers are configured in `~/.claude/mcp.json`:
 }
 ```
 
-## Installation
+Environment variables come from `~/.claude/.env`, sourced by the `c` function in `$PROFILE`.
 
-```bash
-# Engineer (all 18 servers)
-cd ~/kun && bash .claude/scripts/install.sh
+## Reference
 
-# Business role (8 servers)
-cd ~/kun && bash .claude/scripts/install.sh business
+### UI and design (5)
 
-# Content role (8 servers)
-cd ~/kun && bash .claude/scripts/install.sh content
+| Server | Purpose | Trigger |
+|--------|---------|---------|
+| **shadcn** | Component registry, install components | `ui`, `component`, `atom` |
+| **figma** | Design file access (127.0.0.1:3845) | `figma`, design URLs |
+| **tailwind** | CSS utilities, documentation | `tailwind`, `css` |
+| **a11y** | Accessibility audits (WCAG 2.1 AA) | `accessibility`, `a11y` |
+| **storybook** | Visual testing | `storybook` |
 
-# Ops role (9 servers)
-cd ~/kun && bash .claude/scripts/install.sh ops
+### Testing (2)
+
+| Server | Purpose | Trigger |
+|--------|---------|---------|
+| **browser** | Headless Chromium (1920x1080) | `test`, `e2e`, `see` |
+| **browser-headed** | Visible Chromium for auth flows | `see headed` |
+
+### DevOps and infra (4)
+
+| Server | Purpose | Trigger |
+|--------|---------|---------|
+| **github** | Repos, issues, PRs, Actions | `push`, `pr`, `issue` |
+| **vercel** | Deployments, logs | `deploy`, `ship` |
+| **sentry** | Error monitoring | `error`, `debug` |
+| **gcloud** | Google Cloud CLI | `gcloud` |
+
+### Data and auth (4)
+
+| Server | Purpose | Trigger |
+|--------|---------|---------|
+| **neon** | Neon PostgreSQL branching | `prisma`, `migration`, `db` |
+| **postgres** | Database queries (dbhub) | `sql`, `query` |
+| **stripe** | Payments, subscriptions | `payment`, `billing` |
+| **keychain** | macOS Keychain credentials | `credentials` |
+
+### Knowledge and PM (3)
+
+| Server | Purpose | Trigger |
+|--------|---------|---------|
+| **ref** | Technical documentation | `docs`, `lookup` |
+| **context7** | Up-to-date library docs | `latest docs` |
+| **linear** | Issue tracking | `linear`, `task` |
+
+## Role-specific configs
+
+Not every team member needs all 18 servers. Roles filter what's installed.
+
+| Role | Config file | Server count | Servers |
+|------|------------|--------------|---------|
+| **engineer** | `mcp.json` | 18 | All |
+| **business** | `mcp-business.json` | 8 | github, slack, linear, stripe, notion, browser, context7, memory-bank |
+| **content** | `mcp-content.json` | 8 | github, slack, notion, browser, figma, context7, memory-bank, ref |
+| **ops** | `mcp-ops.json` | 9 | github, slack, vercel, sentry, neon, stripe, browser, posthog, memory-bank |
+
+## Examples
+
+### Install a shadcn component
+
+```text
+shadcn install button
 ```
+
+shadcn MCP fetches the latest registry, drops the component into `components/ui/`, updates the import map.
+
+### Query the production database
+
+```text
+sql select count(*) from users where created_at > now() - interval '7 days'
+```
+
+postgres MCP reads `DATABASE_URL` from `.env` and returns results.
+
+### Tail Vercel deployment logs
+
+```text
+deploy logs hogwarts production
+```
+
+vercel MCP authenticates with `VERCEL_TOKEN` and streams the latest deploy.
+
+## Related
+
+- [Connectors](/docs/operations/connectors) — daily operator view of the same servers
+- [Skills](/docs/engine/skills) — slash commands that trigger MCP calls
+- [Credentials](/docs/operations/credentials) — where MCP tokens come from
+- [Stack](/docs/reference/stack) — what's on the databayt stack

--- a/content/docs/operations/cowork.mdx
+++ b/content/docs/operations/cowork.mdx
@@ -3,17 +3,18 @@ title: Cowork
 description: Same brain, two modes — one thinks, one acts
 ---
 
+> Cowork plans, Code executes. They share `~/.claude/` and hand off via Dispatch + GitHub Issues.
 
-Cowork and Claude Code are two modes of the same brain. They share everything in `~/.claude/` — agents, memory, settings, rules. The difference is posture.
+Cowork (Claude Desktop's computer-use mode) and Claude Code are two postures of the same brain. They share every agent, every memory file, every setting in `~/.claude/`. The only difference is whether the session is for thinking or for doing.
 
-## Two Modes
+## Two modes
 
 | Mode | Posture | Who |
 |------|---------|-----|
 | **Cowork** | Think. Plan. Research. Write. Decide. | Ali, Samia, Abdout |
 | **Claude Code** | Do. Build. Deploy. Fix. Ship. | Abdout, Sedon |
 
-## Shared State
+## Shared state
 
 Both modes read and write to:
 
@@ -21,10 +22,12 @@ Both modes read and write to:
 |----------|------|---------|
 | Agents | `~/.claude/agents/` | Same 40 agents in both modes |
 | Memory | `~/.claude/memory/` | Persistent state |
-| Dispatch/Cowork | Notes → Dispatch → Cowork | Handoff note |
-| GitHub Issues | databayt/*/issues | Shared work queue |
+| Dispatch | Apple Notes — Dispatch/Cowork | Handoff notes |
+| GitHub Issues | `databayt/*/issues` | Shared work queue |
 
-## Handoff: Cowork → Code
+## Usage
+
+### Cowork → Code handoff
 
 When work starts in Cowork (planning, strategy, research):
 
@@ -34,9 +37,7 @@ When work starts in Cowork (planning, strategy, research):
 4. Code reads Cowork note at session start
 5. Code picks up the issues and executes
 
-### Example
-
-```
+```text
 [Cowork session]
 Abdout: "Plan the hogwarts notification system"
 → Research patterns, design architecture, write stories
@@ -47,7 +48,7 @@ Abdout: "Plan the hogwarts notification system"
 Captain: reads Cowork note → sees plan → starts executing #10
 ```
 
-## Handoff: Code → Cowork
+### Code → Cowork handoff
 
 When Code finishes work that needs strategic review:
 
@@ -55,11 +56,26 @@ When Code finishes work that needs strategic review:
 2. Code creates a GitHub issue if follow-up is needed
 3. Cowork picks up in the next Desktop session
 
-## Cowork Use Cases
+### Session start protocol
+
+**Every Cowork session:**
+
+1. Check Dispatch/Cowork note for Code's output
+2. Review GitHub issues for completed/blocked items
+3. Plan next moves
+
+**Every Code session:**
+
+1. `dispatch.sh read inbox` — check Abdout's instructions
+2. `dispatch.sh read cowork` — check for Cowork handoffs
+3. `gh issue list --state open` — check work queue
+4. Proceed with highest priority
+
+## Examples
 
 ### Ali (QA + Sales)
 
-```
+```text
 > "Summarize this week's hogwarts progress for pitch materials"
 > "Draft proposal for King Fahad Schools — open source, sharing economy angle"
 > "Research schools, sponsors, investors in Sudan/MENA"
@@ -67,7 +83,7 @@ When Code finishes work that needs strategic review:
 
 ### Samia (R&D)
 
-```
+```text
 > "Translate these UI strings to Arabic"
 > "Write help documentation for the admission module"
 > "Research best practices for school notification systems"
@@ -75,29 +91,19 @@ When Code finishes work that needs strategic review:
 
 ### Abdout (Planning)
 
-```
+```text
 > "Plan the notification system architecture"
 > "Review the weekly revenue report"
 > "Design the multi-tenant billing flow"
 ```
 
-## Session Start Protocol
+## The key insight
 
-### Every Cowork Session
+Cowork doesn't need to know how to code. Claude Code doesn't need to strategize. They share a brain through files, notes, and issues. Abdout switches between them like switching between thinking and doing. Both are Captain — one thinks, one acts.
 
-1. Check Dispatch/Cowork note for Code's output
-2. Review GitHub issues for completed/blocked items
-3. Plan next moves
+## Related
 
-### Every Code Session
-
-1. `dispatch.sh read inbox` — check Abdout's instructions
-2. `dispatch.sh read cowork` — check for Cowork handoffs
-3. `gh issue list --state open` — check work queue
-4. Proceed with highest priority
-
-## The Key Insight
-
-Cowork doesn't need to know how to code. Claude Code doesn't need to strategize. They share a brain through files, notes, and issues.
-
-Abdout switches between them like switching between thinking and doing. Both are Captain — one thinks, one acts.
+- [Dispatch](/docs/operations/dispatch) — the file-based handoff channel
+- [Captain](/docs/operations/captain) — runs in both modes
+- [Team](/docs/operations/team) — who uses which mode
+- [Installation](/docs/installation) — turning on computer use to enable Cowork

--- a/content/docs/operations/dispatch.mdx
+++ b/content/docs/operations/dispatch.mdx
@@ -1,12 +1,13 @@
 ---
 title: Dispatch
-description: Apple Notes async communication — 3 channels for team coordination
+description: Apple Notes async communication — three channels for team coordination
 ---
 
+> Async messages over iCloud. Captain writes updates, Cowork bridges think/do, Abdout leaves instructions.
 
-Async communication via Apple Notes. Three notes in a Dispatch folder, synced via iCloud to all Apple devices. Captain writes updates, Cowork bridges think/do, Abdout leaves instructions.
+Three notes in an Apple Notes folder named `Dispatch`, synced via iCloud to every Apple device. Each channel has a direction and a purpose. The `dispatch.sh` script reads and writes through AppleScript.
 
-## Three Channels
+## Channels
 
 | Note | Direction | Purpose |
 |------|-----------|---------|
@@ -32,7 +33,9 @@ dispatch.sh read cowork    # Check Cowork handoffs
 dispatch.sh read captain   # Review own dispatch log
 ```
 
-### Priority Levels
+## Reference
+
+### Priority levels
 
 | Level | Prefix | When |
 |-------|--------|------|
@@ -41,7 +44,7 @@ dispatch.sh read captain   # Review own dispatch log
 | `decision` | Yellow | Needs Abdout's approval |
 | `urgent` | Red | Immediate attention required |
 
-## Session Start Protocol
+### Session start protocol
 
 Every Claude Code session begins with:
 
@@ -50,9 +53,9 @@ Every Claude Code session begins with:
 3. `gh issue list --repo databayt/kun --state open` — check work queue
 4. Proceed with highest priority
 
-## How It Works
+## How it works
 
-The dispatch system uses AppleScript to read/write Apple Notes:
+The dispatch script uses AppleScript to read and write Apple Notes:
 
 ```bash
 # Write: appends timestamped entry to note
@@ -71,17 +74,47 @@ osascript -e 'tell application "Notes"
 end tell'
 ```
 
-## iCloud Sync
+iCloud sync makes notes available across devices instantly. Dispatches can be read and written from any Apple device.
 
-Notes sync via iCloud across devices. Dispatches can be read and written from anywhere.
+## Dispatch vs GitHub Issues
 
-## Integration with GitHub Issues
+Dispatch handles async communication. GitHub Issues handles structured work.
 
-Dispatch handles async communication. GitHub Issues handles structured work:
-
-```
+```text
 Dispatch: "Admission feature needed for pilot. See issues."
 GitHub:   databayt/hogwarts#10 — Implement admission form
           databayt/hogwarts#11 — Admission notification emails
           databayt/hogwarts#12 — Admission admin dashboard
 ```
+
+Captain writes the dispatch summary. Each issue is the actual unit of work.
+
+## Examples
+
+### Weekly review handoff
+
+```bash
+dispatch.sh captain "Week 18: Hogwarts admission shipped, MRR $0, pilot on track. Three blockers in dispatch/cowork."
+```
+
+### Approval request
+
+```bash
+dispatch.sh captain "Decision: bump Ali to Pro seat ($20/mo)" decision
+```
+
+### Cross-mode handoff
+
+```bash
+# In Cowork after planning session
+dispatch.sh cowork "Notification architecture complete. 3 GH issues, 1 ADR. Pick up at #10."
+
+# Next Code session reads it and proceeds
+```
+
+## Related
+
+- [Cowork](/docs/operations/cowork) — uses Dispatch/Cowork for the think→do handoff
+- [Captain](/docs/operations/captain) — writes Dispatch/Captain on weekly cadence
+- [Issue](/docs/operations/issue) — when to use a GitHub issue vs a dispatch note
+- [Connectors](/docs/operations/connectors) — other communication MCPs

--- a/content/docs/operations/team.mdx
+++ b/content/docs/operations/team.mdx
@@ -3,44 +3,42 @@ title: Team
 description: 4 roles with tailored MCP configs and agent indexes
 ---
 
+> Four humans, four tool sets. Everyone gets exactly what they need, nothing more.
 
-4 humans with tailored tools. Each role gets a specific MCP config, skill set, and agent index — so everyone has exactly the tools they need, nothing more.
+Each role on the databayt team has a specific MCP config, skill subset, and agent index. The role-based install drops only what that role uses, keeping context windows tight and surfaces clean.
 
-## Team Members
+## Members
 
 ### Abdout — Builder
+
 Engineering everything. Architecture, full-stack, deployment.
 
-### Ali — QA Engineer + Sales
-Tests features (reports issues on GitHub), manages sales@databayt.org. Outreach for schools, sponsors, investors, early adopters, leads, clients, contributors.
+### Ali — QA + Sales
 
-### Samia — R&D & Kun Caretaker
-Research on Claude/Anthropic products, sharing economy models, revenue distribution. Taking care of Kun engine. Core vision contributor.
+Tests features (reports issues on GitHub), manages `sales@databayt.org`. Outreach for schools, sponsors, investors, early adopters, leads, clients, contributors.
+
+### Samia — R&D + Kun caretaker
+
+Research on Claude/Anthropic products, sharing economy models, revenue distribution. Looks after the Kun engine. Core vision contributor.
 
 ### Sedon — Executor
+
 Clear task maps, reliable delivery. Saudi operations: bank account, physical presence, payments.
 
-## Role-Specific MCP Configs
+## Installation
 
-| Role | Config File | Servers |
-|------|------------|---------|
-| **engineer** | mcp.json | github, vercel, neon, stripe, sentry, figma, shadcn, browser, + 10 more |
-| **business** | mcp-business.json | github, slack, linear, stripe, notion, browser, context7, memory-bank |
-| **content** | mcp-content.json | github, slack, notion, browser, figma, context7, memory-bank, ref |
-| **ops** | mcp-ops.json | github, slack, vercel, sentry, neon, stripe, browser, posthog, memory-bank |
-
-## Setup
-
-One command per role — installs or updates config + runs health check:
+One command per role — installs or updates config and runs health check.
 
 ```bash
-# macOS/Linux
+# macOS / Linux
 cd ~/kun && bash .claude/scripts/setup.sh engineer
 cd ~/kun && bash .claude/scripts/setup.sh business
 cd ~/kun && bash .claude/scripts/setup.sh content
 cd ~/kun && bash .claude/scripts/setup.sh ops
+```
 
-# Windows (PowerShell)
+```powershell
+# Windows
 cd ~/kun; .\.claude\scripts\setup.ps1 -Role engineer
 cd ~/kun; .\.claude\scripts\setup.ps1 -Role business
 cd ~/kun; .\.claude\scripts\setup.ps1 -Role content
@@ -48,6 +46,17 @@ cd ~/kun; .\.claude\scripts\setup.ps1 -Role ops
 ```
 
 Re-run anytime to update config after pulling latest from git.
+
+## Reference
+
+### Role to MCP map
+
+| Role | Config file | Servers |
+|------|------------|---------|
+| **engineer** | `mcp.json` | github, vercel, neon, stripe, sentry, figma, shadcn, browser, + 10 more |
+| **business** | `mcp-business.json` | github, slack, linear, stripe, notion, browser, context7, memory-bank |
+| **content** | `mcp-content.json` | github, slack, notion, browser, figma, context7, memory-bank, ref |
+| **ops** | `mcp-ops.json` | github, slack, vercel, sentry, neon, stripe, browser, posthog, memory-bank |
 
 ### What gets installed
 
@@ -61,11 +70,11 @@ Re-run anytime to update config after pulling latest from git.
 | **Settings** | — | Hooks (engineer) or minimal |
 | **MCP** | — | Role-specific server set |
 
-## Daily Workflows
+## Examples
 
 ### Abdout — Builder
 
-```
+```text
 > "dev"                    # Start dev server
 > [build features]         # Full agent fleet
 > "build"                  # Validate
@@ -75,7 +84,7 @@ Re-run anytime to update config after pulling latest from git.
 
 ### Ali — QA + Sales
 
-```
+```text
 QA:
 > Test features from URL checklists on GitHub Issues
 > Report bugs as comments (not WhatsApp)
@@ -88,7 +97,7 @@ Sales (sales@databayt.org):
 
 ### Samia — R&D
 
-```
+```text
 Cowork:
 > Research Claude/Anthropic products
 > Study sharing economy models
@@ -98,13 +107,13 @@ Cowork:
 
 ### Sedon — Executor
 
-```
+```text
 > [clear task map]         # Well-defined tasks with steps
 > Saudi operations         # Bank, payments, physical presence
 > Batch weekly             # Monday map, Friday delivery
 ```
 
-## Config Health Monitoring
+## Health monitoring
 
 Each team member's config is verified continuously. Results report to a shared GitHub issue.
 
@@ -121,8 +130,18 @@ bash ~/.claude/scripts/health.sh --report
 ```
 
 Or use the `/health` command inside Claude Code:
-- `/health` — local check + team dashboard from GitHub
-- `/health report` — post local health to GitHub
-- `/health all` — show all team members' latest status
+
+| Command | Purpose |
+|---------|---------|
+| `/health` | Local check + team dashboard from GitHub |
+| `/health report` | Post local health to GitHub |
+| `/health all` | Show all team members' latest status |
 
 Checks: core files exist, JSON valid, MCP count matches role, commands match scope, permissions correct, CLI installed, config staleness.
+
+## Related
+
+- [Captain](/docs/operations/captain) — who allocates work to each member
+- [Dispatch](/docs/operations/dispatch) — cross-member async communication
+- [MCP](/docs/engine/mcp) — full server catalogue
+- [Profile](/docs/engine/skills) — role-based config switching

--- a/content/docs/resources/changelog.mdx
+++ b/content/docs/resources/changelog.mdx
@@ -1,0 +1,44 @@
+---
+title: Changelog
+description: Notable changes to the Kun engine and docs site
+---
+
+> Newest first. Older releases linked from each entry's commits.
+
+For the full machine-readable history, see `git log` on [databayt/kun](https://github.com/databayt/kun/commits/main).
+
+## Unreleased
+
+- Docs site restructured to shadcn-style hierarchical IA — `installation/`, `engine/`, `operations/`, `reference/`, `resources/` ([#39](https://github.com/databayt/kun/pull/39))
+- Canonical page template adopted on 5 flagship pages: installation, agents, skills, commands, captain ([#40](https://github.com/databayt/kun/pull/40))
+- `<LinkedCards>` MDX primitive — path-picker grid component with RTL-aware chevron
+- New resources section: FAQ, changelog, theming, CLI reference
+
+## 2026.05
+
+### Onboarding sharpened
+
+- Onboarding rewritten as Windows-only, Cowork-first single paste — no OS tabs, no manual fallback at the top ([#23](https://github.com/databayt/kun/pull/23))
+- Generic Onboarding page replaces the operator-specific Samia guide ([#21](https://github.com/databayt/kun/pull/21))
+- Samia full-control operator onboarding documented ([#18](https://github.com/databayt/kun/pull/18))
+
+### Engine integration
+
+- `/doctor`, `/maintain`, `/bootstrap` promoted to first-class commands
+- macOS/Linux port — `doctor.sh`, `maintain.sh`, `bootstrap.sh` mirror the PowerShell originals
+- `sync-repos.ps1` reads `repositories.json` (closes #26)
+- Plugin pre-drop + `/install` redirect wired up
+
+### Report pipeline
+
+- Credibility scoring pipeline for report-an-issue ([#16](https://github.com/databayt/kun/pull/16))
+
+## Earlier
+
+For releases prior to 2026.05, see [GitHub releases](https://github.com/databayt/kun/releases) or the full commit history on [main](https://github.com/databayt/kun/commits/main).
+
+## Related
+
+- [Repositories](/docs/reference/repositories) — full org map
+- [GitHub kun](https://github.com/databayt/kun) — source and issues
+- [Roadmap (PRD)](/docs/reference/prd) — what's planned next

--- a/content/docs/resources/cli.mdx
+++ b/content/docs/resources/cli.mdx
@@ -1,0 +1,159 @@
+---
+title: CLI
+description: Flag reference for bootstrap, doctor, maintain, and other engine scripts
+---
+
+> The shell-side surface of the engine. Each script ships PowerShell and bash variants.
+
+All CLI scripts live at `~/.claude/scripts/` after install. They're also runnable directly from raw GitHub URLs via the canonical paste shortcuts.
+
+## Canonical pastes
+
+| URL | What it does |
+|-----|--------------|
+| `https://kun.databayt.org/install` | Windows — downloads and runs `bootstrap.ps1` |
+| `https://kun.databayt.org/install.sh` | macOS/Linux — downloads and runs `bootstrap.sh` |
+| `https://kun.databayt.org/doctor` | Windows — downloads and runs `doctor.ps1` |
+| `https://kun.databayt.org/doctor.sh` | macOS/Linux — downloads and runs `doctor.sh` |
+
+```powershell
+# Windows
+irm https://kun.databayt.org/install | iex
+```
+
+```bash
+# macOS / Linux
+curl -fsSL https://kun.databayt.org/install.sh | bash
+```
+
+## bootstrap
+
+Single-paste cold start. Installs side-tools, Claude Code, the engine config, and clones every active databayt repo.
+
+| Flag | Default | What it does |
+|------|---------|--------------|
+| `-DryRun` | false | Print what would happen, change nothing |
+| `-Track` | false | Open a GitHub issue tracking this install for support |
+| `-GistId <id>` | `68453b25fa9d28c94426c55c179b3838` | Secrets gist ID (databayt-team default) |
+| `-SkipWinget` | false | Skip Windows side-tools (Git, Node, gh, PS7) |
+| `-SkipClaude` | false | Skip Claude Code CLI install |
+| `-SkipConfig` | false | Skip the `~/.claude/` config drop |
+| `-SkipRepos` | false | Skip `sync-repos.ps1` cloning step |
+
+```powershell
+# Standard
+irm https://kun.databayt.org/install | iex
+
+# Track this install for support
+& "$env:USERPROFILE\.claude\scripts\bootstrap.ps1" -Track
+
+# Re-run config only (after sync changes)
+& "$env:USERPROFILE\.claude\scripts\bootstrap.ps1" -SkipWinget -SkipClaude -SkipRepos
+```
+
+bash equivalents use `--dry-run`, `--track`, `--gist-id`, `--skip-winget`, `--skip-claude`, `--skip-config`, `--skip-repos`.
+
+## doctor
+
+Health check + auto-repair for `~/.claude/`. Exits 0 (all green), 1 (warning), 2 (degraded), 3 (broken).
+
+| Flag | Default | What it does |
+|------|---------|--------------|
+| `-Fix` | false | Auto-repair detected issues |
+| `-Update` | false | Pull latest config from databayt/codebase |
+| `-Report` | false | Print structured report (markdown) |
+| `-Quiet` | false | Errors only |
+| `-Json` | false | Machine-readable output |
+
+```powershell
+# Check
+claude doctor
+# or
+& "$env:USERPROFILE\.claude\scripts\doctor.ps1"
+
+# Check + auto-fix
+& "$env:USERPROFILE\.claude\scripts\doctor.ps1" -Fix
+
+# Pull latest + repair
+& "$env:USERPROFILE\.claude\scripts\doctor.ps1" -Fix -Update
+```
+
+## maintain
+
+Daily heartbeat. Syncs repos, runs doctor, notifies on red. Designed for scheduled-task / cron use.
+
+| Flag | Default | What it does |
+|------|---------|--------------|
+| `-Install` | false | Register as Windows Task Scheduler / cron job |
+| `-Status` | false | Show last-run summary |
+| `-Run` | false | Force one immediate run |
+| `-NoNotify` | false | Skip dispatch notifications |
+
+```powershell
+# Install scheduled task (runs at 9am daily)
+& "$env:USERPROFILE\.claude\scripts\maintain.ps1" -Install
+
+# Check last run
+& "$env:USERPROFILE\.claude\scripts\maintain.ps1" -Status
+
+# Force run now
+& "$env:USERPROFILE\.claude\scripts\maintain.ps1" -Run
+```
+
+## sync-repos
+
+Clone or update every active databayt repo. Reads `~/.claude/scripts/repositories.json` for the list.
+
+| Flag | Default | What it does |
+|------|---------|--------------|
+| `-Path <dir>` | `$env:USERPROFILE\projects\databayt` | Target directory |
+| `-DryRun` | false | Print what would clone/pull, change nothing |
+| `-Verbose` | false | Show git output |
+
+```powershell
+& "$env:USERPROFILE\.claude\scripts\sync-repos.ps1"
+& "$env:USERPROFILE\.claude\scripts\sync-repos.ps1" -DryRun
+```
+
+## secrets
+
+Drop `.env` files from a private gist into `~/.claude/.env` and per-repo `.env` locations.
+
+| Flag | Default | What it does |
+|------|---------|--------------|
+| `-GistId <id>` | required | Gist ID containing the team `.env` collection |
+| `-DryRun` | false | List which files would be written |
+
+```powershell
+& "$env:USERPROFILE\.claude\scripts\secrets.ps1" -GistId 68453b25fa9d28c94426c55c179b3838
+```
+
+## install (engine config)
+
+Drops the `~/.claude/` config (agents, skills, MCP, hooks, rules). Called by `bootstrap` but runnable on its own to refresh.
+
+```powershell
+irm https://raw.githubusercontent.com/databayt/codebase/main/.claude/scripts/install.ps1 | iex
+```
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/databayt/codebase/main/.claude/scripts/install.sh | bash
+```
+
+## Exit codes
+
+| Code | Meaning |
+|------|---------|
+| 0 | Success |
+| 1 | Warning — completed with non-fatal issues |
+| 2 | Degraded — partial completion, manual fix needed |
+| 3 | Broken — refused to run or failed early |
+
+Scripts emit a final line `Exit: <code>` so wrappers and CI can branch on it.
+
+## Related
+
+- [Installation](/docs/installation) — when to run which script
+- [Commands](/docs/engine/commands) — slash-command equivalents inside Claude Code
+- [Repositories](/docs/reference/repositories) — what `sync-repos` clones
+- [Secrets](/docs/reference/secrets) — gist layout and `.env` format

--- a/content/docs/resources/faq.mdx
+++ b/content/docs/resources/faq.mdx
@@ -1,0 +1,142 @@
+---
+title: FAQ
+description: Common questions about Kun, the engine, and daily use
+---
+
+> What people actually ask after their first 24 hours with Kun.
+
+## Getting started
+
+<Accordion type="single" collapsible>
+
+<AccordionItem value="plan">
+<AccordionTrigger>Which Claude plan do I need?</AccordionTrigger>
+<AccordionContent>
+**Pro** or **Max** for the recommended Cowork install (computer use is gated to those plans). Team and Enterprise can install manually — see [Installation](/docs/installation) "Manual PowerShell" tab.
+</AccordionContent>
+</AccordionItem>
+
+<AccordionItem value="os">
+<AccordionTrigger>Does Kun work on macOS or Linux?</AccordionTrigger>
+<AccordionContent>
+The engine config (`~/.claude/`) is cross-platform and works on any OS with Claude Code installed. The one-paste installer is currently Windows-focused — macOS/Linux users follow the [self-hosting guide](/docs/installation/self-hosting) or run the manual steps directly.
+</AccordionContent>
+</AccordionItem>
+
+<AccordionItem value="time">
+<AccordionTrigger>How long does a fresh install take?</AccordionTrigger>
+<AccordionContent>
+About 60 minutes with Cowork driving. Most of that is OAuth screens (GitHub, JetBrains, Anthropic) and one or two cloud syncs. The actual scripted work is under 10 minutes.
+</AccordionContent>
+</AccordionItem>
+
+<AccordionItem value="esc">
+<AccordionTrigger>How do I stop Cowork mid-install?</AccordionTrigger>
+<AccordionContent>
+Press **Esc** anywhere on screen. Claude releases control and unhides any apps it minimized. You can resume by telling it to continue.
+</AccordionContent>
+</AccordionItem>
+
+</Accordion>
+
+## Daily use
+
+<Accordion type="single" collapsible>
+
+<AccordionItem value="c">
+<AccordionTrigger>What does the `c` function do?</AccordionTrigger>
+<AccordionContent>
+`c` is `claude --dangerously-skip-permissions` bound to one keystroke. Use it for trusted local work. `cc` is the unflagged `claude` for sessions where you want permission prompts. Both are installed in your `$PROFILE` during setup.
+</AccordionContent>
+</AccordionItem>
+
+<AccordionItem value="keyword">
+<AccordionTrigger>What's the difference between keywords and slash commands?</AccordionTrigger>
+<AccordionContent>
+Same thing, different invocation. `c "/dev"` and `c "dev"` both trigger the dev command. Slash form is explicit; keyword form leans on Claude to route. See [Keywords](/docs/engine/keywords) for the full vocabulary.
+</AccordionContent>
+</AccordionItem>
+
+<AccordionItem value="captain">
+<AccordionTrigger>When should I talk to captain vs a specialist agent?</AccordionTrigger>
+<AccordionContent>
+Captain for company-wide decisions: weekly allocation, cross-product priority, scope cuts. Specialists for the actual work. Captain delegates — it never writes code. See [Captain](/docs/operations/captain) for the decision matrix.
+</AccordionContent>
+</AccordionItem>
+
+<AccordionItem value="multi-repo">
+<AccordionTrigger>How do I work across multiple databayt repos?</AccordionTrigger>
+<AccordionContent>
+Every active repo is cloned to `%USERPROFILE%\projects\databayt\` during install. Each repo has its own `.claude/` config layered over the global one. See [Repositories](/docs/reference/repositories).
+</AccordionContent>
+</AccordionItem>
+
+</Accordion>
+
+## Troubleshooting
+
+<Accordion type="single" collapsible>
+
+<AccordionItem value="doctor">
+<AccordionTrigger>`claude doctor` shows red — what now?</AccordionTrigger>
+<AccordionContent>
+Run `c "/doctor fix"` for auto-repair. If still red, check `~/.claude/.env` exists, your GitHub auth is valid (`gh auth status`), and the install scripts ran end-to-end. The doctor output names the failing check — search [issues](https://github.com/databayt/kun/issues) for that string.
+</AccordionContent>
+</AccordionItem>
+
+<AccordionItem value="uac">
+<AccordionTrigger>Windows UAC is blocking the install</AccordionTrigger>
+<AccordionContent>
+Re-run the install in PowerShell **as Administrator**. winget needs elevation for the side-tools (Git, Node, gh CLI, PowerShell 7). The `~/.claude/` install itself runs as your user, no admin needed.
+</AccordionContent>
+</AccordionItem>
+
+<AccordionItem value="gh">
+<AccordionTrigger>`gh auth login` won't open a browser</AccordionTrigger>
+<AccordionContent>
+Fall back to device-flow: `gh auth login --web=false`. It prints a code; paste it into github.com/login/device on any browser.
+</AccordionContent>
+</AccordionItem>
+
+<AccordionItem value="path">
+<AccordionTrigger>`c` not found in new terminals</AccordionTrigger>
+<AccordionContent>
+The `c` function lives in `$PROFILE`. Run `. $PROFILE` to reload, or open a new terminal. If still missing, check `Test-Path $PROFILE` and re-paste the `c`/`cc` block from [Installation](/docs/installation).
+</AccordionContent>
+</AccordionItem>
+
+</Accordion>
+
+## Engine internals
+
+<Accordion type="single" collapsible>
+
+<AccordionItem value="agents-vs-skills">
+<AccordionTrigger>What's the difference between agents and skills?</AccordionTrigger>
+<AccordionContent>
+**Agents** are domain specialists (markdown in `~/.claude/agents/`) with their own instructions, model, and context. **Skills** are slash commands (markdown in `~/.claude/commands/`) that expand into prompts. Skills invoke agents. See [Agents](/docs/engine/agents) and [Skills](/docs/engine/skills).
+</AccordionContent>
+</AccordionItem>
+
+<AccordionItem value="mcp">
+<AccordionTrigger>Which MCP servers ship by default?</AccordionTrigger>
+<AccordionContent>
+18 servers covering shadcn, GitHub, Vercel, Neon, Stripe, Sentry, Linear, PostHog, and more. Full catalogue at [MCP](/docs/engine/mcp). Add or remove per-machine in `~/.claude/.mcp.json`.
+</AccordionContent>
+</AccordionItem>
+
+<AccordionItem value="customize">
+<AccordionTrigger>How do I customize without forking?</AccordionTrigger>
+<AccordionContent>
+Local overrides go in `~/.claude/CLAUDE.md` and per-repo `<repo>/.claude/CLAUDE.md`. Profile-based selection (engineer/business/content/ops) is in [Profile](/docs/engine/skills). Org-wide changes land in [databayt/codebase](https://github.com/databayt/codebase) via PR.
+</AccordionContent>
+</AccordionItem>
+
+</Accordion>
+
+## Related
+
+- [Installation](/docs/installation) — full setup walkthrough
+- [Captain](/docs/operations/captain) — decision matrix and weekly rhythm
+- [Keywords](/docs/engine/keywords) — vocabulary that drives the engine
+- [GitHub issues](https://github.com/databayt/kun/issues) — bug reports and feature requests

--- a/content/docs/resources/meta.json
+++ b/content/docs/resources/meta.json
@@ -1,4 +1,4 @@
 {
   "title": "Resources",
-  "pages": ["tips", "tweets"]
+  "pages": ["tips", "tweets", "faq", "changelog", "theming", "cli"]
 }

--- a/content/docs/resources/theming.mdx
+++ b/content/docs/resources/theming.mdx
@@ -1,0 +1,106 @@
+---
+title: Theming
+description: OKLch tokens, dark mode, and RTL — how the docs site is themed
+---
+
+> One token set. Light, dark, LTR, RTL — every variant falls out of the same variables.
+
+The docs site uses Tailwind CSS 4 with OKLch color space. All colors flow through CSS custom properties defined in `src/app/globals.css`. Override them at `:root` for global change; override under `.dark` for dark-mode-only change.
+
+## Token reference
+
+| Token | Light | Dark | Purpose |
+|-------|-------|------|---------|
+| `--background` | `oklch(1 0 0)` | `oklch(0.145 0 0)` | Page surface |
+| `--foreground` | `oklch(0.145 0 0)` | `oklch(0.985 0 0)` | Body text |
+| `--card` | `oklch(1 0 0)` | `oklch(0.205 0 0)` | Card surface (LinkedCard, panels) |
+| `--card-foreground` | `oklch(0.145 0 0)` | `oklch(0.985 0 0)` | Text on cards |
+| `--popover` | `oklch(1 0 0)` | `oklch(0.205 0 0)` | Popover/dialog surface |
+| `--primary` | `oklch(0.205 0 0)` | `oklch(0.922 0 0)` | Buttons, links emphasis |
+| `--primary-foreground` | `oklch(0.985 0 0)` | `oklch(0.205 0 0)` | Text on primary |
+| `--secondary` | `oklch(0.97 0 0)` | `oklch(0.269 0 0)` | Secondary buttons |
+| `--muted` | `oklch(0.97 0 0)` | `oklch(0.269 0 0)` | Muted backgrounds |
+| `--muted-foreground` | `oklch(0.556 0 0)` | `oklch(0.708 0 0)` | Secondary text, chevrons |
+| `--accent` | `oklch(0.97 0 0)` | `oklch(0.269 0 0)` | Hover backgrounds |
+| `--accent-foreground` | `oklch(0.205 0 0)` | `oklch(0.985 0 0)` | Text on accent |
+| `--destructive` | `oklch(0.577 0.245 27.325)` | `oklch(0.704 0.191 22.216)` | Errors, danger |
+| `--border` | `oklch(0.922 0 0)` | `oklch(1 0 0 / 10%)` | All borders |
+| `--input` | `oklch(0.922 0 0)` | `oklch(1 0 0 / 15%)` | Input outlines |
+| `--ring` | `oklch(0.708 0 0)` | `oklch(0.556 0 0)` | Focus rings |
+| `--radius` | `0.65rem` | (same) | Base radius (derives `sm`/`md`/`lg`/`xl`) |
+
+Sidebar and chart tokens follow the same pattern — see `src/app/globals.css` for the full set.
+
+## Why OKLch
+
+OKLch is perceptually uniform — adjusting lightness gives equal visual steps across hues. Hex and HSL don't have this property. For dark-mode pairings, you can invert `L` while keeping `C` and `H` constant and get a balanced result.
+
+## Dark mode
+
+Toggle via the `dark` class on `<html>`. The `next-themes` package handles user preference and system sync. Class-based scoping means no JS flash, no FOUC.
+
+```tsx
+<html className={cn(theme === "dark" && "dark")}>
+```
+
+To add a new color variable, define it in both `:root` and `.dark` blocks, then add a `--color-<name>: var(--<name>)` alias inside `@theme inline`.
+
+## RTL support
+
+The docs render right-to-left for `lang=ar` via the `dir` attribute on `<html>`. Always use logical properties so layout flips correctly:
+
+| Don't | Use |
+|-------|-----|
+| `ml-4` | `ms-4` |
+| `mr-4` | `me-4` |
+| `pl-6` | `ps-6` |
+| `pr-6` | `pe-6` |
+| `border-l` | `border-s` |
+| `text-left` | `text-start` |
+| `text-right` | `text-end` |
+| `left-0` | `start-0` |
+| `right-0` | `end-0` |
+
+For icons that have direction (arrows, chevrons), use the `rtl:` variant:
+
+```tsx
+<ChevronRight className="rtl:rotate-180" />
+```
+
+## Container utilities
+
+`src/styles/container.css` defines responsive container classes that automatically pick `ps-`/`pe-` based on direction. Use `.container`, `.container-fluid`, `.container-grid`, or `.container-flex` instead of hand-rolling.
+
+## Examples
+
+### Card with semantic tokens
+
+```tsx
+<div className="rounded-xl border bg-card p-6 text-card-foreground hover:bg-accent hover:text-accent-foreground">
+  Hover me
+</div>
+```
+
+Never use `bg-white`, `bg-gray-100`, `text-black` directly. Always semantic tokens — they flip in dark mode for free.
+
+### Custom token
+
+```css
+:root {
+  --brand: oklch(0.7 0.18 240);
+}
+.dark {
+  --brand: oklch(0.55 0.22 240);
+}
+@theme inline {
+  --color-brand: var(--brand);
+}
+```
+
+Now `bg-brand`, `text-brand`, `border-brand` work.
+
+## Related
+
+- [shadcn — Theming](https://ui.shadcn.com/docs/theming) — the upstream reference
+- [Tailwind CSS 4](https://tailwindcss.com/docs) — utility class reference
+- [Stack](/docs/reference/stack) — what's in the docs site stack


### PR DESCRIPTION
## Summary

Phase 3 of the shadcn-style docs refresh. Stacked on top of #40.

Adds a complete **Resources** section (FAQ, changelog, theming, CLI) that was missing entirely, and applies the canonical page template to six more pages across Engine and Operations.

**This PR targets `docs/shadcn-page-templates` (Phase 2) and should be merged after #40 lands.** Rebase onto main after that.

## Changes

### New resources pages (4)

- **`resources/faq.mdx`** — `<Accordion>`-grouped Q&A across getting started, daily use, troubleshooting, and engine internals
- **`resources/changelog.mdx`** — release notes stub with current "Unreleased" section pointing at PRs #39 and #40 of this refresh
- **`resources/theming.mdx`** — token reference for the OKLch system, dark mode toggle, RTL logical-property table, custom-token recipe
- **`resources/cli.mdx`** — flag reference for `bootstrap`, `doctor`, `maintain`, `sync-repos`, `secrets`, `install` scripts (both PowerShell and bash variants)
- **`resources/meta.json`** updated to declare new page order

### Engine pages templated (3)

- **`engine/mcp.mdx`** — hero, installation moved to top, usage section, reference tables grouped by category, role configs preserved, examples, Related
- **`engine/claude-md.mdx`** — hero, installation, usage with "what's loaded" recipe, three-layer reference, do/avoid lists, examples
- **`engine/keywords.mdx`** — Related section added (Spellbook-driven page keeps its Harry-Potter voice)

### Operations pages templated (3)

- **`operations/cowork.mdx`** — hero, shared-state table, handoff workflow, per-operator examples, Related
- **`operations/team.mdx`** — hero, role descriptions, installation block, MCP/install reference tables, per-role examples, health monitoring, Related
- **`operations/dispatch.mdx`** — hero, channels table, usage, priority/protocol reference, AppleScript internals, dispatch-vs-issues block, examples, Related

## Test plan

- [x] `pnpm docs:check` passes (40 files / 40 slugs / 0 broken links)
- [x] `next build` succeeds — all paths generated
- [ ] After merge: visual check of new resources pages in dev (FAQ accordion, theming tables, CLI snippets)
- [ ] After merge: verify TOC right-rail picks up new H2 sections

## Out of scope

- Remaining operations pages (`context`, `voice`, `credentials`, `connectors`, `apps`, `issue`) stay at Phase 1 baseline — functional but lighter shape, deferred to Phase 4
- Reference pages — already mostly tables, template adoption deferred
- Phase 4 (hover anchors, badges, Cmd+K search, mobile sidebar) — separate PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)