### PR TITLE
docs: adopt shadcn page template on 5 flagship pages

### DIFF
--- a/content/docs/engine/agents/index.mdx
+++ b/content/docs/engine/agents/index.mdx
@@ -1,28 +1,67 @@
 ---
 title: Agents
-description: 40 agents across 4 tiers — from captain to specialists
+description: 40 specialized agents across 4 tiers — from captain to specialists
 ---
 
+> One captain. Three leadership tiers. Thirty-one specialists. Every keyword routes to the right one.
 
-40 specialized agents organized in a 4-tier hierarchy. The top 9 leadership agents manage business, product, and technical strategy. The bottom 31 specialist agents handle execution across stack, design, UI, DevOps, VCS, and domain expertise.
+40 markdown agents in `~/.claude/agents/` give Claude domain expertise. The top 9 run business, product, and technical strategy. The bottom 31 execute across stack, design, UI, DevOps, VCS, and product references.
 
-## Hierarchy
+## Preview
 
+<BuildingBlocks
+  title="Agent fleet"
+  sections={[
+    { title: "Tier 0", items: ["captain"] },
+    { title: "Tier 1 — Business", items: ["revenue", "growth", "support"] },
+    { title: "Tier 2 — Product", items: ["product", "analyst"] },
+    { title: "Tier 3 — Tech Lead", items: ["tech-lead", "ops", "guardian"] },
+    { title: "Stack", items: ["nextjs", "react", "typescript", "tailwind", "prisma", "shadcn", "authjs"] },
+    { title: "Design", items: ["orchestration", "architecture", "pattern", "structure"] },
+    { title: "UI", items: ["atom", "template", "block"] },
+    { title: "DevOps", items: ["build", "deploy", "test"] },
+    { title: "VCS", items: ["git", "github"] },
+    { title: "Specialized", items: ["middleware", "i18n", "semantic", "sse", "optimize", "performance", "comment", "icon"] },
+    { title: "References", items: ["hogwarts", "souq", "mkan", "shifa"] }
+  ]}
+/>
+
+## Installation
+
+All 40 agents land at `~/.claude/agents/` during the standard install.
+
+```bash
+cd ~/kun && bash .claude/scripts/install.sh
 ```
-captain (Tier 0 — company brain)
-├── Business (Tier 1): revenue, growth, support
-├── Product (Tier 2): product, analyst
-└── Tech Leadership (Tier 3): tech-lead, ops, guardian
-        └── orchestration → 31 specialist agents
+
+See [Installation](/docs/installation) for the full setup walkthrough.
+
+## Usage
+
+Agents activate three ways: via the `Agent` tool, via keywords that map to them, or via natural language.
+
+```text
+@captain Plan this week's allocation
 ```
 
-## Tier 0 — Captain
+```text
+@orchestration ship hogwarts admission
+```
+
+```text
+table users like hogwarts
+# → block agent → DataTable pattern → prisma agent → schema
+```
+
+## Reference
+
+### Tier 0 — Captain
 
 | Agent | Scope |
 |-------|-------|
 | **captain** | CEO brain — weekly allocation, revenue strategy, team coordination across 5 products and 4 humans. Never writes code. Always delegates. |
 
-## Tier 1 — Business (3)
+### Tier 1 — Business (3)
 
 | Agent | Scope | Primary Human |
 |-------|-------|---------------|
@@ -30,14 +69,14 @@ captain (Tier 0 — company brain)
 | **growth** | Content strategy, SEO, social media, developer relations, Arabic-first content | Samia, Ali |
 | **support** | Customer onboarding, issue triage, knowledge base, SLA tracking | Sedon, Ali |
 
-## Tier 2 — Product (2)
+### Tier 2 — Product (2)
 
 | Agent | Scope | Primary Human |
 |-------|-------|---------------|
 | **product** | Roadmap across 5 products, user stories, ICE scoring, release planning | All |
 | **analyst** | Market intelligence per vertical, competitor analysis, usage analytics | Ali, Samia |
 
-## Tier 3 — Tech Leadership (3)
+### Tier 3 — Tech Leadership (3)
 
 | Agent | Scope | Primary Human |
 |-------|-------|---------------|
@@ -45,9 +84,9 @@ captain (Tier 0 — company brain)
 | **ops** | CI/CD, deployment health, API spend tracking, cost optimization, uptime | Sedon, Abdout |
 | **guardian** | OWASP Top 10, performance budgets, SSPL compliance, medical data privacy | Abdout |
 
-## Specialist Agents (31 agents, 7 chains)
+### Specialist chains (31 agents, 7 chains)
 
-### Stack Chain (7)
+#### Stack (7)
 
 | Agent | Domain |
 |-------|--------|
@@ -59,7 +98,7 @@ captain (Tier 0 — company brain)
 | shadcn | Radix primitives, registry, MCP |
 | authjs | JWT, OAuth, sessions |
 
-### Design Chain (4)
+#### Design (4)
 
 | Agent | Domain |
 |-------|--------|
@@ -68,16 +107,15 @@ captain (Tier 0 — company brain)
 | pattern | Code conventions, anti-patterns |
 | structure | File organization, naming |
 
-### UI Chain (4)
+#### UI (3)
 
 | Agent | Domain |
 |-------|--------|
-| shadcn | Radix primitives, registry |
 | atom | Compose 2+ shadcn/ui primitives |
 | template | Full-page layouts |
 | block | UI + business logic (DataTable, auth, payments) |
 
-### DevOps Chain (3)
+#### DevOps (3)
 
 | Agent | Domain |
 |-------|--------|
@@ -85,14 +123,14 @@ captain (Tier 0 — company brain)
 | deploy | Vercel, staging/production |
 | test | Vitest, Playwright, TDD |
 
-### VCS Chain (2)
+#### VCS (2)
 
 | Agent | Domain |
 |-------|--------|
 | git | Branching, commits, conventional format |
 | github | PRs, issues, Actions, code review |
 
-### Specialized (8)
+#### Specialized (8)
 
 | Agent | Domain |
 |-------|--------|
@@ -105,7 +143,7 @@ captain (Tier 0 — company brain)
 | comment | Code comments |
 | icon | SVG icon management |
 
-### Reference Chain (4)
+#### Product references (4)
 
 | Agent | Product |
 |-------|---------|
@@ -114,7 +152,7 @@ captain (Tier 0 — company brain)
 | mkan | Rental marketplace patterns |
 | shifa | Medical platform patterns |
 
-## How Agents Work
+## How agents work
 
 Agents are markdown files in `~/.claude/agents/` with YAML frontmatter:
 
@@ -125,30 +163,40 @@ description: What this agent does
 model: opus
 ---
 
-# Agent Name
-
 Instructions, context, and domain knowledge...
 ```
 
-When invoked (via the Agent tool or keyword trigger), Claude loads the agent's instructions and delegates accordingly.
+When invoked, Claude loads the agent's instructions and routes accordingly.
 
-## Inter-Agent Routing
+## Examples
 
-```
+### Inter-agent routing
+
+```text
 "saas billing"
   → orchestration agent
   → prisma (schema) + block (UI) + stripe MCP
   → Complete billing feature
+```
 
+```text
 "ship hogwarts admission"
   → captain
   → product (stories) → tech-lead (architecture)
   → orchestration → specialists
 ```
 
-## Installation
-
-```bash
-# All 40 agents installed to ~/.claude/agents/
-cd ~/kun && bash .claude/scripts/install.sh
+```text
+"table users from codebase"
+  → block agent
+  → DataTable pattern + prisma schema + shadcn ui/
+  → Working table with sort, filter, pagination
 ```
+
+## Related
+
+- [Skills](/docs/engine/skills) — Slash commands that invoke agents
+- [Captain](/docs/operations/captain) — Tier 0, never writes code, always delegates
+- [Workflows](/docs/reference/workflows) — Multi-agent chains
+- [Keywords](/docs/engine/keywords) — Vocabulary that routes to agents
+- [MCP](/docs/engine/mcp) — Tool servers agents call

--- a/content/docs/engine/commands.mdx
+++ b/content/docs/engine/commands.mdx
@@ -1,12 +1,32 @@
 ---
 title: Commands
-description: Slash commands for rapid workflows
+description: Slash commands that trigger complete workflows
 ---
 
+> Type `/x` in Claude Code. Commands are the keyboard shortcuts of the engine.
 
-Type `/command` in Claude Code to trigger a complete workflow. Commands are markdown templates in `~/.claude/commands/` that expand into full prompts with agent routing and MCP integration.
+Commands are markdown templates in `~/.claude/commands/` that expand into full prompts with agent routing and MCP integration.
 
-## Core Commands
+## Usage
+
+```bash
+/dev
+/build
+/feature billing hogwarts
+/proposal "King Fahad Schools"
+```
+
+Or trigger via keywords without the leading slash:
+
+```text
+dev
+ship
+report
+```
+
+## Reference
+
+### Core
 
 | Command | Purpose |
 |---------|---------|
@@ -16,7 +36,21 @@ Type `/command` in Claude Code to trigger a complete workflow. Commands are mark
 | `/quick` | Fast commit (skip build validation) |
 | `/deploy` | Deploy to Vercel staging/production |
 
-## Creation Commands
+### Pipeline
+
+| Command | Purpose |
+|---------|---------|
+| `/feature <name> [product]` | Full pipeline — idea to production |
+| `/idea <name>` | Capture feature as GitHub issue |
+| `/spec #N` | Generate technical spec from issue |
+| `/schema #N` | Create Prisma model + migration + Zod |
+| `/code #N` | Create server actions + auth + validation |
+| `/wire #N` | Create pages + forms + tables + i18n |
+| `/check` | Quality gate — type-check + build + visual |
+| `/ship` | Commit + deploy to Vercel production |
+| `/watch` | Post-deploy health check |
+
+### Creation
 
 | Command | Purpose |
 |---------|---------|
@@ -26,7 +60,7 @@ Type `/command` in Claude Code to trigger a complete workflow. Commands are mark
 | `/saas [feature]` | Generate complete SaaS feature |
 | `/clone [source]` | Clone pattern from codebase or GitHub |
 
-## Quality Commands
+### Quality
 
 | Command | Purpose |
 |---------|---------|
@@ -36,7 +70,21 @@ Type `/command` in Claude Code to trigger a complete workflow. Commands are mark
 | `/performance` | Core Web Vitals performance audit |
 | `/handover [block]` | 5-pass production QA |
 
-## Business Commands
+### Coverage Sweeps
+
+| Command | Purpose |
+|---------|---------|
+| `/translate [block]` | Find and fix hardcoded strings |
+| `/nextjs [block]` | Enforce Next.js 16 App Router patterns |
+| `/react [block]` | Fix waterfalls, barrel imports, setState |
+| `/typescript [block]` | Remove `any`, fix types |
+| `/tailwind [block]` | Semantic tokens, logical properties for RTL |
+| `/shadcn [block]` | Replace raw HTML with ui/ primitives |
+| `/prisma [block]` | Audit queries — select, tenant, N+1 |
+| `/authjs [block]` | Audit auth — auth(), sessions, roles |
+| `/coverage [product] [keyword]` | Coverage report |
+
+### Business
 
 | Command | Purpose | Role |
 |---------|---------|------|
@@ -44,7 +92,7 @@ Type `/command` in Claude Code to trigger a complete workflow. Commands are mark
 | `/pricing [product]` | Calculate pricing tiers | business |
 | `/weekly [mode]` | Captain weekly review (plan/check/review) | all |
 
-## Content Commands
+### Content
 
 | Command | Purpose | Role |
 |---------|---------|------|
@@ -52,15 +100,18 @@ Type `/command` in Claude Code to trigger a complete workflow. Commands are mark
 | `/content-calendar` | Plan weekly content schedule | content |
 | `/docs` | Generate MDX documentation | all |
 
-## Ops Commands
+### Ops
 
 | Command | Purpose | Role |
 |---------|---------|------|
 | `/monitor` | Check deployments + costs + uptime | ops |
 | `/costs` | API spend breakdown | ops |
 | `/incident [severity]` | Incident response (P0/P1/P2) | ops |
+| `/doctor` | Audit `~/.claude/` health + updates | all |
+| `/maintain` | Daily heartbeat scheduled task | all |
+| `/bootstrap` | Single-paste cold start | all |
 
-## Communication Commands
+### Communication
 
 | Command | Purpose |
 |---------|---------|
@@ -68,7 +119,15 @@ Type `/command` in Claude Code to trigger a complete workflow. Commands are mark
 | `/issue [repo] [title]` | Create GitHub issue with labels |
 | `/credentials [action]` | Manage Keychain API keys |
 
-## Utility Commands
+### Intelligence
+
+| Command | Purpose |
+|---------|---------|
+| `/learn` | Org intelligence — full org, repos, team, conventions |
+| `/analyze <repo>` | Generate `.claude/` config PR from repo patterns |
+| `/profile [name]` | Show/switch/create configuration profiles |
+
+### Utility
 
 | Command | Purpose |
 |---------|---------|
@@ -77,7 +136,7 @@ Type `/command` in Claude Code to trigger a complete workflow. Commands are mark
 | `/screenshot` | View recent screenshot |
 | `/motion` | Add Framer Motion animations |
 
-## Creating Custom Commands
+## Creating custom commands
 
 Commands are markdown files with a simple structure:
 
@@ -94,3 +153,9 @@ Arguments: $ARGUMENTS
 ```
 
 Place in `~/.claude/commands/` and they become available as `/command-name`.
+
+## Related
+
+- [Skills](/docs/engine/skills) — How skills wrap commands with agent routing
+- [Keywords](/docs/engine/keywords) — Vocabulary triggering each command
+- [Agents](/docs/engine/agents) — Specialists commands route to

--- a/content/docs/engine/skills.mdx
+++ b/content/docs/engine/skills.mdx
@@ -1,84 +1,21 @@
 ---
 title: Skills
-description: 25 reusable skills with keyword triggers
+description: Slash commands that trigger complete workflows
 ---
 
+> One word triggers a workflow. Skills are the verbs of the engine.
 
-25 slash commands that trigger complete workflows. Say a keyword or type `/command` — the engine handles the rest.
+Skills are markdown files in `~/.claude/commands/` that expand into full prompts when invoked. Say a keyword or type `/command` — the engine handles the rest.
 
-## Workflow Skills
+## Installation
 
-| Skill | Trigger | What It Does |
-|-------|---------|-------------|
-| /dev | `dev` | Kill port 3000, start pnpm dev, open Chrome |
-| /build | `build` | pnpm build + TypeScript check + auto-fix |
-| /quick | `push` | Lint, fix, commit, push |
-| /deploy | `deploy`, `ship` | Vercel deploy with retry (max 5) |
+Every skill lands in `~/.claude/commands/` during the standard install.
 
-## Creation Skills
+```bash
+cd ~/kun && bash .claude/scripts/install.sh
+```
 
-| Skill | Trigger | What It Does |
-|-------|---------|-------------|
-| /atom | `atom [name]` | Create/list/preview atom components |
-| /template | `template [name]` | Create/list/preview page layouts |
-| /block | `block [name]` | Create/refactor/audit with 100-point scoring |
-| /saas | `saas [feature]` | Schema + actions + UI + pages |
-
-## Quality Skills
-
-| Skill | Trigger | What It Does |
-|-------|---------|-------------|
-| /test | `test [file]` | Vitest + Playwright tests |
-| /security | `security` | OWASP Top 10 + dependency scan |
-| /performance | `performance` | Core Web Vitals + bundle + DB queries |
-| /fix | `fix` | Auto-fix all TypeScript/lint/build errors |
-
-## Utility Skills
-
-| Skill | Trigger | Purpose |
-|-------|---------|---------|
-| /docs | `docs` | MDX, API docs, Storybook stories |
-| /codebase | `codebase` | Browse/search/copy patterns |
-| /repos | `repos` | Explore databayt repositories |
-| /screenshot | `screenshot` | View recent screenshot |
-| /motion | `motion` | Add Framer Motion animations |
-| /handover | `handover [block]` | 5-pass production QA |
-
-## Business Skills
-
-| Skill | Trigger | What It Does |
-|-------|---------|-------------|
-| /proposal | `proposal [client]` | Generate client proposal via revenue agent |
-| /pricing | `pricing [product]` | Calculate pricing tiers with competitor comparison |
-| /weekly | `weekly [plan/check/review]` | Captain's weekly review cycle |
-
-## Content Skills
-
-| Skill | Trigger | What It Does |
-|-------|---------|-------------|
-| /translate | `translate [file]` | AR/EN translation with context preservation |
-| /content-calendar | `content-calendar` | Weekly content schedule across pillars |
-
-## Ops Skills
-
-| Skill | Trigger | What It Does |
-|-------|---------|-------------|
-| /monitor | `monitor` | Check deployments + costs + uptime across products |
-| /costs | `costs` | API spend breakdown and optimization |
-| /incident | `incident [severity]` | P0/P1/P2 incident response workflow |
-
-## Role Availability
-
-| Role | Available Skills |
-|------|-----------------|
-| **engineer** | All 25 |
-| **business** | Core + business (proposal, pricing, weekly, docs, repos) |
-| **content** | Core + content (translate, content-calendar, docs, repos) |
-| **ops** | Core + ops (monitor, costs, incident, docs, repos) |
-
-## How Skills Work
-
-Skills are markdown files in `~/.claude/commands/` that expand into full prompts when invoked:
+## Usage
 
 ```bash
 # Type in Claude Code
@@ -89,3 +26,110 @@ proposal King Fahad Schools
 ```
 
 The skill loads its template, invokes the relevant agents and MCP servers, and produces the output.
+
+## Reference
+
+### Workflow
+
+| Skill | Trigger | What It Does |
+|-------|---------|-------------|
+| `/dev` | `dev` | Kill port 3000, start pnpm dev, open Chrome |
+| `/build` | `build` | pnpm build + TypeScript check + auto-fix |
+| `/quick` | `push` | Lint, fix, commit, push |
+| `/deploy` | `deploy`, `ship` | Vercel deploy with retry (max 5) |
+
+### Creation
+
+| Skill | Trigger | What It Does |
+|-------|---------|-------------|
+| `/atom` | `atom [name]` | Create/list/preview atom components |
+| `/template` | `template [name]` | Create/list/preview page layouts |
+| `/block` | `block [name]` | Create/refactor/audit with 100-point scoring |
+| `/saas` | `saas [feature]` | Schema + actions + UI + pages |
+
+### Quality
+
+| Skill | Trigger | What It Does |
+|-------|---------|-------------|
+| `/test` | `test [file]` | Vitest + Playwright tests |
+| `/security` | `security` | OWASP Top 10 + dependency scan |
+| `/performance` | `performance` | Core Web Vitals + bundle + DB queries |
+| `/fix` | `fix` | Auto-fix all TypeScript/lint/build errors |
+
+### Utility
+
+| Skill | Trigger | Purpose |
+|-------|---------|---------|
+| `/docs` | `docs` | MDX, API docs, Storybook stories |
+| `/codebase` | `codebase` | Browse/search/copy patterns |
+| `/repos` | `repos` | Explore databayt repositories |
+| `/screenshot` | `screenshot` | View recent screenshot |
+| `/motion` | `motion` | Add Framer Motion animations |
+| `/handover` | `handover [block]` | 5-pass production QA |
+
+### Business
+
+| Skill | Trigger | What It Does |
+|-------|---------|-------------|
+| `/proposal` | `proposal [client]` | Generate client proposal via revenue agent |
+| `/pricing` | `pricing [product]` | Calculate pricing tiers with competitor comparison |
+| `/weekly` | `weekly [plan/check/review]` | Captain's weekly review cycle |
+
+### Content
+
+| Skill | Trigger | What It Does |
+|-------|---------|-------------|
+| `/translate` | `translate [file]` | AR/EN translation with context preservation |
+| `/content-calendar` | `content-calendar` | Weekly content schedule across pillars |
+
+### Ops
+
+| Skill | Trigger | What It Does |
+|-------|---------|-------------|
+| `/monitor` | `monitor` | Check deployments + costs + uptime across products |
+| `/costs` | `costs` | API spend breakdown and optimization |
+| `/incident` | `incident [severity]` | P0/P1/P2 incident response workflow |
+
+## Role availability
+
+Not everyone needs every skill. The role profile filters what gets installed.
+
+| Role | Available Skills |
+|------|-----------------|
+| **engineer** | All 25 |
+| **business** | Core + business (proposal, pricing, weekly, docs, repos) |
+| **content** | Core + content (translate, content-calendar, docs, repos) |
+| **ops** | Core + ops (monitor, costs, incident, docs, repos) |
+
+## Examples
+
+### Ship a feature end-to-end
+
+```bash
+c "/feature billing hogwarts"
+```
+
+Chains: idea → spec → schema → code → wire → check → ship → watch.
+
+### Audit costs across products
+
+```bash
+c "/costs"
+```
+
+Per-product API spend breakdown with optimization suggestions.
+
+### Ship to production
+
+```bash
+c "/deploy"
+```
+
+Vercel deploy with auto-retry, error detection, deployment URL verification.
+
+## Related
+
+- [Agents](/docs/engine/agents) — Specialists that skills invoke
+- [Commands](/docs/engine/commands) — Full command catalog
+- [Keywords](/docs/engine/keywords) — Vocabulary that routes to skills
+- [Captain](/docs/operations/captain) — Coordinates the human side

--- a/content/docs/installation/index.mdx
+++ b/content/docs/installation/index.mdx
@@ -1,14 +1,20 @@
 ---
-title: Onboarding
-description: Install Cowork, let it do the rest
+title: Installation
+description: One install, one paste, one watch. Cowork drives every step.
 ---
 
+> A fresh laptop becomes a working databayt machine in about 60 minutes.
 
-> One install, one paste, one watch. Cowork drives every other step.
+The fastest path is Cowork (computer use). It installs Claude Code, runs the config script, pulls every repo, and turns the laptop green on `claude doctor`. Manual PowerShell fallback is below for Team/Enterprise plans.
 
-The fastest path to running databayt on a fresh Windows laptop: install Claude Desktop (Cowork), turn on computer use, paste the team prompt, watch your machine set itself up.
-
-Plan ~60 minutes. **Pro or Max plan required** — computer use isn't on Team or Enterprise. Manual fallback at the bottom.
+<LinkedCards columns={2}>
+  <LinkedCard href="/docs/installation/claude-code" title="Claude Code setup">
+    Engine config, agents, skills, MCP servers — the team `~/.claude/` install
+  </LinkedCard>
+  <LinkedCard href="/docs/installation/self-hosting" title="Self-hosting">
+    Tailscale + tmux + Docker for air-gapped or remote setups
+  </LinkedCard>
+</LinkedCards>
 
 ## What you end up with
 
@@ -19,21 +25,30 @@ Plan ~60 minutes. **Pro or Max plan required** — computer use isn't on Team or
 - Every active databayt repo cloned to `%USERPROFILE%\projects\databayt\`
 - `claude doctor` green
 
----
+## Quick start
 
-## 1. Install Cowork
+<Tabs defaultValue="cowork">
+  <TabsList>
+    <TabsTrigger value="cowork">Cowork (recommended)</TabsTrigger>
+    <TabsTrigger value="manual">Manual PowerShell</TabsTrigger>
+  </TabsList>
+  <TabsContent value="cowork">
 
-Download and run the [Windows x64 installer](https://claude.ai/api/desktop/win32/x64/setup/latest/redirect) (or [ARM64](https://claude.ai/api/desktop/win32/arm64/setup/latest/redirect)).
+**Pro or Max plan required** — computer use isn't on Team or Enterprise.
 
-Launch it, sign in with your Anthropic account. Confirm the bottom-left shows **Pro** or **Max**.
+<Steps>
 
-## 2. Turn on computer use
+### Install Cowork
+
+Download and run the [Windows x64 installer](https://claude.ai/api/desktop/win32/x64/setup/latest/redirect) (or [ARM64](https://claude.ai/api/desktop/win32/arm64/setup/latest/redirect)). Sign in with your Anthropic account. Confirm the bottom-left shows **Pro** or **Max**.
+
+### Turn on computer use
 
 Settings → General → scroll to **Desktop app** → toggle **Allow Claude to use your computer**.
 
 First time Claude tries to control the screen, Windows prompts for accessibility access. Grant it. Reference: [Anthropic — computer use in Desktop](https://code.claude.com/docs/en/desktop#let-claude-use-your-computer).
 
-## 3. Open the Code tab and paste this
+### Open the Code tab and paste this
 
 Claude Desktop has three tabs — **Chat**, **Cowork**, **Code**. Computer use lives in **Code**. Start a new Code session and paste the prompt below.
 
@@ -86,9 +101,10 @@ still pending or anything I owe (OAuth completions, plan upgrades, etc.).
 
 Press **Esc** anywhere on screen to abort. Claude releases control and unhides your apps.
 
----
+</Steps>
 
-## Manual fallback
+  </TabsContent>
+  <TabsContent value="manual">
 
 For Team or Enterprise plans (no computer use), or when you'd rather type. Run these in PowerShell.
 
@@ -135,7 +151,8 @@ Get-Command c
 
 For hogwarts, your team contact shares the `.env` out-of-band (no `.env.example`).
 
----
+  </TabsContent>
+</Tabs>
 
 ## Daily entry points
 
@@ -152,17 +169,15 @@ For hogwarts, your team contact shares the `.env` out-of-band (no `.env.example`
 
 Full keyword list: [keywords](/docs/engine/keywords).
 
----
+## Related
 
-## Reference
-
-- [Computer use in Desktop](https://code.claude.com/docs/en/desktop#let-claude-use-your-computer)
 - [Claude Code — install detail](/docs/installation/claude-code)
 - [Captain — decisions and delegation](/docs/operations/captain)
 - [Cowork ↔ Code bridge](/docs/operations/cowork)
 - [Connectors — MCP catalog](/docs/operations/connectors)
-- [Anthropic Directory](https://claude.ai/directory)
 - [Keywords — full vocabulary](/docs/engine/keywords)
 - [Team — roles](/docs/operations/team)
 - [Repositories — full org map](/docs/reference/repositories)
+- [Computer use in Desktop](https://code.claude.com/docs/en/desktop#let-claude-use-your-computer)
+- [Anthropic Directory](https://claude.ai/directory)
 - [Contributing — github-workflow rule](https://github.com/databayt/kun/blob/main/.claude/rules/github-workflow.md)

--- a/content/docs/operations/captain.mdx
+++ b/content/docs/operations/captain.mdx
@@ -3,45 +3,25 @@ title: Captain
 description: CEO brain — delegates across 40 agents and 4 humans
 ---
 
+> The apex agent. Decides, allocates, prioritizes, delegates, tracks, adjusts.
 
-The apex agent. Captain is Databayt's CEO brain — it knows every product, every person, every dollar, every deadline. It makes the calls: what to build, who works on what, when to ship, when to cut scope.
+Captain is Databayt's CEO brain — it knows every product, every person, every dollar, every deadline. It makes the calls: what to build, who works on what, when to ship, when to cut scope. Captain never writes code or creates content.
 
-**Captain never**: Writes code, creates content, handles individual support tickets.
-**Captain always**: Decides, allocates, prioritizes, delegates, tracks, adjusts.
+## Workflow
 
-## Decision Matrix
-
-### ACT (Captain's Authority)
-
-- Weekly sprint allocation (who works on what product)
-- Priority ordering between products
-- Scope cut decisions (what's in MVP, what's deferred)
-- Resource rebalancing based on results
-- Revenue target adjustments
-
-### ESCALATE TO Abdout
-
-- Budget increases over $50/month
-- New product launches or product sunsetting
-- Hiring decisions
-- License changes
-- Partnership agreements
-- Any decision with legal implications
-
-### DELEGATE
-
-| Domain | Agent | What They Own |
-|--------|-------|---------------|
-| Pricing and deals | `revenue` | Proposals, contracts, MRR tracking |
-| Content and marketing | `growth` | SEO, social, content calendar |
-| Customer success | `support` | Onboarding, issues, knowledge base |
-| Roadmap and features | `product` | Stories, prioritization, releases |
-| Market intelligence | `analyst` | Competitors, analytics, benchmarks |
-| Technical architecture | `tech-lead` | Cross-repo patterns, upgrades |
-| Infrastructure and costs | `ops` | CI/CD, monitoring, spend |
-| Security and quality | `guardian` | OWASP, performance, compliance |
-
-## Weekly Rhythm
+<FlowChart
+  title="Captain's weekly rhythm"
+  showIcons={false}
+  nodes={[
+    { id: "mon", label: "Monday — Plan" },
+    { id: "wed", label: "Wednesday — Check" },
+    { id: "fri", label: "Friday — Review" }
+  ]}
+  edges={[
+    { from: "mon", to: "wed", note: "mid-week adjust" },
+    { from: "wed", to: "fri", note: "wrap + setup next" }
+  ]}
+/>
 
 ### Monday: Plan
 
@@ -69,11 +49,43 @@ The apex agent. Captain is Databayt's CEO brain — it knows every product, ever
 3. Customer feedback summary
 4. Set up next Monday's plan
 
-## Cross-Agent Coordination
+## Decision matrix
 
-### "Ship hogwarts admission this week"
+### ACT (Captain's authority)
 
-```
+- Weekly sprint allocation (who works on what product)
+- Priority ordering between products
+- Scope cut decisions (what's in MVP, what's deferred)
+- Resource rebalancing based on results
+- Revenue target adjustments
+
+### ESCALATE to Abdout
+
+- Budget increases over $50/month
+- New product launches or product sunsetting
+- Hiring decisions
+- License changes
+- Partnership agreements
+- Any decision with legal implications
+
+### DELEGATE
+
+| Domain | Agent | What they own |
+|--------|-------|---------------|
+| Pricing and deals | `revenue` | Proposals, contracts, MRR tracking |
+| Content and marketing | `growth` | SEO, social, content calendar |
+| Customer success | `support` | Onboarding, issues, knowledge base |
+| Roadmap and features | `product` | Stories, prioritization, releases |
+| Market intelligence | `analyst` | Competitors, analytics, benchmarks |
+| Technical architecture | `tech-lead` | Cross-repo patterns, upgrades |
+| Infrastructure and costs | `ops` | CI/CD, monitoring, spend |
+| Security and quality | `guardian` | OWASP, performance, compliance |
+
+## Examples
+
+### Ship hogwarts admission this week
+
+```text
 captain:
   → product: Define admission scope + acceptance criteria
   → tech-lead: Verify architecture, shared patterns
@@ -84,9 +96,9 @@ captain:
   → revenue: Prepare invoice
 ```
 
-### "Ali found a new potential customer"
+### Ali found a new potential customer
 
-```
+```text
 captain:
   → analyst: Research the prospect
   → revenue: Generate tailored proposal
@@ -95,7 +107,17 @@ captain:
   → growth: Case study opportunity
 ```
 
-## Strategic Priorities
+### Production incident at 2am
+
+```text
+captain:
+  → ops: Triage severity (P0/P1/P2)
+  → guardian: Security impact assessment
+  → support: Customer communication
+  → product: Postmortem after resolved
+```
+
+## Strategic priorities
 
 1. **Hogwarts pilot → first revenue** — Ahmed Baha must have a working product
 2. **Kun engine → team multiplication** — The engine that makes 4 people work like 20
@@ -103,7 +125,7 @@ captain:
 4. **Shifa → future** — Highest revenue potential but needs compliance
 5. **Swift-app → companion** — Only after a web product has traction
 
-## Financial Awareness
+## Financial awareness
 
 | Metric | Current | Target |
 |--------|---------|--------|
@@ -114,8 +136,16 @@ captain:
 
 ## Communication
 
-Captain communicates through 3 channels:
+Captain communicates through three channels:
 
 1. **Dispatch** (Apple Notes) — async updates, decisions, handoffs
 2. **GitHub Issues** — structured work items with labels and milestones
 3. **Claude Native** — real-time via Code, Cowork, or Voice
+
+## Related
+
+- [Agents](/docs/engine/agents) — Tier 0 is captain; tier 1-3 are who captain delegates to
+- [Team](/docs/operations/team) — The four humans captain coordinates
+- [Dispatch](/docs/operations/dispatch) — Async communication channel
+- [Cowork](/docs/operations/cowork) — Captain ↔ Claude Code bridge
+- [Workflows](/docs/reference/workflows) — Multi-agent chains captain orchestrates

--- a/src/components/docs/linked-card.tsx
+++ b/src/components/docs/linked-card.tsx
@@ -1,0 +1,57 @@
+import Link from "next/link"
+import { ChevronRight } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+
+interface LinkedCardsProps {
+  children: React.ReactNode
+  className?: string
+  columns?: 2 | 3
+}
+
+export function LinkedCards({ children, className, columns = 3 }: LinkedCardsProps) {
+  return (
+    <div
+      className={cn(
+        "not-prose my-6 grid grid-cols-1 gap-4 sm:grid-cols-2",
+        columns === 3 && "lg:grid-cols-3",
+        className,
+      )}
+    >
+      {children}
+    </div>
+  )
+}
+
+interface LinkedCardProps {
+  href: string
+  title: string
+  children?: React.ReactNode
+  className?: string
+}
+
+export function LinkedCard({ href, title, children, className }: LinkedCardProps) {
+  const isExternal = href.startsWith("http")
+  return (
+    <Link
+      href={href}
+      target={isExternal ? "_blank" : undefined}
+      rel={isExternal ? "noopener noreferrer" : undefined}
+      className={cn(
+        "group flex flex-col gap-1 rounded-xl border bg-card p-6 text-card-foreground no-underline transition-colors hover:bg-accent hover:text-accent-foreground",
+        className,
+      )}
+    >
+      <div className="flex items-center gap-2 text-sm font-medium tracking-tight">
+        <span>{title}</span>
+        <ChevronRight
+          className="ms-auto h-4 w-4 text-muted-foreground transition-transform group-hover:translate-x-0.5 rtl:rotate-180 rtl:group-hover:-translate-x-0.5"
+          strokeWidth={1.5}
+        />
+      </div>
+      {children && (
+        <div className="text-sm text-muted-foreground [&_p]:my-0">{children}</div>
+      )}
+    </Link>
+  )
+}

--- a/src/mdx-components.tsx
+++ b/src/mdx-components.tsx
@@ -20,6 +20,7 @@ import { BuildingBlocks, KunBuildingBlocks, BlockDiagram } from "@/components/do
 import { StackedBlocks, KunStackedBlocks } from "@/components/docs/arrangements/stacked-blocks"
 import { StepperFlow, Phase1SetupFlow, Phase2SetupFlow } from "@/components/docs/arrangements/stepper-flow"
 import { Spellbook, SpellSchool, SpellbookLegend, SpellWorkflows, SpellMastery, SpellStats } from "@/components/docs/spellbook"
+import { LinkedCard, LinkedCards } from "@/components/docs/linked-card"
 
 // This file is required to use MDX in `app` directory.
 
@@ -310,6 +311,9 @@ const mdxComponents = {
     SpellWorkflows,
     SpellMastery,
     SpellStats,
+    // Path-picker grid (shadcn-style)
+    LinkedCard,
+    LinkedCards,
 }
 
 export function useMDXComponents(components: Record<string, React.ComponentType<unknown>>): Record<string, React.ComponentType<unknown>> {


### PR DESCRIPTION
## Summary

Phase 2 of the shadcn-style docs refresh, **re-opened from a clean branch** after #40 was contaminated by the parallel auto-sync work. Stacked on top of #39.

Adopts the canonical shadcn page template (hero → preview → installation → usage → reference → examples → related) on the five highest-impact pages, and adds the `<LinkedCards>` primitive that path-picker grids depend on.

**This PR targets `docs/shadcn-ia-restructure` (Phase 1) and should be merged after #39 lands.** Rebase onto main after that.

## Changes

- **`src/components/docs/linked-card.tsx` (new):** `<LinkedCards>` grid container + `<LinkedCard>` item. Hover state, RTL-flipped chevron, semantic tokens only (`bg-card`, `bg-accent`).
- **`src/mdx-components.tsx`:** registers `LinkedCard` and `LinkedCards` for MDX.
- **`content/docs/installation/index.mdx`:** title bumped from "Onboarding" to "Installation". `<LinkedCards>` path picker, `<Tabs>` for Cowork vs Manual, `<Steps>` for the 3-step Cowork flow.
- **`content/docs/engine/agents/index.mdx`:** `<BuildingBlocks>` tier preview replaces the ASCII art; installation moved up; reference tables reorganized; routing examples expanded.
- **`content/docs/engine/skills.mdx`:** installation + usage at the top; categorized reference tables; examples section added.
- **`content/docs/engine/commands.mdx`:** adds pipeline, coverage sweeps, intelligence sections that were missing.
- **`content/docs/operations/captain.mdx`:** `<FlowChart>` of the Mon/Wed/Fri rhythm; decision matrix + scenario examples + financial dashboard preserved.

## Why a fresh branch

The original Phase 2 branch picked up an auto-sync commit (`52315a7`) from a parallel `feat/auto-sync-service` branch that was being worked on simultaneously. The leak ended up inside #40's diff and could not be force-pushed away (harness denied). This branch is the same Phase 2 work cherry-picked cleanly onto Phase 1 — diff matches what #40 was supposed to be.

## Test plan

- [x] `pnpm docs:check` clean
- [x] `next build` succeeds — 37 docs paths generated
- [x] All 5 rewritten pages render without MDX errors
- [ ] After merge: visual check of each page in dev — preview blocks render, LinkedCards are clickable, RTL works

## Stack

- #39 — Phase 1 (IA restructure)
- **#44** ← this PR (Phase 2, clean rebuild)
- #42 — Phase 3 (resources + 6 more pages)
- #43 — Phase 4 (anchors + badges)

The Phase 3 and Phase 4 PRs already branch from this clean chain, so they don't need re-targeting — `#42` is `docs/shadcn-new-sections` which contains commit `3a99d36` (Phase 2 cherry-pick), then Phase 3 commits, identical to what this branch ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)