### PR TITLE
docs: hover-anchor headings + New/Updated sidebar badges

### DIFF
--- a/src/components/docs/docs-sidebar.tsx
+++ b/src/components/docs/docs-sidebar.tsx
@@ -4,6 +4,7 @@ import Link from "next/link"
 import { usePathname } from "next/navigation"
 
 import type { docsSource } from "@/lib/source"
+import { PAGES_NEW, PAGES_UPDATED } from "@/lib/docs"
 import {
   Sidebar,
   SidebarContent,
@@ -97,6 +98,8 @@ export function DocsSidebar({
   function renderLink(item: DocEntry) {
     const fullHref = `${prefix}${item.href}`
     const isActive = pathname === fullHref || pathname === item.href
+    const isNew = PAGES_NEW.includes(item.href)
+    const isUpdated = !isNew && PAGES_UPDATED.includes(item.href)
 
     return (
       <SidebarMenuItem key={item.href}>
@@ -105,7 +108,19 @@ export function DocsSidebar({
           isActive={isActive}
           className="relative h-[30px] w-full border border-transparent text-[0.8rem] font-medium p-0"
         >
-          <Link href={fullHref} className="block w-full">{item.label}</Link>
+          <Link href={fullHref} className="flex w-full items-center gap-2">
+            <span>{item.label}</span>
+            {isNew && (
+              <span className="ms-auto rounded-sm bg-primary/10 px-1.5 py-0.5 text-[0.65rem] font-medium text-primary">
+                New
+              </span>
+            )}
+            {isUpdated && (
+              <span className="ms-auto rounded-sm bg-muted px-1.5 py-0.5 text-[0.65rem] font-medium text-muted-foreground">
+                Updated
+              </span>
+            )}
+          </Link>
         </SidebarMenuButton>
       </SidebarMenuItem>
     )

--- a/src/lib/docs.ts
+++ b/src/lib/docs.ts
@@ -1,0 +1,23 @@
+// Sidebar badges. Both arrays hold lang-agnostic /docs/* paths.
+// Add an entry when you ship a new page or substantially rewrite an existing one,
+// then remove it after ~2 weeks once the badge has served its purpose.
+
+export const PAGES_NEW: readonly string[] = [
+  "/docs/resources/faq",
+  "/docs/resources/changelog",
+  "/docs/resources/theming",
+  "/docs/resources/cli",
+]
+
+export const PAGES_UPDATED: readonly string[] = [
+  "/docs/installation",
+  "/docs/engine/agents",
+  "/docs/engine/skills",
+  "/docs/engine/commands",
+  "/docs/engine/mcp",
+  "/docs/engine/claude-md",
+  "/docs/operations/captain",
+  "/docs/operations/cowork",
+  "/docs/operations/team",
+  "/docs/operations/dispatch",
+]

--- a/src/mdx-components.tsx
+++ b/src/mdx-components.tsx
@@ -24,6 +24,29 @@ import { LinkedCard, LinkedCards } from "@/components/docs/linked-card"
 
 // This file is required to use MDX in `app` directory.
 
+// Slug from heading text — keeps anchors stable across renders.
+function slugify(value: React.ReactNode): string | undefined {
+  if (value === undefined || value === null) return undefined
+  return value
+    .toString()
+    .replace(/ /g, "-")
+    .replace(/'/g, "")
+    .replace(/\?/g, "")
+    .toLowerCase()
+}
+
+function HeadingAnchor({ id }: { id: string }) {
+  return (
+    <a
+      href={`#${id}`}
+      aria-label={`Link to ${id.replace(/-/g, " ")}`}
+      className="text-muted-foreground ms-2 font-normal no-underline opacity-0 transition-opacity group-hover:opacity-100 focus-visible:opacity-100"
+    >
+      #
+    </a>
+  )
+}
+
 const mdxComponents = {
     // Allows customizing built-in components, e.g. to add styling.
     h1: ({ className, ...props }: React.HTMLAttributes<HTMLHeadingElement>) => (
@@ -35,42 +58,54 @@ const mdxComponents = {
         {...props}
       />
     ),
-    h2: ({ className, ...props }: React.HTMLAttributes<HTMLHeadingElement>) => {
-      const id = props.children
-        ?.toString()
-        .replace(/ /g, "-")
-        .replace(/'/g, "")
-        .replace(/\?/g, "")
-        .toLowerCase()
+    h2: ({ className, children, ...props }: React.HTMLAttributes<HTMLHeadingElement>) => {
+      const id = slugify(children)
       return (
         <h2
           id={id}
           className={cn(
-            "font-heading [&+]*:[code]:text-xl mt-10 scroll-m-28 text-xl font-medium tracking-tight first:mt-0 lg:mt-16 [&+.steps]:!mt-0 [&+.steps>h3]:!mt-4 [&+h3]:!mt-6 [&+p]:!mt-4",
+            "font-heading group [&+]*:[code]:text-xl mt-10 scroll-m-28 text-xl font-medium tracking-tight first:mt-0 lg:mt-16 [&+.steps]:!mt-0 [&+.steps>h3]:!mt-4 [&+h3]:!mt-6 [&+p]:!mt-4",
             className
           )}
           {...props}
-        />
+        >
+          {children}
+          {id && <HeadingAnchor id={id} />}
+        </h2>
       )
     },
-    h3: ({ className, ...props }: React.HTMLAttributes<HTMLHeadingElement>) => (
-      <h3
-        className={cn(
-          "font-heading mt-12 scroll-m-28 text-lg font-medium tracking-tight [&+p]:!mt-4 *:[code]:text-xl",
-          className
-        )}
-        {...props}
-      />
-    ),
-    h4: ({ className, ...props }: React.HTMLAttributes<HTMLHeadingElement>) => (
-      <h4
-        className={cn(
-          "font-heading mt-8 scroll-m-28 text-base font-medium tracking-tight",
-          className
-        )}
-        {...props}
-      />
-    ),
+    h3: ({ className, children, ...props }: React.HTMLAttributes<HTMLHeadingElement>) => {
+      const id = slugify(children)
+      return (
+        <h3
+          id={id}
+          className={cn(
+            "font-heading group mt-12 scroll-m-28 text-lg font-medium tracking-tight [&+p]:!mt-4 *:[code]:text-xl",
+            className
+          )}
+          {...props}
+        >
+          {children}
+          {id && <HeadingAnchor id={id} />}
+        </h3>
+      )
+    },
+    h4: ({ className, children, ...props }: React.HTMLAttributes<HTMLHeadingElement>) => {
+      const id = slugify(children)
+      return (
+        <h4
+          id={id}
+          className={cn(
+            "font-heading group mt-8 scroll-m-28 text-base font-medium tracking-tight",
+            className
+          )}
+          {...props}
+        >
+          {children}
+          {id && <HeadingAnchor id={id} />}
+        </h4>
+      )
+    },
     h5: ({ className, ...props }: React.HTMLAttributes<HTMLHeadingElement>) => (
       <h5
         className={cn(


### PR DESCRIPTION
## Summary

Phase 4 of the shadcn-style docs refresh. Stacked on top of #42. **Targets `docs/shadcn-new-sections` and should be merged after #42 lands.** Rebase onto main after that.

Two polish primitives that move kun docs the rest of the way toward shadcn parity without rewiring infrastructure: hover-anchor `#` next to every section heading, and small `New` / `Updated` badges in the sidebar.

## Changes

- **`src/mdx-components.tsx`** — extract `slugify()` helper, add `<HeadingAnchor>` component, apply to h2/h3/h4. Anchor is `opacity-0` and fades in on `group-hover` or when the link itself receives focus (keyboard-accessible).
- **`src/lib/docs.ts` (new)** — `PAGES_NEW` and `PAGES_UPDATED` arrays. New entries currently flag the 4 Phase 3 resources pages (FAQ, changelog, theming, CLI). Updated flags the 10 pages templated in Phase 2 / 3.
- **`src/components/docs/docs-sidebar.tsx`** — `renderLink` reads both arrays and shows an inline badge. New beats Updated if both flagged.

## Test plan

- [x] `pnpm docs:check` clean (40 / 40 / 0)
- [x] `next build` succeeds
- [ ] After merge: hover any h2/h3/h4 — `#` fades in, click copies URL
- [ ] After merge: sidebar shows "New" badge on the four resources entries and "Updated" on the ten flagged pages
- [ ] After merge: dark mode + RTL spot-check on a flagged page

## Out of scope

- **Mobile sidebar via Sheet** — deferred because the current `<Sidebar collapsible="none">` would need to flip to `"offcanvas"` plus a layout-level `<SidebarTrigger>`, and that risks regressing desktop. Splitting into its own PR.
- **Cmd+K search** — Fumadocs ships `createFromSource` for free, but the dialog UI is a real surface area. Separate PR.
- **Redirect 307 → 301 flip** — premature. Plan calls for 7 days of monitoring first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)