### PR TITLE
docs: document the system end-to-end (bootstrap/doctor/maintain/auto-sync)

### DIFF
--- a/content/docs/operations/auto-sync.mdx
+++ b/content/docs/operations/auto-sync.mdx
@@ -1,0 +1,181 @@
+---
+title: Auto-sync
+description: Real-time bidirectional git sync for every databayt repo at ~/<name>
+---
+
+> Every commit you make pushes within ~2 seconds. Every commit a teammate pushes pulls within ~60 seconds. Per-repo isolation — one failure never stops the others.
+
+A background service that watches all 11 databayt repos at `~/<name>` and keeps them synced with GitHub. After install, it's set-and-forget.
+
+See [reference/repositories — local layout](/docs/reference/repositories#local-layout) for where the repos live.
+
+---
+
+## Install
+
+```powershell
+# Windows
+& "$env:USERPROFILE\.claude\scripts\auto-sync-install.ps1" -Install
+```
+
+```bash
+# macOS / Linux
+~/.claude/scripts/auto-sync-install.sh --install
+```
+
+No admin/sudo required — user-scoped. Starts on every logon and restarts on failure.
+
+To start immediately without logging out:
+
+```powershell
+& "$env:USERPROFILE\.claude\scripts\auto-sync-install.ps1" -Run
+```
+
+```bash
+~/.claude/scripts/auto-sync-install.sh --run
+```
+
+---
+
+## How it works
+
+For each repo at `~/<name>` with a `.git/` directory:
+
+1. **Push side (real-time)** — a `FileSystemWatcher` (Windows) / `fswatch` (macOS) / `inotifywait` (Linux) watches `.git/refs/heads`. When you make a local commit, the watcher fires; after a 2-second debounce, auto-sync runs `git push`.
+2. **Pull side (every 60s)** — a polling loop runs `git fetch` + `git pull --rebase` per repo. If the working tree is dirty, the pull is skipped (your in-flight work isn't touched).
+3. **Conflict on pull** — `git rebase --abort` is called, the failure is logged, and the next poll tries again. Your working tree stays as you left it.
+4. **Push failure** — logged as a warning (auth issue, force-push conflict, no network). The next commit on that repo retries.
+
+Per-repo isolation: a single repo failing (no upstream, auth broken, force-push needed) doesn't stop the others.
+
+---
+
+## Configuration
+
+| Flag | PowerShell | bash | Default | What it does |
+|------|-----------|------|---------|--------------|
+| Poll interval | `-PollInterval 60` | `--poll-interval 60` | 60s | How often to fetch+pull each repo |
+| Debounce | `-Debounce 2` | `--debounce 2` | 2s | How long after a local commit before pushing |
+| Dry run | `-DryRun` | `--dry-run` | off | Log what would happen, don't push/pull |
+| Once | `-Once` | `--once` | off | Exit after one poll cycle (for testing) |
+| Verbose | `-Verbose` | `--verbose` | off | Echo every log line to console |
+
+Test before installing:
+
+```powershell
+& "$env:USERPROFILE\.claude\scripts\auto-sync.ps1" -DryRun -Once -Verbose
+```
+
+```bash
+~/.claude/scripts/auto-sync.sh --dry-run --once --verbose
+```
+
+---
+
+## Status, logs, uninstall
+
+```powershell
+# Status
+auto-sync-install.ps1 -Status
+
+# Tail today's log
+Get-Content "$env:USERPROFILE\.claude\logs\auto-sync-$(Get-Date -Format yyyy-MM-dd).log" -Wait
+
+# Stop and remove
+auto-sync-install.ps1 -Uninstall
+```
+
+```bash
+# Status
+~/.claude/scripts/auto-sync-install.sh --status
+
+# Tail today's log
+tail -f ~/.claude/logs/auto-sync-$(date +%Y-%m-%d).log
+
+# Stop and remove
+~/.claude/scripts/auto-sync-install.sh --uninstall
+```
+
+---
+
+## Log format
+
+Each line: `[HH:MM:SS] [LEVEL] [repo-name           ] message`
+
+| Level | Meaning |
+|-------|---------|
+| `INFO` | Startup, repo discovery |
+| `PUSH` | Successful push (with commit count) |
+| `PULL` | Successful pull (with commit count) |
+| `WARN` | Skipped (dirty tree, no upstream, push failed) |
+| `ERROR` | Pull failed → rebase aborted; or unexpected exception |
+
+Sample:
+
+```
+[09:14:02] [INFO ] [_main_              ] auto-sync starting | poll=60s | debounce=2s | dry-run=False
+[09:14:02] [INFO ] [_main_              ] watching 11 repos
+[09:14:33] [PUSH ] [kun                 ] 1 commit(s) pushed
+[09:15:02] [PULL ] [hogwarts            ] 3 commit(s) rebased
+[09:15:02] [WARN ] [souq                ] 2 behind but working tree dirty -- skipping pull
+```
+
+---
+
+## Service backend per OS
+
+| OS | Backend | Trigger | Restart on failure |
+|---|---|---|---|
+| Windows | Task Scheduler | At logon (current user) | 3 retries, 1-min interval |
+| macOS | launchd LaunchAgent | RunAtLoad + KeepAlive | Automatic (KeepAlive=true) |
+| Linux | systemd user service | WantedBy=default.target | Restart=always, RestartSec=10 |
+
+All user-scoped. No admin/sudo.
+
+---
+
+## What auto-sync does NOT do
+
+- **Doesn't commit for you** — only pushes commits you've already made
+- **Doesn't resolve merge conflicts** — aborts the rebase and logs
+- **Doesn't force-push** — if upstream history was rewritten, you'll see a `WARN` and need to handle manually
+- **Doesn't sync uncommitted work** — your working tree is sacred
+- **Doesn't touch branches other than the current one** — feature branches you haven't pushed yet stay local
+
+Treat auto-sync as a co-pilot for the common case (linear commits to main / feature branches with upstream). Anything weirder, handle yourself.
+
+---
+
+## Relationship to `maintain`
+
+| | [`maintain`](/docs/operations/maintain) | `auto-sync` |
+|---|---|---|
+| Frequency | Once daily at 09:00 | Real-time + every 60s |
+| What it does | Doctor + sync-repos burst + notify on red | Push on local commit, pull on poll |
+| Resource use | One-shot, ~30s | Always running, ~5-30MB RAM |
+| Purpose | Health check + drift catcher | Active sync |
+
+Run both. `maintain` catches what auto-sync misses; auto-sync keeps you fresh between maintain runs.
+
+---
+
+## Troubleshooting
+
+| Symptom | Fix |
+|---------|-----|
+| Logs say `no cloned repos found` | Run `sync-repos.ps1` (or `.sh`) first to clone repos to `~/<name>` |
+| Logs say `no upstream` for a repo | `cd ~/<repo>; git push -u origin <branch>` once to set upstream |
+| Push fails with auth error | Re-run `gh auth login` — auto-sync uses the same credentials |
+| Linux: `auto-sync-install.sh --install` says `systemctl not found` | Your distro doesn't have systemd; run `auto-sync.sh` from cron manually |
+| macOS: launchd loaded but no logs | Check `~/.claude/logs/auto-sync-launchd.err` for startup errors |
+| Windows: scheduled task exits with code 1 immediately | Check log; common cause is a non-ASCII char in the script (PS 5 can't read UTF-8 without a BOM) |
+| Want to pause sync without uninstalling | Windows: `Disable-ScheduledTask -TaskName kun-auto-sync`. Linux: `systemctl --user stop kun-auto-sync`. macOS: `launchctl unload ~/Library/LaunchAgents/com.databayt.kun-auto-sync.plist`. |
+
+---
+
+## Reference
+
+- [System overview](/docs/reference/system) — where auto-sync fits
+- [Repositories — local layout](/docs/reference/repositories#local-layout) — where the repos live
+- [`auto-sync.ps1` source](https://github.com/databayt/kun/blob/main/.claude/scripts/auto-sync.ps1)
+- [`auto-sync.sh` source](https://github.com/databayt/kun/blob/main/.claude/scripts/auto-sync.sh)

--- a/content/docs/operations/bootstrap.mdx
+++ b/content/docs/operations/bootstrap.mdx
@@ -1,0 +1,125 @@
+---
+title: Bootstrap
+description: 16-step single-paste cold-start from a fresh laptop to a green doctor
+---
+
+> One line in your terminal. 16 numbered steps. Three OAuth sign-ins. ~20 minutes. Green `doctor`.
+
+The orchestrator script that runs every other script. Called once on a fresh laptop; re-run via `/finish` to repair an existing install.
+
+See also: [installation overview](/docs/installation), [system map](/docs/reference/system).
+
+---
+
+## Run it
+
+```powershell
+# Windows
+irm https://kun.databayt.org/install | iex
+```
+
+```bash
+# macOS / Linux
+curl -fsSL https://kun.databayt.org/install.sh | bash
+```
+
+Approve UAC/sudo, watch the 16 numbered steps stream by.
+
+---
+
+## The 16 steps
+
+Each line prints `[N/16]` with one of `⏳ ✅ ⏭ ⚠️ ❌`. Output is teed to `~/.claude/logs/bootstrap-<ts>.log`.
+
+| # | Step | Notes |
+|---|------|-------|
+| 0  | ExecutionPolicy / shell check | Sets `RemoteSigned` (Windows) |
+| 1  | Elevate via UAC / sudo | Re-launches as admin if needed |
+| 2  | Verify OS + shell version | Windows 11 + PS 5.1+ or bash 3.2+ |
+| 3  | Create `~/.claude/logs/` | Audit log directory |
+| 4  | `winget` / `brew` bundle | git, Node LTS, gh, PS 7, Claude Code CLI, Claude Desktop |
+| 5  | Refresh `PATH` from registry | New binaries usable in current session |
+| 6  | `npm install -g pnpm` | |
+| 7  | WebStorm | Skip with `-SkipWebStorm` |
+| 8  | Claude Code [Beta] plugin | Pre-dropped into WebStorm `plugins/` |
+| 9  | `install.ps1` → `~/.claude/` | Copies CLAUDE.md, agents, skills, rules, memory, scripts, role-specific `mcp.json` |
+| 10 | `settings.json` | Engineer gets the full one; other roles get a minimal env block |
+| 11 | `$PROFILE` c/cc functions | Idempotent — runs `Repair-Profile` from `lib/Fix-Shell.ps1` |
+| 12 | **OAuth batch** | 3 sign-ins: GitHub, Claude, JetBrains |
+| 13 | `secrets.ps1 -GistId ...` | Pulls `.env` from the team Gist |
+| 14 | `sync-repos.ps1` | Clones all 11 repos to `~/<name>` |
+| 15 | `maintain -Install` | Arms the daily 09:00 heartbeat |
+| 16 | `doctor` | Exit 0 = green, 3 = updates available, 1/2 = needs fix |
+
+---
+
+## Flags
+
+| Flag | Windows | macOS/Linux | What it does |
+|------|---------|-------------|--------------|
+| Role | `-Role business` | `--role business` | Slim config — `engineer\|business\|content\|ops` |
+| Dry run | `-DryRun` | `--dry-run` | Print every step without executing |
+| Track | `-Track` | `--track` | Create a GitHub issue ticking each step as it completes |
+| Skip OAuth | `-SkipOAuth` | `--skip-oauth` | Leave sign-ins to the user |
+| Skip WebStorm | `-SkipWebStorm` | `--skip-ide` | No IDE install |
+| Skip Cowork | `-SkipCowork` | `--skip-desktop` | No Claude Desktop install |
+
+Pass flags via the one-liner by downloading first:
+
+```powershell
+irm https://kun.databayt.org/install -OutFile $env:TEMP\bootstrap.ps1
+& $env:TEMP\bootstrap.ps1 -Role business -DryRun
+```
+
+```bash
+curl -fsSL https://kun.databayt.org/install.sh -o /tmp/bootstrap.sh
+bash /tmp/bootstrap.sh --role business --dry-run
+```
+
+---
+
+## OAuth batch (step 12)
+
+You hear a single beep, then three sign-ins, press-Enter between each:
+
+1. **GitHub** — `gh auth login --web --git-protocol https`. Browser opens, paste device code.
+2. **Claude** — open a new PowerShell and run `claude`. Browser opens for sign-in. Press Enter when you see "Logged in".
+3. **JetBrains** — WebStorm opens. Sign in (or start trial). Press Enter when the project window appears.
+
+Each is skipped if already authenticated. Total ~5 minutes.
+
+---
+
+## Roles
+
+| Role | Includes | For |
+|------|----------|-----|
+| `engineer` | All agents · all MCPs · all skills | Building features |
+| `business` | `docs`, `repos`, `proposal`, `pricing`, `weekly` | Sales, revenue, partnerships |
+| `content` | `docs`, `repos`, `translate`, `content-calendar`, `weekly` | Writers, marketers |
+| `ops` | `docs`, `repos`, `monitor`, `costs`, `incident`, `weekly` | DevOps, infrastructure |
+
+Default is `engineer`.
+
+---
+
+## What you end up with
+
+See [installation/](/docs/installation) and [system overview](/docs/reference/system#what-you-end-up-with).
+
+- Claude Code CLI on PATH
+- `c` function in `$PROFILE`
+- Full `~/.claude/` config
+- All 11 repos at `~/<name>`
+- WebStorm + Claude Code [Beta] plugin
+- `maintain` armed for daily 09:00
+- `doctor` green
+- Audit log at `~/.claude/logs/bootstrap-<ts>.log`
+
+---
+
+## Reference
+
+- [`bootstrap.ps1` source](https://github.com/databayt/kun/blob/main/.claude/scripts/bootstrap.ps1)
+- [`bootstrap.sh` source](https://github.com/databayt/kun/blob/main/.claude/scripts/bootstrap.sh)
+- [System map](/docs/reference/system) — how bootstrap fits with maintain, doctor, auto-sync

--- a/content/docs/operations/doctor.mdx
+++ b/content/docs/operations/doctor.mdx
@@ -1,0 +1,181 @@
+---
+title: Doctor
+description: System health audit — 7 categories, semantic exit codes, auto-fix slugs
+---
+
+> One command for health, updates, and self-repair. Green by default; specific and actionable when not.
+
+`doctor` runs 7 modular checks across the `~/.claude/` config, your shell, your identity, your repos, and your scheduled tasks. It reports per-item with one of five statuses and exits with a semantic code (0/1/2/3) that downstream tools (`maintain`, `bootstrap`, CI) rely on.
+
+---
+
+## Run it
+
+```powershell
+# Windows
+& "$env:USERPROFILE\.claude\scripts\doctor.ps1"
+```
+
+```bash
+# macOS / Linux
+~/.claude/scripts/doctor.sh
+```
+
+Or via skill: `c "/doctor"`.
+
+---
+
+## Flags
+
+| Flag | What it does |
+|------|--------------|
+| `-Fix` / `--fix` | Apply any registered auto-fixes (PROFILE missing c/cc, bin not on PATH, etc.) |
+| `-Update` / `--update` | Apply available updates (claude CLI bump, `git pull` on `~/kun` + `~/codebase`) |
+| `-Report` / `--report` | Post a comment to the `config-health` GitHub issue in `databayt/kun` |
+| `-Json` / `--json` | Emit results as JSON (machine-readable; same exit codes) |
+| `-Quiet` / `--quiet` | Suppress `pass` rows; only show warn/fail/update |
+| `-Deep` / `--deep` | Heavier checks (currently a placeholder for future expansion) |
+
+---
+
+## Status icons
+
+| Icon | Status | Meaning |
+|---|---|---|
+| ✅ | `pass` | Working as expected |
+| ⚠️ | `warn` | Off but not broken (stale, uncommitted, optional missing) |
+| ❌ | `fail` | Broken — fix required |
+| 🔄 | `update` | Newer version available |
+| ⏸ | `paused` | Optional thing not installed (not a problem) |
+
+---
+
+## Exit codes
+
+| Exit | Meaning | Used by |
+|---|---|---|
+| 0 | All green | `bootstrap` accepts; `maintain` silent |
+| 1 | At least one **fail** | `bootstrap` warns; `maintain` notifies |
+| 2 | At least one **warn** (no fails) | `bootstrap` accepts; `maintain` may notify |
+| 3 | At least one **update** available | `bootstrap` accepts; suggest `/doctor update` |
+
+Precedence: `fail > warn > update > pass`.
+
+---
+
+## The 7 check categories
+
+Each category is a separate `Check-*.ps1` module in `~/.claude/scripts/lib/`. Adding a new check = drop a `Test-X` function in a new module and add it to `doctor.ps1`'s `$results +=` chain.
+
+### CORE FILES (`Check-Core.ps1`)
+- ✅ `CLAUDE.md` present, < 30 days old
+- ✅ `settings.json` present, valid JSON, < 30 days old
+- ✅ `mcp.json` present, valid JSON, < 30 days old
+- ✅ `.env` present, < 7 days old (`Fix: rerun-secrets` if stale)
+- ✅ `agents/` ≥ N files (engineer 20 · business 10 · content 10 · ops 10)
+- ✅ `commands/` ≥ N files (engineer 15 · business 5 · content 5 · ops 7)
+
+### SHELL (`Check-Shell.ps1`)
+- ✅ `$PROFILE` file exists (`Fix: create-profile`)
+- ✅ `c` function defined as `claude --dangerously-skip-permissions` (`Fix: append-c-function`)
+- ✅ `~/.claude/bin` on PATH — live + persisted in `$PROFILE` (`Fix: prepend-bin-path`)
+
+### IDENTITY (`Check-Identity.ps1`)
+- ✅ `gh` CLI installed and `gh auth status` shows logged-in account
+- ✅ `claude` CLI installed; checks for `.credentials.json` or `session.json`
+
+### ORG REPOS (`Check-Repos.ps1`)
+For each repo in `~/.claude/memory/repositories.json` (or fallback list):
+- ✅ Cloned at expected `~/<name>` path
+- ✅ Git readable (branch + short commit)
+- ✅ Working tree clean (else ⚠️ "N uncommitted")
+- ❌ if not cloned (`Fix: clone-<name>`)
+
+### UPDATES (`Check-Updates.ps1`)
+- 🔄 **claude CLI** — semver compare against `api.github.com/repos/anthropics/claude-code/releases/latest`
+- 🔄 **`~/kun`** — `git fetch` then compare `@` vs `@{u}`; reports commits behind
+- 🔄 **`~/codebase`** — same as `~/kun`
+
+### SCHEDULED (`Check-Scheduled.ps1`)
+- ✅ `kun-maintain` task armed (Windows Task Scheduler) — shows next run + last exit
+- ⏸ if not armed (`maintain -Install`)
+
+### IDE (`Check-IDE.ps1`)
+- ✅ WebStorm detected (any `WebStorm*` config dir under `$env:APPDATA\JetBrains\`)
+- ✅ Claude Code [Beta] plugin loaded in `plugins/`
+- ⏸ if WebStorm not installed (optional)
+
+---
+
+## Auto-fixes (`-Fix`)
+
+`doctor -Fix` reads the `Fix:` slug on any failing check and dispatches:
+
+| Slug | Action |
+|---|---|
+| `create-profile` | Creates `$PROFILE.CurrentUserAllHosts` and appends the c/cc block |
+| `append-c-function` | Appends the c/cc block to existing `$PROFILE` |
+| `prepend-bin-path` | Same — runs `Repair-Profile` in `lib/Fix-Shell.ps1` |
+| `rerun-secrets` | Prints `secrets.ps1 -GistId <id>` hint (doesn't run — secrets need explicit trigger) |
+| `clone-<name>` | Prints `sync-repos.ps1 <name>` hint (doesn't run — clones touch the network) |
+
+Auto-fixes are conservative by design: they touch `$PROFILE` only, and never run network operations without the user explicitly invoking the underlying script.
+
+---
+
+## Sample green report
+
+```
+✅ healthy · engineer @ MACHINE · 2026-05-18 14:32
+
+CORE FILES
+  ✅ CLAUDE.md             exists · 3d old
+  ✅ settings.json         valid JSON · 3d old
+  ✅ mcp.json              valid JSON · 3d old
+  ✅ .env                  2d old
+  ✅ agents/               28 files
+  ✅ commands/             17 files
+
+SHELL
+  ✅ $PROFILE              defined in $PROFILE
+  ✅ c function            defined in $PROFILE
+  ✅ ~/.claude/bin         on PATH
+
+IDENTITY
+  ✅ gh                    logged in as @abdout
+  ✅ claude                signed in · 2.1.143
+
+ORG REPOS
+  ✅ codebase              clean · main · 475db80
+  ✅ kun                   clean · main · 3cc56d6
+  ✅ shadcn                clean · main · 1137b24a
+  ... (× 11 repos)
+
+UPDATES
+  ✅ claude CLI            up to date · 2.1.143
+  ✅ ~/kun                 up to date
+  ✅ ~/codebase            up to date
+
+SCHEDULED
+  ✅ kun-maintain          next 2026-05-19 09:00 · last run 05-18 09:00 (exit 0)
+
+IDE
+  ✅ WebStorm              2026.1 detected
+  ✅ Claude Code [Beta]    Claude-Code-0.x.y
+```
+
+---
+
+## Known false positives
+
+- **`~/.claude/bin not on PATH`** — `Check-Shell.ps1:29` looks for the literal expanded path `C:\Users\<you>\.claude\bin`, but `$PROFILE` uses the unexpanded `$env:USERPROFILE\.claude\bin`. If you see this warn but `c` works in a fresh terminal, the PATH is loading correctly; the regex just doesn't catch the variable form. Tracked in [system — known gaps](/docs/reference/system#known-gaps).
+
+---
+
+## Reference
+
+- [`doctor.ps1` source](https://github.com/databayt/kun/blob/main/.claude/scripts/doctor.ps1)
+- [`doctor.sh` source](https://github.com/databayt/kun/blob/main/.claude/scripts/doctor.sh)
+- [`Check-*.ps1` modules](https://github.com/databayt/kun/tree/main/.claude/scripts/lib)
+- [System map](/docs/reference/system) — how doctor fits with bootstrap, maintain, auto-sync
+- [Maintain](/docs/operations/maintain) — runs doctor daily at 09:00

--- a/content/docs/operations/maintain.mdx
+++ b/content/docs/operations/maintain.mdx
@@ -1,0 +1,132 @@
+---
+title: Maintain
+description: Daily heartbeat — runs doctor + sync-repos at 09:00, notifies on red
+---
+
+> The morning check. Runs every weekday at 09:00. Calls `doctor`, syncs repos, posts a notification if anything is red.
+
+`maintain` is the daily safety net. While [`auto-sync`](/docs/operations/auto-sync) keeps repos fresh in real-time, `maintain` runs a comprehensive health check once a day and surfaces anything that needs attention.
+
+---
+
+## Install
+
+```powershell
+# Windows — Task Scheduler at 09:00
+& "$env:USERPROFILE\.claude\scripts\maintain.ps1" -Install
+```
+
+```bash
+# macOS — launchd at 09:00
+# Linux — systemd user timer at 09:00
+~/.claude/scripts/maintain.sh --install
+```
+
+Bootstrap step 15 calls this automatically. Run manually only if you re-armed the task or moved machines.
+
+---
+
+## Flags
+
+| Flag | What it does |
+|------|--------------|
+| `-Install` / `--install` | Register the scheduled task / launchd plist / systemd timer |
+| `-Uninstall` / `--uninstall` | Remove it |
+| `-Status` / `--status` | Show task state and next run time |
+| `-Run` / `--run` | Run maintain now (one-shot, doesn't register anything) |
+| `-DryRun` / `--dry-run` | Log what would happen without doing it |
+| `-Silent` / `--silent` | Suppress console output (still logs to file) |
+| `-Schedule HH:MM` / `--schedule=HH:MM` | Change the schedule from default 09:00 |
+
+---
+
+## What it does
+
+For every scheduled run:
+
+```
+   1. doctor (audit)
+            |
+            v
+   2. sync-repos (catch any drift auto-sync missed)
+            |
+            v
+   3. if doctor exit != 0:
+        - log to ~/.claude/logs/maintain-<date>.log
+        - desktop notification (toast on Windows, NSUserNotification on macOS)
+        - optionally: doctor -Report to comment on the config-health GitHub issue
+```
+
+Each run takes ~30 seconds end-to-end on a healthy machine. Idle the rest of the day.
+
+---
+
+## Backend per OS
+
+| OS | Mechanism | Path | Trigger |
+|---|---|---|---|
+| Windows | Task Scheduler | `\kun-maintain` | Daily at 09:00 (local time) |
+| macOS | launchd | `~/Library/LaunchAgents/com.databayt.kun-maintain.plist` | `StartCalendarInterval` 09:00 |
+| Linux | systemd --user | `~/.config/systemd/user/kun-maintain.{service,timer}` | `OnCalendar=*-*-* 09:00:00` |
+
+systemd timer uses `Persistent=true` so missed runs (laptop asleep) fire on wake — same effective behavior as launchd.
+
+---
+
+## Log format
+
+Each run appends to `~/.claude/logs/maintain-<date>.log`:
+
+```
+[2026-05-18T09:00:01Z] [INFO] maintain start
+[2026-05-18T09:00:01Z] [INFO] running doctor
+[2026-05-18T09:00:09Z] [INFO] doctor exit: 0 (green)
+[2026-05-18T09:00:09Z] [INFO] running sync-repos
+[2026-05-18T09:00:33Z] [INFO] sync-repos complete
+[2026-05-18T09:00:33Z] [INFO] maintain done · 32s
+```
+
+When doctor returns non-zero:
+
+```
+[2026-05-18T09:00:09Z] [WARN] doctor exit: 2 (warnings)
+[2026-05-18T09:00:09Z] [WARN]   IDE | Claude Code [Beta] | not loaded
+[2026-05-18T09:00:09Z] [WARN]   SHELL | ~/.claude/bin | not on PATH
+[2026-05-18T09:00:10Z] [INFO] notifying via toast
+```
+
+---
+
+## Relationship to `auto-sync`
+
+| | `maintain` | [`auto-sync`](/docs/operations/auto-sync) |
+|---|---|---|
+| Frequency | Once daily at 09:00 | Real-time + every 60s |
+| Scope | Doctor + full sync-repos sweep | Push on local commit, pull on poll |
+| Resource use | One-shot, ~30s | Always running, ~5-30MB RAM |
+| Failure mode | Logs + toast | Per-repo isolation, retries |
+| Purpose | Health audit + drift catcher | Active sync |
+
+`maintain` runs `sync-repos` which clones any missing repos and pulls everything. `auto-sync` only watches already-cloned repos. So if you cloned a new repo today, `auto-sync` won't see it until tomorrow's `maintain` run brings it into scope (or until you re-start `auto-sync`).
+
+---
+
+## Troubleshooting
+
+| Symptom | Fix |
+|---------|-----|
+| `-Install` fails with "Access denied" on Windows | Try opening PowerShell as Administrator; the user-scoped task should still work without elevation for most configs |
+| Linux: `systemctl --user is-active kun-maintain` says inactive | Run `loginctl enable-linger $USER` to keep user services running across sessions |
+| macOS: launchd loaded but never fires at 09:00 | macOS suppresses launchd jobs when the laptop is asleep at the trigger time; next wake should catch it |
+| Notifications not appearing | Windows: Task Scheduler runs hidden, toast may be suppressed — check the log directly. macOS: grant Terminal/iTerm notification permission. |
+| Want to disable for a day | Windows: `Disable-ScheduledTask -TaskName kun-maintain`. Linux: `systemctl --user stop kun-maintain.timer`. macOS: `launchctl unload ~/Library/LaunchAgents/com.databayt.kun-maintain.plist`. Re-enable with the opposite. |
+
+---
+
+## Reference
+
+- [`maintain.ps1` source](https://github.com/databayt/kun/blob/main/.claude/scripts/maintain.ps1)
+- [`maintain.sh` source](https://github.com/databayt/kun/blob/main/.claude/scripts/maintain.sh)
+- [System map](/docs/reference/system) — how maintain fits with bootstrap, doctor, auto-sync
+- [Doctor](/docs/operations/doctor) — what maintain runs daily
+- [Auto-sync](/docs/operations/auto-sync) — the real-time complement

--- a/content/docs/operations/meta.json
+++ b/content/docs/operations/meta.json
@@ -10,6 +10,11 @@
     "credentials",
     "connectors",
     "apps",
-    "issue"
+    "issue",
+    "---System---",
+    "bootstrap",
+    "doctor",
+    "maintain",
+    "auto-sync"
   ]
 }

--- a/content/docs/reference/meta.json
+++ b/content/docs/reference/meta.json
@@ -1,6 +1,7 @@
 {
   "title": "Reference",
   "pages": [
+    "system",
     "configuration",
     "architecture",
     "workflows",

--- a/content/docs/reference/repositories.mdx
+++ b/content/docs/reference/repositories.mdx
@@ -5,6 +5,69 @@ description: "Reference guide for databayt repositories"
 
 Complete reference of all repositories in the databayt GitHub organization.
 
+## Local layout
+
+**Every databayt org repo lives at your user-home root — `~/<repo>` — on every machine, every OS.**
+
+```
+~/codebase                    # pattern library
+~/kun                         # this repo (config + docs)
+~/shadcn                      # UI fork
+~/radix                       # primitives fork
+~/hogwarts                    # education SaaS
+~/souq                        # e-commerce
+~/mkan                        # rentals
+~/shifa                       # healthcare
+~/swift-app                   # iOS
+~/distributed-computer        # Rust infra
+~/marketing                   # landing pages
+```
+
+| OS | What `~` expands to |
+|---|---|
+| Windows | `C:\Users\<you>\<repo>` |
+| macOS | `/Users/<you>/<repo>` |
+| Linux | `/home/<you>/<repo>` |
+
+No `oss/` subdirectory, no `projects/` parent, no per-product folders. Tab-completion at `~/h` lands you in `hogwarts` on every teammate's machine.
+
+**`bootstrap` does this for you** — step 14 (`sync-repos.{ps1,sh}`) clones all 11 repos to `~/<name>`.
+
+## Sync
+
+To re-sync at any time:
+
+```powershell
+# Windows
+& "$env:USERPROFILE\.claude\scripts\sync-repos.ps1"
+```
+
+```bash
+# macOS / Linux
+~/.claude/scripts/sync-repos.sh
+```
+
+Continuous sync happens automatically via [auto-sync](/docs/operations/auto-sync). The [daily maintain](/docs/operations/maintain) at 09:00 also runs sync-repos as a drift catcher.
+
+## Migrating from the old `~/oss/*` layout
+
+```powershell
+# Windows
+Get-ChildItem $env:USERPROFILE\oss -Directory | ForEach-Object {
+    Move-Item $_.FullName $env:USERPROFILE\
+}
+Remove-Item $env:USERPROFILE\oss
+```
+
+```bash
+# macOS / Linux
+mv ~/oss/* ~/ && rmdir ~/oss
+```
+
+Then re-run `doctor` to verify.
+
+---
+
 ## Core Libraries
 
 ### codebase

--- a/content/docs/reference/system.mdx
+++ b/content/docs/reference/system.mdx
@@ -1,0 +1,223 @@
+---
+title: System
+description: End-to-end map of how bootstrap, install, doctor, maintain, sync-repos, and auto-sync fit together
+---
+
+> One paste sets up a new laptop. After that, six small scripts keep it healthy and in sync with GitHub forever.
+
+This page documents the **operational engine** that runs on every teammate's machine — what each script does, how they call each other, and the lifecycle from cold-start to daily steady-state.
+
+---
+
+## The six scripts
+
+| Script | Role | When it runs |
+|---|---|---|
+| [`bootstrap`](/docs/operations/bootstrap) | Orchestrator — runs 16 steps from a cold laptop to working machine | **Once** on fresh install, or via `/finish` to repair |
+| [`install`](/docs/installation/claude-code) | Copies `~/.claude/` config from kun repo — role-aware bundles | Called by bootstrap step 9 |
+| [`secrets`](/docs/reference/secrets) | Pulls `.env` from a private team Gist | Called by bootstrap step 13 |
+| [`sync-repos`](/docs/reference/repositories#sync) | Clones all 11 org repos to `~/<name>` (SSH-first, HTTPS fallback) | Called by bootstrap step 14 |
+| [`maintain`](/docs/operations/maintain) | Daily heartbeat — runs doctor + sync once at 09:00 | Scheduled via Task Scheduler / launchd / systemd user |
+| [`auto-sync`](/docs/operations/auto-sync) | Real-time per-repo git sync — pushes on commit, pulls every 60s | Logon-triggered background service |
+| [`doctor`](/docs/operations/doctor) | Health audit — 7 check categories, semantic exit codes | Called by bootstrap step 16 + maintain; manual anytime |
+
+---
+
+## The cold-start flow
+
+```
+                    paste one line in terminal
+              irm https://kun.databayt.org/install | iex
+                              |
+                              v
+              +-------------------------------+
+              | bootstrap.ps1 / bootstrap.sh  |
+              |                               |
+              | 16 numbered steps, ~20 min:   |
+              |  [0]  ExecutionPolicy         |
+              |  [1]  Elevate (UAC/sudo)      |
+              |  [2]  Verify OS + shell       |
+              |  [3]  Create ~/.claude/logs/  |
+              |  [4]  winget/brew bundle      |
+              |  [5]  Refresh PATH            |
+              |  [6]  pnpm via npm            |
+              |  [7]  WebStorm                |
+              |  [8]  Claude Code [Beta]      |
+              |       plugin pre-drop         |
+              |  [9]  install.ps1             |--> ~/.claude/{agents,commands,
+              |                               |     rules,memory,scripts,...}
+              | [10]  settings.json           |
+              | [11]  $PROFILE c/cc + bin     |
+              | [12]  OAuth batch             |--> GitHub, Claude, JetBrains
+              | [13]  secrets.ps1             |--> ~/.claude/.env
+              | [14]  sync-repos.ps1          |--> ~/codebase, ~/kun, ~/hogwarts,
+              |                               |     ~/souq, ~/mkan, ~/shifa,
+              |                               |     ~/shadcn, ~/radix, ~/swift-app,
+              |                               |     ~/distributed-computer, ~/marketing
+              | [15]  maintain -Install       |--> daily 09:00 task armed
+              | [16]  doctor                  |--> green / 0 1 2 3 exit code
+              +-------------------------------+
+                              |
+                              v
+                  KUN BOOTSTRAP COMPLETE
+                  Audit log: ~/.claude/logs/bootstrap-<ts>.log
+```
+
+After the cold-start, you have a fully-configured machine and the runtime services (`maintain`, `auto-sync`) take over.
+
+---
+
+## The steady-state loop
+
+```
+                Every day, every machine, every teammate:
+
+  09:00 ------> maintain  --> doctor (audit) --> sync-repos (catch drift)
+                   |              |
+                   |              v
+                   |        if exit != 0: notify (toast/log/issue comment)
+                   |
+                   +--> takes ~30s, then sleeps until tomorrow
+
+  Continuous --> auto-sync (background service)
+                   |
+                   v
+       FileSystemWatcher on each ~/<repo>/.git/refs/heads
+                   |
+                   v
+       Local commit detected --> debounce 2s --> git push
+                   |
+                   +--> every 60s --> git fetch + git pull --rebase per repo
+                                       (skip if working tree dirty)
+                                       (abort + log on conflict)
+```
+
+`maintain` is the safety net. `auto-sync` is the heartbeat. Together they keep every teammate's repos current with origin without manual `git push`/`git pull`.
+
+---
+
+## The `~/.claude/` artifact
+
+`install.ps1` produces this layout on every machine. Same structure on Windows, macOS, Linux.
+
+```
+~/.claude/
++-- CLAUDE.md                  global instructions (~600 lines, keyword grammar)
++-- CLAUDE.local.md             your personal overrides (not synced)
++-- .env                        pulled from Gist by secrets.ps1
++-- settings.json               env vars + hooks + permission allowlist
++-- mcp.json                    MCP server config (role-specific bundle)
++-- agents/                     28+ specialized agents
++-- commands/                   slash commands (/feature, /doctor, ...)
++-- rules/                      path-scoped rules
++-- memory/
+|   +-- repositories.json       canonical org repo map (read by sync, doctor)
+|   +-- atom.json, template.json, block.json, report.json
++-- scripts/
+|   +-- bootstrap.ps1 / .sh
+|   +-- install.ps1 / .sh
+|   +-- secrets.ps1 / .sh
+|   +-- sync-repos.ps1 / .sh
+|   +-- maintain.ps1 / .sh
+|   +-- doctor.ps1 / .sh
+|   +-- auto-sync.ps1 / .sh                  <-- continuous service
+|   +-- auto-sync-install.ps1 / .sh          <-- registers as background task
+|   +-- lib/
+|       +-- Check-Core.ps1, Check-Shell.ps1, Check-Identity.ps1,
+|           Check-Repos.ps1, Check-Updates.ps1, Check-Scheduled.ps1,
+|           Check-IDE.ps1                    <-- doctor's modular checks
+|       +-- Fix-Shell.ps1                    <-- doctor -Fix dispatcher
+|       +-- Bootstrap-Common.ps1, Confirm-Admin.ps1, Install-Winget.ps1,
+|           Update-Path.ps1, Stage-OAuth.ps1, Drop-Plugin.ps1, Track-Issue.ps1
++-- logs/
+    +-- bootstrap-<ts>.log
+    +-- maintain-<date>.log
+    +-- auto-sync-<date>.log
+```
+
+See [`installation/claude-code`](/docs/installation/claude-code) for the deeper breakdown.
+
+---
+
+## The repo layout
+
+Every databayt org repo lives at **`~/<name>`** on every machine, every OS. See [repositories — local layout](/docs/reference/repositories#local-layout).
+
+| OS | What `~` expands to |
+|---|---|
+| Windows | `C:\Users\<you>\<repo>` |
+| macOS | `/Users/<you>/<repo>` |
+| Linux | `/home/<you>/<repo>` |
+
+No `oss/` subdirectory, no `projects/` parent, no per-product folders. Tab-completion at `~/h` lands you in `hogwarts` on every teammate's machine.
+
+---
+
+## The friendly URLs
+
+`next.config.ts` redirects short URLs to raw GitHub script content. This is what makes a single-line install possible.
+
+| URL | Redirects to | Used by |
+|---|---|---|
+| `kun.databayt.org/install` | `bootstrap.ps1` raw on GitHub | Windows one-paste cold-start |
+| `kun.databayt.org/install.sh` | `bootstrap.sh` raw on GitHub | macOS/Linux one-paste cold-start |
+| `kun.databayt.org/finish[.sh]` | `bootstrap.{ps1,sh}` | Re-run / repair |
+| `kun.databayt.org/doctor[.sh]` | `doctor.{ps1,sh}` | Standalone health check |
+
+Source: `next.config.ts:11-23`.
+
+---
+
+## Daily commands
+
+After cold-start, these slash commands wrap the underlying scripts:
+
+| Say | Calls | Purpose |
+|---|---|---|
+| `c "/doctor"` | `doctor.ps1` | See system health (exit 0/1/2/3) |
+| `c "/doctor fix"` | `doctor -Fix` | Auto-repair fixable warnings |
+| `c "/doctor update"` | `doctor -Update` | Apply available updates |
+| `c "/maintain install"` | `maintain -Install` | Arm/re-arm the daily 09:00 task |
+| `c "/bootstrap"` | re-run bootstrap | Fresh install or full repair |
+| `c "/finish"` | re-run bootstrap | Same as `/bootstrap` |
+
+---
+
+## Exit code semantics (doctor)
+
+Every script that wraps `doctor` (maintain, bootstrap step 16, CI) relies on these codes:
+
+| Exit | Meaning | What to do |
+|---|---|---|
+| 0 | All green | Nothing |
+| 1 | At least one **fail** | `doctor -Fix` or read the report |
+| 2 | At least one **warn** (no fails) | Usually safe; review and address |
+| 3 | At least one **update** available | `doctor -Update` to apply |
+
+Precedence: fail > warn > update > pass.
+
+---
+
+## What's documented where
+
+| Topic | Doc |
+|---|---|
+| Cold-start flow + prerequisites | [installation/](/docs/installation) |
+| 16-step bootstrap detail | [operations/bootstrap](/docs/operations/bootstrap) |
+| Daily heartbeat (`maintain`) | [operations/maintain](/docs/operations/maintain) |
+| Health audit (`doctor`) | [operations/doctor](/docs/operations/doctor) |
+| Real-time sync (`auto-sync`) | [operations/auto-sync](/docs/operations/auto-sync) |
+| Repo locations + sync | [reference/repositories](/docs/reference/repositories) |
+| `.env` and gist setup | [reference/secrets](/docs/reference/secrets) |
+| Engine layers + team roles | [reference/architecture](/docs/reference/architecture) |
+
+---
+
+## Known gaps
+
+The engine has real but small rough edges worth tracking:
+
+1. **`Repair-Profile` is PowerShell-version-blind** — writes only to `$PROFILE.CurrentUserAllHosts` of the host that called it. If bootstrap ran from PS 7, Windows PowerShell 5 never gets the `c` function. Fix: iterate both `~/Documents/PowerShell/profile.ps1` and `~/Documents/WindowsPowerShell/profile.ps1`.
+2. **`Check-Shell.ps1` `~/.claude/bin` false positive** — looks for the literal expanded path `C:\Users\<you>\.claude\bin` in `$PROFILE`, but the profile uses `$env:USERPROFILE\.claude\bin` (unexpanded). Reports "not on PATH" even when it loads correctly.
+3. **`maintain -Install` needs admin on some Windows configs** — `schtasks /Create` may require elevation. Should self-elevate or fall back to a user-scoped task that doesn't trigger UAC.
+4. **`auto-sync` on Windows requires ASCII-only scripts** — `powershell.exe` (PS 5) reads .ps1 as Windows-1252 without a BOM. UTF-8 multibyte chars cause parse errors. All shipped auto-sync scripts are ASCII-clean; future contributors should grep for `[^\x00-\x7F]` before merging.

--- a/src/components/docs/docs-sidebar.tsx
+++ b/src/components/docs/docs-sidebar.tsx
@@ -4,6 +4,7 @@ import Link from "next/link"
 import { usePathname } from "next/navigation"
 
 import type { docsSource } from "@/lib/source"
+import { PAGES_NEW, PAGES_UPDATED } from "@/lib/docs"
 import {
   Sidebar,
   SidebarContent,
@@ -97,6 +98,8 @@ export function DocsSidebar({
   function renderLink(item: DocEntry) {
     const fullHref = `${prefix}${item.href}`
     const isActive = pathname === fullHref || pathname === item.href
+    const isNew = PAGES_NEW.includes(item.href)
+    const isUpdated = !isNew && PAGES_UPDATED.includes(item.href)
 
     return (
       <SidebarMenuItem key={item.href}>
@@ -105,7 +108,19 @@ export function DocsSidebar({
           isActive={isActive}
           className="relative h-[30px] w-full border border-transparent text-[0.8rem] font-medium p-0"
         >
-          <Link href={fullHref} className="block w-full">{item.label}</Link>
+          <Link href={fullHref} className="flex w-full items-center gap-2">
+            <span>{item.label}</span>
+            {isNew && (
+              <span className="ms-auto rounded-sm bg-primary/10 px-1.5 py-0.5 text-[0.65rem] font-medium text-primary">
+                New
+              </span>
+            )}
+            {isUpdated && (
+              <span className="ms-auto rounded-sm bg-muted px-1.5 py-0.5 text-[0.65rem] font-medium text-muted-foreground">
+                Updated
+              </span>
+            )}
+          </Link>
         </SidebarMenuButton>
       </SidebarMenuItem>
     )

--- a/src/lib/docs.ts
+++ b/src/lib/docs.ts
@@ -1,0 +1,23 @@
+// Sidebar badges. Both arrays hold lang-agnostic /docs/* paths.
+// Add an entry when you ship a new page or substantially rewrite an existing one,
+// then remove it after ~2 weeks once the badge has served its purpose.
+
+export const PAGES_NEW: readonly string[] = [
+  "/docs/resources/faq",
+  "/docs/resources/changelog",
+  "/docs/resources/theming",
+  "/docs/resources/cli",
+]
+
+export const PAGES_UPDATED: readonly string[] = [
+  "/docs/installation",
+  "/docs/engine/agents",
+  "/docs/engine/skills",
+  "/docs/engine/commands",
+  "/docs/engine/mcp",
+  "/docs/engine/claude-md",
+  "/docs/operations/captain",
+  "/docs/operations/cowork",
+  "/docs/operations/team",
+  "/docs/operations/dispatch",
+]

--- a/src/mdx-components.tsx
+++ b/src/mdx-components.tsx
@@ -24,6 +24,29 @@ import { LinkedCard, LinkedCards } from "@/components/docs/linked-card"
 
 // This file is required to use MDX in `app` directory.
 
+// Slug from heading text — keeps anchors stable across renders.
+function slugify(value: React.ReactNode): string | undefined {
+  if (value === undefined || value === null) return undefined
+  return value
+    .toString()
+    .replace(/ /g, "-")
+    .replace(/'/g, "")
+    .replace(/\?/g, "")
+    .toLowerCase()
+}
+
+function HeadingAnchor({ id }: { id: string }) {
+  return (
+    <a
+      href={`#${id}`}
+      aria-label={`Link to ${id.replace(/-/g, " ")}`}
+      className="text-muted-foreground ms-2 font-normal no-underline opacity-0 transition-opacity group-hover:opacity-100 focus-visible:opacity-100"
+    >
+      #
+    </a>
+  )
+}
+
 const mdxComponents = {
     // Allows customizing built-in components, e.g. to add styling.
     h1: ({ className, ...props }: React.HTMLAttributes<HTMLHeadingElement>) => (
@@ -35,42 +58,54 @@ const mdxComponents = {
         {...props}
       />
     ),
-    h2: ({ className, ...props }: React.HTMLAttributes<HTMLHeadingElement>) => {
-      const id = props.children
-        ?.toString()
-        .replace(/ /g, "-")
-        .replace(/'/g, "")
-        .replace(/\?/g, "")
-        .toLowerCase()
+    h2: ({ className, children, ...props }: React.HTMLAttributes<HTMLHeadingElement>) => {
+      const id = slugify(children)
       return (
         <h2
           id={id}
           className={cn(
-            "font-heading [&+]*:[code]:text-xl mt-10 scroll-m-28 text-xl font-medium tracking-tight first:mt-0 lg:mt-16 [&+.steps]:!mt-0 [&+.steps>h3]:!mt-4 [&+h3]:!mt-6 [&+p]:!mt-4",
+            "font-heading group [&+]*:[code]:text-xl mt-10 scroll-m-28 text-xl font-medium tracking-tight first:mt-0 lg:mt-16 [&+.steps]:!mt-0 [&+.steps>h3]:!mt-4 [&+h3]:!mt-6 [&+p]:!mt-4",
             className
           )}
           {...props}
-        />
+        >
+          {children}
+          {id && <HeadingAnchor id={id} />}
+        </h2>
       )
     },
-    h3: ({ className, ...props }: React.HTMLAttributes<HTMLHeadingElement>) => (
-      <h3
-        className={cn(
-          "font-heading mt-12 scroll-m-28 text-lg font-medium tracking-tight [&+p]:!mt-4 *:[code]:text-xl",
-          className
-        )}
-        {...props}
-      />
-    ),
-    h4: ({ className, ...props }: React.HTMLAttributes<HTMLHeadingElement>) => (
-      <h4
-        className={cn(
-          "font-heading mt-8 scroll-m-28 text-base font-medium tracking-tight",
-          className
-        )}
-        {...props}
-      />
-    ),
+    h3: ({ className, children, ...props }: React.HTMLAttributes<HTMLHeadingElement>) => {
+      const id = slugify(children)
+      return (
+        <h3
+          id={id}
+          className={cn(
+            "font-heading group mt-12 scroll-m-28 text-lg font-medium tracking-tight [&+p]:!mt-4 *:[code]:text-xl",
+            className
+          )}
+          {...props}
+        >
+          {children}
+          {id && <HeadingAnchor id={id} />}
+        </h3>
+      )
+    },
+    h4: ({ className, children, ...props }: React.HTMLAttributes<HTMLHeadingElement>) => {
+      const id = slugify(children)
+      return (
+        <h4
+          id={id}
+          className={cn(
+            "font-heading group mt-8 scroll-m-28 text-base font-medium tracking-tight",
+            className
+          )}
+          {...props}
+        >
+          {children}
+          {id && <HeadingAnchor id={id} />}
+        </h4>
+      )
+    },
     h5: ({ className, ...props }: React.HTMLAttributes<HTMLHeadingElement>) => (
       <h5
         className={cn(


### PR DESCRIPTION
## Summary

Fills the gaps in the new hierarchical IA with five operational-engine docs that document everything we built over the bootstrap chain + repos-at-home + auto-sync work. One master overview ties them together.

## Pages added

| Path | What it covers |
|------|----------------|
| `reference/system.mdx` | **Master overview** — the 6 scripts, the cold-start flow, the steady-state loop, the `~/.claude/` artifact map, repo layout, friendly URLs, exit code semantics, and known gaps |
| `operations/bootstrap.mdx` | 16-step single-paste cold start — run command, full step table, flags, OAuth batch UX, roles |
| `operations/doctor.mdx` | 7 check categories (Core/Shell/Identity/Repos/Updates/Scheduled/IDE), status icons, exit codes, auto-fix slugs, sample report |
| `operations/maintain.mdx` | Daily heartbeat — install per OS, what each run does, log format, relationship to auto-sync |
| `operations/auto-sync.mdx` | Real-time bidirectional git sync — install, flags, log format, service backend per OS, troubleshooting |

## Pages updated

| Path | Change |
|------|--------|
| `reference/repositories.mdx` | Adds prominent "Local layout" section near the top — the canonical answer to "where does X live?" now lands above the fold |
| `operations/meta.json` | Adds `---System---` divider + the 4 new pages to the sidebar |
| `reference/meta.json` | Adds `system` as the first reference doc |

## Why this PR exists

Three earlier PRs (#37 onboarding rewrite, #38 repos at home root, #41 auto-sync) shipped their docs at the top-level `content/docs/` directory, which predated the shadcn-style hierarchical IA restructure in PR #39. This PR ports/extends that content into the new IA spots and adds the missing operational pages (`bootstrap`, `doctor`, `maintain`) that didn't exist anywhere before.

## Cross-linking

Every new page links to:
- `reference/system` (the master overview)
- The relevant `.claude/scripts/*` source file on GitHub
- Sibling operations pages when they relate (`doctor` ↔ `maintain` ↔ `auto-sync`)

## Dependencies

Stacks on `docs/shadcn-new-sections` (the active docs branch) to inherit the new IA. **No** dependency on the bootstrap chain (#29-#36) — these are docs describing future-merged scripts. They'll be accurate once the script PRs land.

## Test plan

- [ ] `pnpm dev` — navigate the new sidebar entries, confirm pages render without MDX errors
- [ ] Cross-links resolve (Operations → System → Operations)
- [ ] `/docs/reference/repositories` shows "Local layout" as the first section after the intro
- [ ] `/docs/reference/system` renders the ASCII diagrams correctly
- [ ] Spot-check a sample command — copy-paste-runnable on Windows + macOS/Linux

## Known gaps (called out in `system.mdx`)

The doc lists 4 real-but-small rough edges as future tracking items:
1. `Repair-Profile` is PowerShell-version-blind (only writes to current host's `$PROFILE`)
2. `Check-Shell.ps1` `~/.claude/bin` false positive (regex doesn't match unexpanded `$env:USERPROFILE`)
3. `maintain -Install` may need admin on some Windows configs
4. Auto-sync scripts must be ASCII-only (PS 5 + UTF-8 BOM-less = parse errors) — already enforced, just a contributor reminder

Refs #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)