### PR TITLE
feat(installer): quiet wizard — cross-platform guided installer + kun.databayt.org

### DIFF
--- a/.claude/scripts/installer-linux.sh
+++ b/.claude/scripts/installer-linux.sh
@@ -1,0 +1,281 @@
+#!/bin/bash
+# =============================================================================
+# Quiet Wizard — Linux Installer
+# =============================================================================
+# Three-act guided installer for Linux. Detects zenity → kdialog → TUI fallback.
+# Wraps onboarding-linux.sh with native dialogs and deep-link action buttons.
+#
+# Bootstrap:
+#   curl -fsSL https://kun.databayt.com/install | bash
+# Direct:
+#   bash <(curl -fsSL https://raw.githubusercontent.com/databayt/kun/main/.claude/scripts/installer-linux.sh)
+#
+# State file: ${XDG_CONFIG_HOME:-~/.config}/databayt/installer-state.json
+#
+# NOTE: Claude Desktop is NOT available on Linux. Wrapper skips desktop
+# sign-in and computer-use toggle steps. Linux users use CLI + browser +
+# IDE plugins.
+# =============================================================================
+
+set -e
+
+# ── Detect GUI backend ──────────────────────────────────────────
+GUI=""
+if [[ -n "$DISPLAY" || -n "$WAYLAND_DISPLAY" ]]; then
+    if command -v zenity >/dev/null 2>&1; then GUI="zenity"
+    elif command -v kdialog >/dev/null 2>&1; then GUI="kdialog"
+    fi
+fi
+[[ "${1:-}" == "--no-gui" ]] && { GUI=""; shift; }
+
+# ── State file ──────────────────────────────────────────────────
+STATE_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/databayt"
+STATE_FILE="$STATE_DIR/installer-state.json"
+mkdir -p "$STATE_DIR"
+
+state_get() {
+    [[ -f "$STATE_FILE" ]] || { echo ""; return; }
+    python3 -c "import json,sys; d=json.load(open('$STATE_FILE')); print(d.get('$1',''))" 2>/dev/null
+}
+state_set() {
+    python3 -c "
+import json, os
+p = '$STATE_FILE'
+d = json.load(open(p)) if os.path.exists(p) else {}
+d['$1'] = '$2'
+json.dump(d, open(p, 'w'), indent=2)
+"
+}
+
+# ── Dialog abstraction (zenity / kdialog / TUI) ─────────────────
+ask_text() {
+    local prompt="$1" default="${2:-}"
+    case "$GUI" in
+        zenity)  zenity --entry --title="Databayt Setup" --text="$prompt" --entry-text="$default" 2>/dev/null || echo "" ;;
+        kdialog) kdialog --title "Databayt Setup" --inputbox "$prompt" "$default" 2>/dev/null || echo "" ;;
+        *)       printf "\033[1m%s\033[0m " "$prompt"
+                 [[ -n "$default" ]] && printf "[%s] " "$default"
+                 read -r ans </dev/tty
+                 echo "${ans:-$default}" ;;
+    esac
+}
+ask_yesno() {
+    local prompt="$1"
+    case "$GUI" in
+        zenity)  zenity --question --title="Databayt Setup" --text="$prompt" 2>/dev/null && echo "Yes" || echo "No" ;;
+        kdialog) kdialog --title "Databayt Setup" --yesno "$prompt" 2>/dev/null && echo "Yes" || echo "No" ;;
+        *)       printf "\033[1m%s\033[0m [y/N] " "$prompt"; read -r ans </dev/tty
+                 [[ "$ans" =~ ^[Yy] ]] && echo "Yes" || echo "No" ;;
+    esac
+}
+ask_choice() {
+    # ask_choice <prompt> <opt1> <opt2> [opt3] — TUI uses numbered menu
+    local prompt="$1" opt1="$2" opt2="$3" opt3="${4:-}"
+    case "$GUI" in
+        zenity)
+            local rows=("$opt1" "$opt2")
+            [[ -n "$opt3" ]] && rows+=("$opt3")
+            zenity --list --title="Databayt Setup" --text="$prompt" --column=Option "${rows[@]}" --hide-header 2>/dev/null || echo ""
+            ;;
+        kdialog)
+            local args=("$opt1" "$opt1" "$opt2" "$opt2")
+            [[ -n "$opt3" ]] && args+=("$opt3" "$opt3")
+            kdialog --title "Databayt Setup" --menu "$prompt" "${args[@]}" 2>/dev/null || echo ""
+            ;;
+        *)
+            printf "\n\033[1m%s\033[0m\n" "$prompt"
+            printf "  1) %s\n" "$opt1"
+            printf "  2) %s\n" "$opt2"
+            [[ -n "$opt3" ]] && printf "  3) %s\n" "$opt3"
+            printf "  > "; read -r n </dev/tty
+            case "$n" in 1) echo "$opt1";; 2) echo "$opt2";; 3) echo "$opt3";; *) echo "";; esac
+            ;;
+    esac
+}
+ask_role() {
+    case "$GUI" in
+        zenity)  zenity --list --title="Databayt Setup" --text="Pick your role:" --column=Role engineer business content ops 2>/dev/null || echo "" ;;
+        kdialog) kdialog --title "Databayt Setup" --menu "Pick your role:" engineer engineer business business content content ops ops 2>/dev/null || echo "" ;;
+        *)       ask_choice "Pick your role:" engineer business content ops ;;
+    esac
+}
+notify() {
+    case "$GUI" in
+        zenity)  zenity --notification --text="$1: $2" 2>/dev/null || true ;;
+        kdialog) kdialog --passivepopup "$1: $2" 4 2>/dev/null || true ;;
+        *)       printf "\033[1;36m[%s]\033[0m %s\n" "$1" "$2" ;;
+    esac
+}
+open_url() {
+    if command -v xdg-open >/dev/null 2>&1; then xdg-open "$1" >/dev/null 2>&1 &
+    elif command -v gio >/dev/null 2>&1; then gio open "$1" >/dev/null 2>&1 &
+    else printf "Open: %s\n" "$1"
+    fi
+}
+
+# ── Bootstrap: clone kun if not present ─────────────────────────
+if [[ ! -d "$HOME/kun" ]]; then
+    notify "Cloning" "kun repo"
+    git clone https://github.com/databayt/kun.git "$HOME/kun" >/dev/null 2>&1 || {
+        echo "Could not clone databayt/kun. Check network and try again." >&2
+        exit 1
+    }
+fi
+
+BACKEND="$HOME/kun/.claude/scripts/onboarding-linux.sh"
+if [[ ! -f "$BACKEND" ]]; then
+    echo "Backend script missing: $BACKEND" >&2
+    exit 1
+fi
+
+# =============================================================================
+# ACT 1 — Pre-flight
+# =============================================================================
+WELCOME=$(ask_choice "Welcome — this sets up a fresh Linux box for databayt.\n\nAbout 15-20 minutes (mostly silent downloads).\n\nReady?" "Start" "Cancel")
+[[ "$WELCOME" != "Start" ]] && { notify "Cancelled" "Run again anytime"; exit 0; }
+
+ROLE=$(state_get role)
+GIST_ID=$(state_get gistId)
+GIT_NAME_ARG=$(state_get gitName)
+GIT_EMAIL_ARG=$(state_get gitEmail)
+WITH_TAILSCALE=$(state_get withTailscale)
+
+# Role: auto-detect from existing mcp.json
+if [[ -z "$ROLE" ]]; then
+    if [[ -f "$HOME/.claude/mcp.json" ]]; then
+        if grep -q '"shadcn"' "$HOME/.claude/mcp.json" 2>/dev/null; then ROLE="engineer"
+        elif grep -q '"linear"' "$HOME/.claude/mcp.json" 2>/dev/null; then ROLE="business"
+        elif grep -q '"figma"' "$HOME/.claude/mcp.json" 2>/dev/null; then ROLE="content"
+        elif grep -q '"posthog"' "$HOME/.claude/mcp.json" 2>/dev/null; then ROLE="ops"
+        fi
+    fi
+    if [[ -z "$ROLE" ]]; then
+        ROLE=$(ask_role)
+        [[ -z "$ROLE" ]] && { notify "Cancelled" "No role"; exit 0; }
+    fi
+    state_set role "$ROLE"
+fi
+
+# Git identity
+if [[ -z "$GIT_NAME_ARG" ]]; then
+    EXISTING_NAME=$(git config --global user.name 2>/dev/null || echo "")
+    if [[ -n "$EXISTING_NAME" ]]; then
+        GIT_NAME_ARG="$EXISTING_NAME"
+        GIT_EMAIL_ARG=$(git config --global user.email 2>/dev/null || echo "")
+    else
+        GIT_NAME_ARG=$(ask_text "Your full name (for git commits):")
+        [[ -z "$GIT_NAME_ARG" ]] && { notify "Cancelled" "No name"; exit 0; }
+        GIT_EMAIL_ARG=$(ask_text "Your email (for git commits):")
+        [[ -z "$GIT_EMAIL_ARG" ]] && { notify "Cancelled" "No email"; exit 0; }
+    fi
+    state_set gitName "$GIT_NAME_ARG"
+    state_set gitEmail "$GIT_EMAIL_ARG"
+fi
+
+# Gist ID
+if [[ -z "$GIST_ID" ]]; then
+    GIST_ID=$(ask_text "Secrets Gist ID (or blank to skip):")
+    state_set gistId "$GIST_ID"
+fi
+
+# Tailscale
+if [[ -z "$WITH_TAILSCALE" ]]; then
+    TS_ANS=$(ask_yesno "Enable Tailscale SSH? (Remote control from iPhone/laptop.)")
+    [[ "$TS_ANS" == "Yes" ]] && WITH_TAILSCALE="1" || WITH_TAILSCALE="0"
+    state_set withTailscale "$WITH_TAILSCALE"
+fi
+
+# =============================================================================
+# ACT 2 — Silent batch
+# =============================================================================
+notify "Installing" "~15-20 min in terminal"
+
+BACKEND_ARGS=("$ROLE")
+[[ -n "$GIST_ID" ]] && BACKEND_ARGS+=("$GIST_ID")
+BACKEND_ARGS+=("--quiet" "--name" "$GIT_NAME_ARG" "--email" "$GIT_EMAIL_ARG")
+[[ "$WITH_TAILSCALE" == "1" ]] && BACKEND_ARGS+=("--with-tailscale")
+
+echo ""
+echo "════════════════════════════════════════════════════"
+echo " Databayt Setup — Silent Install in Progress"
+echo "════════════════════════════════════════════════════"
+echo " Role: $ROLE"
+echo " You can minimize this terminal and do other work."
+echo "════════════════════════════════════════════════════"
+echo ""
+
+set +e
+bash "$BACKEND" "${BACKEND_ARGS[@]}" 2> >(while IFS= read -r line; do
+    echo "$line" >&2
+    if [[ "$line" == PROGRESS:* ]]; then
+        IFS=':' read -r _ phase label <<< "$line"
+        notify "Phase $phase" "$label"
+    fi
+done)
+BACKEND_RC=$?
+set -e
+
+if [[ "$BACKEND_RC" -ne 0 ]]; then
+    RETRY=$(ask_choice "Install hit an issue (exit $BACKEND_RC). What now?" "Retry" "Skip" "Quit")
+    case "$RETRY" in
+        Retry) exec bash "$0" ;;
+        Quit)  exit "$BACKEND_RC" ;;
+    esac
+fi
+state_set silentBatch "done"
+
+# =============================================================================
+# ACT 3 — Manual finishing (no Claude Desktop on Linux)
+# =============================================================================
+notify "Almost done" "Final clicks"
+
+# 3a. VS Code Claude extension — auto-install
+if command -v code >/dev/null 2>&1 && [[ "$(state_get vsCodeExt)" != "1" ]]; then
+    if code --list-extensions 2>/dev/null | grep -q "anthropic.claude-code"; then
+        state_set vsCodeExt "1"
+    else
+        code --install-extension anthropic.claude-code >/dev/null 2>&1 && state_set vsCodeExt "1" || true
+    fi
+fi
+
+# 3b. WebStorm Claude plugin (engineer)
+if [[ "$ROLE" == "engineer" ]] && command -v webstorm >/dev/null 2>&1 || [[ -d "/snap/webstorm" ]]; then
+    if [[ "$(state_get webstormPlugin)" != "1" ]]; then
+        ANS=$(ask_choice "(Optional) Install Claude Code plugin in WebStorm:\n\n1. Click [Open WebStorm]\n2. Settings → Plugins → Marketplace → 'Claude Code' → Install\n3. Click [Done]" "Open WebStorm" "Done" "Skip")
+        case "$ANS" in
+            "Open WebStorm")
+                if command -v webstorm >/dev/null 2>&1; then webstorm & else snap run webstorm & fi
+                ANS=$(ask_choice "Plugin installed?" "Done" "Skip")
+                ;;
+        esac
+        [[ "$ANS" == "Done" ]] && state_set webstormPlugin "1"
+    fi
+fi
+
+# 3c. Final verify
+notify "Verifying" "Health check"
+HEALTH_OUT=""
+if [[ -f "$HOME/.claude/scripts/health.sh" ]]; then
+    HEALTH_OUT=$(bash "$HOME/.claude/scripts/health.sh" 2>&1 | tail -5 || true)
+fi
+
+FINAL_MSG="Setup complete! Role: $ROLE\n\n"
+FINAL_MSG+="Tools: git, node, pnpm, gh, claude, opencode\n"
+FINAL_MSG+="Repos: ~/kun"
+[[ "$ROLE" == "engineer" ]] && FINAL_MSG+=", ~/hogwarts, ~/codebase, +org repos"
+FINAL_MSG+="\nConfig: ~/.claude/ (agents, skills, MCP)\n\n"
+FINAL_MSG+="Linux note: no Claude Desktop. Use:\n"
+FINAL_MSG+="  • CLI: 'claude' / 'c' / 'opencode'\n"
+FINAL_MSG+="  • Browser: https://claude.ai/code\n"
+FINAL_MSG+="  • IDE: VS Code + WebStorm Claude plugins\n\n"
+FINAL_MSG+="Mobile: install Claude on iPhone/Android with the same account."
+
+ask_choice "$FINAL_MSG" "Done" "View Docs" >/dev/null
+
+if [[ "$(ask_yesno "Open onboarding docs in browser?")" == "Yes" ]]; then
+    open_url "https://github.com/databayt/kun/blob/main/content/docs/onboarding.mdx"
+fi
+
+state_set lastStep "done"
+state_set timestamp "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+notify "All done" "Open a new terminal to start"

--- a/.claude/scripts/installer-linux.sh
+++ b/.claude/scripts/installer-linux.sh
@@ -6,7 +6,7 @@
 # Wraps onboarding-linux.sh with native dialogs and deep-link action buttons.
 #
 # Bootstrap:
-#   curl -fsSL https://kun.databayt.com/install | bash
+#   curl -fsSL https://kun.databayt.org/install | bash
 # Direct:
 #   bash <(curl -fsSL https://raw.githubusercontent.com/databayt/kun/main/.claude/scripts/installer-linux.sh)
 #

--- a/.claude/scripts/installer-linux.sh
+++ b/.claude/scripts/installer-linux.sh
@@ -139,6 +139,42 @@ GIST_ID=$(state_get gistId)
 GIT_NAME_ARG=$(state_get gitName)
 GIT_EMAIL_ARG=$(state_get gitEmail)
 WITH_TAILSCALE=$(state_get withTailscale)
+REPOS_DIR=$(state_get reposDir)
+HAS_GITHUB=$(state_get hasGithub)
+HAS_ANTHROPIC=$(state_get hasAnthropic)
+
+# Account guidance
+if [[ -z "$HAS_GITHUB" ]]; then
+    ANS=$(ask_choice "Do you have a GitHub account?" "Yes, I have one" "No, create one" "Skip")
+    if [[ "$ANS" == "No, create one" ]]; then
+        open_url "https://github.com/join"
+        ask_choice "GitHub sign-up opened. Done when you've created the account." "Done" "Skip" >/dev/null
+    fi
+    state_set hasGithub "1"
+fi
+if [[ -z "$HAS_ANTHROPIC" ]]; then
+    ANS=$(ask_choice "Do you have an Anthropic account?\n(For Claude Code CLI + claude.ai/code in browser.)" "Yes, I have one" "No, create one" "Skip")
+    if [[ "$ANS" == "No, create one" ]]; then
+        open_url "https://claude.ai/login"
+        ask_choice "Anthropic sign-in opened. Done when you've created the account." "Done" "Skip" >/dev/null
+    fi
+    state_set hasAnthropic "1"
+fi
+
+# Repos dir
+if [[ -z "$REPOS_DIR" ]]; then
+    CHOICE=$(ask_choice "Where do you want databayt org repos saved?\n(Default: home root)" "Home root (~/)" "~/databayt/" "Custom...")
+    case "$CHOICE" in
+        "Home root (~/)") REPOS_DIR="$HOME" ;;
+        "~/databayt/")    REPOS_DIR="$HOME/databayt"; mkdir -p "$REPOS_DIR" ;;
+        "Custom...")
+            CUSTOM=$(ask_text "Enter absolute path:" "$HOME/projects/databayt")
+            [[ -z "$CUSTOM" ]] && CUSTOM="$HOME"
+            REPOS_DIR="$CUSTOM"; mkdir -p "$REPOS_DIR" ;;
+        *) REPOS_DIR="$HOME" ;;
+    esac
+    state_set reposDir "$REPOS_DIR"
+fi
 
 # Role: auto-detect from existing mcp.json
 if [[ -z "$ROLE" ]]; then
@@ -193,6 +229,7 @@ notify "Installing" "~15-20 min in terminal"
 BACKEND_ARGS=("$ROLE")
 [[ -n "$GIST_ID" ]] && BACKEND_ARGS+=("$GIST_ID")
 BACKEND_ARGS+=("--quiet" "--name" "$GIT_NAME_ARG" "--email" "$GIT_EMAIL_ARG")
+[[ -n "$REPOS_DIR" && "$REPOS_DIR" != "$HOME" ]] && BACKEND_ARGS+=("--repos-dir" "$REPOS_DIR")
 [[ "$WITH_TAILSCALE" == "1" ]] && BACKEND_ARGS+=("--with-tailscale")
 
 echo ""

--- a/.claude/scripts/installer.ps1
+++ b/.claude/scripts/installer.ps1
@@ -1,0 +1,334 @@
+# =============================================================================
+# Quiet Wizard - Windows Installer
+# =============================================================================
+# Three-act guided installer for Windows. Uses WPF dialogs (PresentationFramework
+# ships with .NET on Win10/11). Wraps onboarding-windows.ps1 -Quiet.
+#
+# Bootstrap:
+#   iwr https://kun.databayt.com/install.ps1 | iex
+# Direct:
+#   iwr https://raw.githubusercontent.com/databayt/kun/main/.claude/scripts/installer.ps1 | iex
+#
+# State file: $env:APPDATA\Databayt\installer-state.json (auto-resume)
+# =============================================================================
+
+param(
+    [switch]$NoGui   # force terminal mode (CI / headless)
+)
+
+$ErrorActionPreference = "Continue"
+
+Add-Type -AssemblyName PresentationFramework
+Add-Type -AssemblyName System.Windows.Forms
+
+# ── State file ──────────────────────────────────────────────────
+$stateDir = "$env:APPDATA\Databayt"
+$stateFile = "$stateDir\installer-state.json"
+New-Item -ItemType Directory -Force -Path $stateDir | Out-Null
+
+function Get-State($key) {
+    if (-not (Test-Path $stateFile)) { return "" }
+    try {
+        $d = Get-Content $stateFile -Raw | ConvertFrom-Json
+        return $d.$key
+    } catch { return "" }
+}
+function Set-State($key, $value) {
+    $d = if (Test-Path $stateFile) {
+        try { Get-Content $stateFile -Raw | ConvertFrom-Json } catch { @{} }
+    } else { @{} }
+    # PSCustomObject -> Hashtable so we can add properties
+    $h = @{}
+    if ($d) { $d.PSObject.Properties | ForEach-Object { $h[$_.Name] = $_.Value } }
+    $h[$key] = $value
+    $h | ConvertTo-Json | Set-Content $stateFile -Encoding UTF8
+}
+
+# ── Dialog helpers ──────────────────────────────────────────────
+function Ask-YesNo($prompt) {
+    if ($NoGui) {
+        Write-Host "$prompt [y/N] " -NoNewline -ForegroundColor Cyan
+        $a = Read-Host
+        if ($a -match '^[Yy]') { return "Yes" } else { return "No" }
+    }
+    $r = [System.Windows.MessageBox]::Show($prompt, "Databayt Setup", "YesNo", "Question")
+    if ($r -eq "Yes") { return "Yes" } else { return "No" }
+}
+function Ask-Text($prompt, $default = "") {
+    if ($NoGui) {
+        Write-Host "$prompt " -NoNewline -ForegroundColor Cyan
+        if ($default) { Write-Host "[$default] " -NoNewline }
+        $a = Read-Host
+        if ([string]::IsNullOrEmpty($a)) { return $default } else { return $a }
+    }
+    # WinForms InputBox - simplest reliable text input on Win10+
+    return [Microsoft.VisualBasic.Interaction]::InputBox($prompt, "Databayt Setup", $default)
+}
+function Ask-Choice($prompt, $opt1, $opt2, $opt3 = $null) {
+    if ($NoGui) {
+        Write-Host "`n$prompt" -ForegroundColor Cyan
+        Write-Host "  1) $opt1"
+        Write-Host "  2) $opt2"
+        if ($opt3) { Write-Host "  3) $opt3" }
+        Write-Host "  > " -NoNewline
+        $n = Read-Host
+        switch ($n) { "1" { return $opt1 } "2" { return $opt2 } "3" { return $opt3 } default { return "" } }
+    }
+    # WPF custom dialog for 2-3 button choice
+    $window = New-Object System.Windows.Window
+    $window.Title = "Databayt Setup"
+    $window.Width = 480; $window.Height = 220
+    $window.WindowStartupLocation = "CenterScreen"; $window.ResizeMode = "NoResize"
+    $stack = New-Object System.Windows.Controls.StackPanel; $stack.Margin = "20"
+    $tb = New-Object System.Windows.Controls.TextBlock
+    $tb.Text = $prompt; $tb.TextWrapping = "Wrap"; $tb.Margin = "0,0,0,20"; $tb.FontSize = 13
+    $stack.Children.Add($tb) | Out-Null
+    $row = New-Object System.Windows.Controls.StackPanel; $row.Orientation = "Horizontal"; $row.HorizontalAlignment = "Right"
+    $result = ""
+    $buttons = @($opt1, $opt2); if ($opt3) { $buttons += $opt3 }
+    foreach ($b in $buttons) {
+        $btn = New-Object System.Windows.Controls.Button
+        $btn.Content = $b; $btn.Width = 100; $btn.Margin = "10,0,0,0"; $btn.Padding = "5"
+        $btn.Add_Click({ $script:result = $this.Content; $window.Close() }.GetNewClosure())
+        $row.Children.Add($btn) | Out-Null
+    }
+    $stack.Children.Add($row) | Out-Null
+    $window.Content = $stack
+    $window.ShowDialog() | Out-Null
+    return $script:result
+}
+function Ask-Role() {
+    if ($NoGui) { return Ask-Choice "Pick your role:" "engineer" "business" "content" }
+    $roles = @("engineer", "business", "content", "ops")
+    $window = New-Object System.Windows.Window
+    $window.Title = "Databayt Setup"; $window.Width = 360; $window.Height = 280
+    $window.WindowStartupLocation = "CenterScreen"; $window.ResizeMode = "NoResize"
+    $stack = New-Object System.Windows.Controls.StackPanel; $stack.Margin = "20"
+    $lbl = New-Object System.Windows.Controls.TextBlock; $lbl.Text = "Pick your role:"; $lbl.Margin = "0,0,0,10"; $lbl.FontSize = 13
+    $stack.Children.Add($lbl) | Out-Null
+    $list = New-Object System.Windows.Controls.ListBox
+    foreach ($r in $roles) { $list.Items.Add($r) | Out-Null }
+    $list.SelectedIndex = 0; $list.Height = 120
+    $stack.Children.Add($list) | Out-Null
+    $btn = New-Object System.Windows.Controls.Button
+    $btn.Content = "OK"; $btn.Width = 80; $btn.Margin = "0,15,0,0"; $btn.HorizontalAlignment = "Right"
+    $script:result = ""
+    $btn.Add_Click({ $script:result = $list.SelectedItem; $window.Close() })
+    $stack.Children.Add($btn) | Out-Null
+    $window.Content = $stack
+    $window.ShowDialog() | Out-Null
+    return $script:result
+}
+function Notify($title, $body) {
+    if ($NoGui) { Write-Host "[$title] $body" -ForegroundColor Cyan; return }
+    # BalloonTip via NotifyIcon — fire and forget
+    $bal = New-Object System.Windows.Forms.NotifyIcon
+    $bal.Icon = [System.Drawing.SystemIcons]::Information
+    $bal.BalloonTipTitle = $title; $bal.BalloonTipText = $body
+    $bal.Visible = $true; $bal.ShowBalloonTip(3000)
+    Start-Sleep -Milliseconds 100
+    $bal.Dispose()
+}
+Add-Type -AssemblyName Microsoft.VisualBasic   # for InputBox
+
+# ── Bootstrap: clone kun if missing ─────────────────────────────
+if (-not (Test-Path "$env:USERPROFILE\kun")) {
+    Notify "Cloning" "kun repo"
+    git clone https://github.com/databayt/kun.git "$env:USERPROFILE\kun" 2>&1 | Out-Null
+    if (-not $?) {
+        [System.Windows.MessageBox]::Show("Could not clone databayt/kun. Check network.", "Setup failed", "OK", "Error") | Out-Null
+        exit 1
+    }
+}
+
+$Backend = "$env:USERPROFILE\kun\.claude\scripts\onboarding-windows.ps1"
+if (-not (Test-Path $Backend)) {
+    [System.Windows.MessageBox]::Show("Backend missing: $Backend", "Setup failed", "OK", "Error") | Out-Null
+    exit 1
+}
+
+# =============================================================================
+# ACT 1 - Pre-flight
+# =============================================================================
+$welcome = Ask-Choice "Welcome - this sets up a fresh Windows laptop for databayt.`n`nAbout 20 minutes (mostly silent downloads).`n`nReady?" "Start" "Cancel"
+if ($welcome -ne "Start") { Notify "Cancelled" "Run again anytime"; exit 0 }
+
+$role = Get-State role
+$gistId = Get-State gistId
+$gitName = Get-State gitName
+$gitEmail = Get-State gitEmail
+$withTailscale = Get-State withTailscale
+$proMax = Get-State proMax
+
+# Role: auto-detect from existing mcp.json
+if (-not $role) {
+    $mcp = "$env:USERPROFILE\.claude\mcp.json"
+    if (Test-Path $mcp) {
+        $content = Get-Content $mcp -Raw
+        if ($content -match '"shadcn"') { $role = "engineer" }
+        elseif ($content -match '"linear"') { $role = "business" }
+        elseif ($content -match '"figma"') { $role = "content" }
+        elseif ($content -match '"posthog"') { $role = "ops" }
+    }
+    if (-not $role) {
+        $role = Ask-Role
+        if (-not $role) { Notify "Cancelled" "No role"; exit 0 }
+    }
+    Set-State role $role
+}
+
+# Git identity
+if (-not $gitName) {
+    $existingName = git config --global user.name 2>$null
+    if ($existingName) {
+        $gitName = $existingName
+        $gitEmail = git config --global user.email 2>$null
+    } else {
+        $gitName = Ask-Text "Your full name (for git commits):"
+        if (-not $gitName) { Notify "Cancelled" "No name"; exit 0 }
+        $gitEmail = Ask-Text "Your email (for git commits):"
+        if (-not $gitEmail) { Notify "Cancelled" "No email"; exit 0 }
+    }
+    Set-State gitName $gitName
+    Set-State gitEmail $gitEmail
+}
+
+# Gist ID
+if (-not $gistId) {
+    $gistId = Ask-Text "Secrets Gist ID (or blank to skip):"
+    Set-State gistId $gistId
+}
+
+# Pro/Max
+if (-not $proMax) {
+    $ans = Ask-YesNo "Do you have a Claude Pro or Max subscription?`n`n(Affects Desktop Chat/Cowork/Code tabs.)"
+    if ($ans -eq "Yes") { $proMax = "1" } else { $proMax = "0" }
+    Set-State proMax $proMax
+}
+
+# Tailscale
+if (-not $withTailscale) {
+    $ans = Ask-YesNo "Enable Tailscale SSH? (Remote control from iPhone/laptop.)"
+    if ($ans -eq "Yes") { $withTailscale = "1" } else { $withTailscale = "0" }
+    Set-State withTailscale $withTailscale
+}
+
+# =============================================================================
+# ACT 2 - Silent batch
+# =============================================================================
+Notify "Installing" "~15-20 min in terminal"
+
+$backendArgs = @("-Role", $role, "-Quiet", "-GitName", $gitName, "-GitEmail", $gitEmail)
+if ($gistId) { $backendArgs += @("-GistId", $gistId) }
+if ($withTailscale -eq "1") { $backendArgs += @("-WithTailscale") }
+
+Write-Host ""
+Write-Host "════════════════════════════════════════════════════" -ForegroundColor Cyan
+Write-Host " Databayt Setup - Silent Install in Progress"
+Write-Host "════════════════════════════════════════════════════"
+Write-Host " Role: $role"
+Write-Host " Minimize this window and do other work."
+Write-Host "════════════════════════════════════════════════════"
+Write-Host ""
+
+# Run backend, capture stderr to filter for PROGRESS markers
+$psi = New-Object System.Diagnostics.ProcessStartInfo
+$psi.FileName = "powershell.exe"
+$psi.Arguments = "-NoProfile -ExecutionPolicy Bypass -File `"$Backend`" $($backendArgs -join ' ')"
+$psi.RedirectStandardError = $true; $psi.RedirectStandardOutput = $false
+$psi.UseShellExecute = $false; $psi.CreateNoWindow = $false
+$proc = [System.Diagnostics.Process]::Start($psi)
+# Stream stderr — fire notify on PROGRESS markers
+while (-not $proc.StandardError.EndOfStream) {
+    $line = $proc.StandardError.ReadLine()
+    if ($line -match '^PROGRESS:([\d/]+):(.+)$') {
+        Notify "Phase $($matches[1])" $matches[2]
+    } else {
+        [Console]::Error.WriteLine($line)
+    }
+}
+$proc.WaitForExit()
+$rc = $proc.ExitCode
+
+if ($rc -ne 0) {
+    $retry = Ask-Choice "Install hit an issue (exit $rc). What now?" "Retry" "Skip" "Quit"
+    switch ($retry) {
+        "Retry" { & $PSCommandPath; exit }
+        "Quit"  { exit $rc }
+    }
+}
+Set-State silentBatch "done"
+
+# =============================================================================
+# ACT 3 - Manual finishing
+# =============================================================================
+Notify "Almost done" "Final clicks"
+
+# 3a. Claude Desktop sign-in (Pro/Max)
+$claudeApp = "$env:LOCALAPPDATA\Programs\claude-desktop\Claude.exe"
+$claudeApp2 = "${env:ProgramFiles}\Claude\Claude.exe"
+if ($proMax -eq "1" -and ((Test-Path $claudeApp) -or (Test-Path $claudeApp2)) -and (Get-State desktopSignedIn) -ne "1") {
+    $ans = Ask-Choice "Sign in to Claude Desktop:`n`n1. Click [Open Claude]`n2. Sign in with your Anthropic account`n3. Click [Done]" "Open Claude" "Done" "Skip"
+    if ($ans -eq "Open Claude") {
+        if (Test-Path $claudeApp) { Start-Process $claudeApp } else { Start-Process $claudeApp2 }
+        $ans = Ask-Choice "Signed in?" "Done" "Skip"
+    }
+    if ($ans -eq "Done") { Set-State desktopSignedIn "1" }
+}
+
+# 3b. Computer-use toggle (Pro/Max)
+if ($proMax -eq "1" -and (Get-State computerUse) -ne "1") {
+    $ans = Ask-Choice "(Optional) Enable Claude Desktop computer-use:`n`n1. Click [Open Settings]`n2. Claude Desktop -> Settings -> General -> Toggle 'Allow Claude to use your computer'`n3. Click [Done]" "Open Settings" "Done" "Skip"
+    if ($ans -eq "Open Settings") {
+        if (Test-Path $claudeApp) { Start-Process $claudeApp } elseif (Test-Path $claudeApp2) { Start-Process $claudeApp2 }
+        Start-Process "ms-settings:easeofaccess"
+        $ans = Ask-Choice "Toggle enabled?" "Done" "Skip"
+    }
+    if ($ans -eq "Done") { Set-State computerUse "1" }
+}
+
+# 3c. VS Code Claude extension - auto-install
+$hasCode = Get-Command code -EA SilentlyContinue
+if ($hasCode -and (Get-State vsCodeExt) -ne "1") {
+    $exts = code --list-extensions 2>$null
+    if ($exts -match "anthropic.claude-code") {
+        Set-State vsCodeExt "1"
+    } else {
+        code --install-extension anthropic.claude-code 2>$null
+        if ($?) { Set-State vsCodeExt "1" }
+    }
+}
+
+# 3d. WebStorm Claude plugin (engineer)
+$wsPath = "${env:ProgramFiles}\JetBrains\WebStorm*"
+if ($role -eq "engineer" -and (Test-Path $wsPath) -and (Get-State webstormPlugin) -ne "1") {
+    $ans = Ask-Choice "(Optional) Install Claude Code plugin in WebStorm:`n`n1. Click [Open WebStorm]`n2. Settings -> Plugins -> Marketplace -> 'Claude Code' -> Install`n3. Click [Done]" "Open WebStorm" "Done" "Skip"
+    if ($ans -eq "Open WebStorm") {
+        Start-Process (Get-ChildItem "$wsPath\bin\webstorm64.exe" | Select-Object -First 1).FullName 2>$null
+        $ans = Ask-Choice "Plugin installed?" "Done" "Skip"
+    }
+    if ($ans -eq "Done") { Set-State webstormPlugin "1" }
+}
+
+# 3e. Final verify
+Notify "Verifying" "Health check"
+$healthScript = "$env:USERPROFILE\.claude\scripts\health.ps1"
+if (Test-Path $healthScript) { & $healthScript 2>&1 | Select-Object -Last 5 | Out-Host }
+
+$finalMsg = "Setup complete! Role: $role`n`n"
+$finalMsg += "Tools: git, node, pnpm, gh, claude, opencode`n"
+$finalMsg += "Repos: $env:USERPROFILE\kun"
+if ($role -eq "engineer") { $finalMsg += ", \hogwarts, \codebase, +org repos" }
+$finalMsg += "`nConfig: $env:USERPROFILE\.claude\ (agents, skills, MCP)`n`n"
+$finalMsg += "Next: open a new PowerShell and type 'c' to start Claude Code.`n`n"
+$finalMsg += "Mobile: install Claude on iPhone/Android with same Anthropic account."
+
+Ask-Choice $finalMsg "Done" "View Docs" | Out-Null
+
+if ((Ask-YesNo "Open onboarding docs in browser?") -eq "Yes") {
+    Start-Process "https://github.com/databayt/kun/blob/main/content/docs/onboarding.mdx"
+}
+
+Set-State lastStep "done"
+Set-State timestamp (Get-Date -Format "yyyy-MM-ddTHH:mm:ssZ")
+Notify "All done" "Open a new terminal to start"

--- a/.claude/scripts/installer.ps1
+++ b/.claude/scripts/installer.ps1
@@ -159,6 +159,43 @@ $gitName = Get-State gitName
 $gitEmail = Get-State gitEmail
 $withTailscale = Get-State withTailscale
 $proMax = Get-State proMax
+$reposDir = Get-State reposDir
+$hasGithub = Get-State hasGithub
+$hasAnthropic = Get-State hasAnthropic
+
+# Account guidance
+if (-not $hasGithub) {
+    $ans = Ask-Choice "Do you have a GitHub account?" "Yes, I have one" "No, create one" "Skip"
+    if ($ans -eq "No, create one") {
+        Start-Process "https://github.com/join"
+        Ask-Choice "GitHub sign-up opened in browser. Done when you've created the account." "Done" "Skip" | Out-Null
+    }
+    Set-State hasGithub "1"
+}
+if (-not $hasAnthropic) {
+    $ans = Ask-Choice "Do you have an Anthropic account?`n(For Claude Desktop sign-in + CLI.)" "Yes, I have one" "No, create one" "Skip"
+    if ($ans -eq "No, create one") {
+        Start-Process "https://claude.ai/login"
+        Ask-Choice "Anthropic sign-in opened. Done when you've created the account.`n`nNote: Pro/Max sub unlocks Desktop Chat/Cowork/Code tabs." "Done" "Skip" | Out-Null
+    }
+    Set-State hasAnthropic "1"
+}
+
+# Repos dir
+if (-not $reposDir) {
+    $choice = Ask-Choice "Where do you want databayt org repos saved?`n(Default: home root - C:\Users\<you>\)" "Home root" "%USERPROFILE%\databayt" "Custom..."
+    switch ($choice) {
+        "Home root"             { $reposDir = $env:USERPROFILE }
+        "%USERPROFILE%\databayt" { $reposDir = "$env:USERPROFILE\databayt"; New-Item -ItemType Directory -Force -Path $reposDir | Out-Null }
+        "Custom..."             {
+            $custom = Ask-Text "Enter absolute path:" "$env:USERPROFILE\projects\databayt"
+            if (-not $custom) { $custom = $env:USERPROFILE }
+            $reposDir = $custom; New-Item -ItemType Directory -Force -Path $reposDir | Out-Null
+        }
+        default { $reposDir = $env:USERPROFILE }
+    }
+    Set-State reposDir $reposDir
+}
 
 # Role: auto-detect from existing mcp.json
 if (-not $role) {
@@ -220,6 +257,7 @@ Notify "Installing" "~15-20 min in terminal"
 
 $backendArgs = @("-Role", $role, "-Quiet", "-GitName", $gitName, "-GitEmail", $gitEmail)
 if ($gistId) { $backendArgs += @("-GistId", $gistId) }
+if ($reposDir -and $reposDir -ne $env:USERPROFILE) { $backendArgs += @("-ReposDir", $reposDir) }
 if ($withTailscale -eq "1") { $backendArgs += @("-WithTailscale") }
 
 Write-Host ""

--- a/.claude/scripts/installer.ps1
+++ b/.claude/scripts/installer.ps1
@@ -5,7 +5,7 @@
 # ships with .NET on Win10/11). Wraps onboarding-windows.ps1 -Quiet.
 #
 # Bootstrap:
-#   iwr https://kun.databayt.com/install.ps1 | iex
+#   iwr https://kun.databayt.org/install.ps1 | iex
 # Direct:
 #   iwr https://raw.githubusercontent.com/databayt/kun/main/.claude/scripts/installer.ps1 | iex
 #

--- a/.claude/scripts/installer.sh
+++ b/.claude/scripts/installer.sh
@@ -1,0 +1,273 @@
+#!/bin/bash
+# =============================================================================
+# Quiet Wizard — macOS Installer
+# =============================================================================
+# Three-act guided installer: pre-flight form, silent batch, manual finishing.
+# Wraps onboarding-mac.sh in osascript dialogs with deep-link action buttons.
+#
+# Bootstrap:
+#   curl -fsSL https://kun.databayt.com/install | bash
+# Direct:
+#   bash <(curl -fsSL https://raw.githubusercontent.com/databayt/kun/main/.claude/scripts/installer.sh)
+#
+# State file at: ~/Library/Application Support/Databayt/installer-state.json
+# (auto-resumes from last completed step)
+# =============================================================================
+
+set -e
+
+# ── State file ──────────────────────────────────────────────────
+STATE_DIR="$HOME/Library/Application Support/Databayt"
+STATE_FILE="$STATE_DIR/installer-state.json"
+mkdir -p "$STATE_DIR"
+
+state_get() {
+    [[ -f "$STATE_FILE" ]] || { echo ""; return; }
+    /usr/bin/python3 -c "import json,sys; d=json.load(open('$STATE_FILE')); print(d.get('$1',''))" 2>/dev/null
+}
+state_set() {
+    /usr/bin/python3 -c "
+import json, os
+p = '$STATE_FILE'
+d = json.load(open(p)) if os.path.exists(p) else {}
+d['$1'] = '$2'
+json.dump(d, open(p, 'w'), indent=2)
+"
+}
+
+# ── osascript helpers ───────────────────────────────────────────
+ask_text() {
+    # ask_text <prompt> <default> → echoes user input or empty if cancelled
+    local prompt="$1" default="${2:-}"
+    osascript <<EOF 2>/dev/null
+try
+    set r to display dialog "$prompt" default answer "$default" with title "Databayt Setup"
+    return text returned of r
+on error
+    return ""
+end try
+EOF
+}
+ask_choice() {
+    # ask_choice <prompt> <opt1> <opt2> [opt3] → echoes chosen button or empty
+    local prompt="$1" opt1="$2" opt2="$3" opt3="${4:-}"
+    local buttons="{\"$opt1\", \"$opt2\""
+    [[ -n "$opt3" ]] && buttons="$buttons, \"$opt3\""
+    buttons="$buttons}"
+    osascript <<EOF 2>/dev/null
+try
+    set r to display dialog "$prompt" buttons $buttons default button "$opt1" with title "Databayt Setup"
+    return button returned of r
+on error
+    return ""
+end try
+EOF
+}
+notify() {
+    osascript -e "display notification \"$1\" with title \"Databayt Setup\" subtitle \"$2\"" 2>/dev/null || true
+}
+ask_role() {
+    osascript <<'EOF' 2>/dev/null
+set roles to {"engineer", "business", "content", "ops"}
+try
+    set r to choose from list roles with prompt "Pick your role:" default items {"engineer"} with title "Databayt Setup"
+    if r is false then return ""
+    return item 1 of r
+on error
+    return ""
+end try
+EOF
+}
+
+# ── Bootstrap: clone kun if not present ─────────────────────────
+if [[ ! -d "$HOME/kun" ]]; then
+    notify "Cloning kun repo..." "Setting up"
+    if ! git clone https://github.com/databayt/kun.git "$HOME/kun" >/dev/null 2>&1; then
+        osascript -e 'display alert "Setup failed" message "Could not clone databayt/kun. Check your network and try again."' 2>/dev/null
+        exit 1
+    fi
+fi
+
+BACKEND="$HOME/kun/.claude/scripts/onboarding-mac.sh"
+if [[ ! -f "$BACKEND" ]]; then
+    osascript -e 'display alert "Setup failed" message "Backend script missing: ~/kun/.claude/scripts/onboarding-mac.sh"' 2>/dev/null
+    exit 1
+fi
+
+# =============================================================================
+# ACT 1 — Pre-flight (auto-detect, dialog only what's missing)
+# =============================================================================
+WELCOME=$(ask_choice "Welcome — this sets up a fresh Mac for databayt.\n\nAbout 20 minutes (mostly silent downloads).\n\nReady?" "Start" "Cancel")
+[[ "$WELCOME" != "Start" ]] && { notify "Setup cancelled" "Run again anytime"; exit 0; }
+
+# Resume from state file if present
+ROLE=$(state_get role)
+GIST_ID=$(state_get gistId)
+GIT_NAME_ARG=$(state_get gitName)
+GIT_EMAIL_ARG=$(state_get gitEmail)
+WITH_TAILSCALE=$(state_get withTailscale)
+PRO_MAX=$(state_get proMax)
+
+# Role: auto-detect from existing mcp.json, else ask
+if [[ -z "$ROLE" ]]; then
+    if [[ -f "$HOME/.claude/mcp.json" ]]; then
+        if grep -q '"shadcn"' "$HOME/.claude/mcp.json" 2>/dev/null; then ROLE="engineer"
+        elif grep -q '"linear"' "$HOME/.claude/mcp.json" 2>/dev/null; then ROLE="business"
+        elif grep -q '"figma"' "$HOME/.claude/mcp.json" 2>/dev/null; then ROLE="content"
+        elif grep -q '"posthog"' "$HOME/.claude/mcp.json" 2>/dev/null; then ROLE="ops"
+        fi
+    fi
+    if [[ -z "$ROLE" ]]; then
+        ROLE=$(ask_role)
+        [[ -z "$ROLE" ]] && { notify "Cancelled" "No role selected"; exit 0; }
+    fi
+    state_set role "$ROLE"
+fi
+
+# Git identity: auto-detect, else ask
+if [[ -z "$GIT_NAME_ARG" ]]; then
+    EXISTING_NAME=$(git config --global user.name 2>/dev/null || echo "")
+    if [[ -n "$EXISTING_NAME" ]]; then
+        GIT_NAME_ARG="$EXISTING_NAME"
+        GIT_EMAIL_ARG=$(git config --global user.email 2>/dev/null || echo "")
+    else
+        GIT_NAME_ARG=$(ask_text "Your full name (for git commits):")
+        [[ -z "$GIT_NAME_ARG" ]] && { notify "Cancelled" "No name given"; exit 0; }
+        GIT_EMAIL_ARG=$(ask_text "Your email (for git commits):")
+        [[ -z "$GIT_EMAIL_ARG" ]] && { notify "Cancelled" "No email given"; exit 0; }
+    fi
+    state_set gitName "$GIT_NAME_ARG"
+    state_set gitEmail "$GIT_EMAIL_ARG"
+fi
+
+# Gist ID: ask once, persist; can skip
+if [[ -z "$GIST_ID" ]]; then
+    GIST_ID=$(ask_text "Secrets Gist ID (or leave blank to skip — you can load later):")
+    state_set gistId "$GIST_ID"
+fi
+
+# Pro/Max: affects Act 3 (Claude Desktop sign-in, computer-use toggle)
+if [[ -z "$PRO_MAX" ]]; then
+    PM_ANS=$(ask_choice "Do you have a Claude Pro or Max subscription?\n\n(Affects whether you get the Desktop Chat/Cowork/Code tabs.)" "Yes" "No")
+    [[ "$PM_ANS" == "Yes" ]] && PRO_MAX="1" || PRO_MAX="0"
+    state_set proMax "$PRO_MAX"
+fi
+
+# Tailscale: optional (default off)
+if [[ -z "$WITH_TAILSCALE" ]]; then
+    TS_ANS=$(ask_choice "Enable Tailscale SSH? (For remote control from iPhone/laptop.)\n\nCan be added later." "Yes" "No")
+    [[ "$TS_ANS" == "Yes" ]] && WITH_TAILSCALE="1" || WITH_TAILSCALE="0"
+    state_set withTailscale "$WITH_TAILSCALE"
+fi
+
+# =============================================================================
+# ACT 2 — Silent batch (in terminal; notifications on phase transitions)
+# =============================================================================
+notify "Starting install..." "~15-20 minutes"
+
+BACKEND_ARGS=("$ROLE")
+[[ -n "$GIST_ID" ]] && BACKEND_ARGS+=("$GIST_ID")
+BACKEND_ARGS+=("--quiet" "--name" "$GIT_NAME_ARG" "--email" "$GIT_EMAIL_ARG")
+[[ "$WITH_TAILSCALE" == "1" ]] && BACKEND_ARGS+=("--with-tailscale")
+
+echo ""
+echo "════════════════════════════════════════════════════"
+echo " Databayt Setup — Silent Install in Progress"
+echo "════════════════════════════════════════════════════"
+echo " Role: $ROLE"
+echo " You can minimize this terminal and do other work."
+echo "════════════════════════════════════════════════════"
+echo ""
+
+# Stream backend output to terminal, watch stderr for PROGRESS markers → notifications
+set +e
+bash "$BACKEND" "${BACKEND_ARGS[@]}" 2> >(while IFS= read -r line; do
+    echo "$line" >&2
+    if [[ "$line" == PROGRESS:* ]]; then
+        IFS=':' read -r _ phase label <<< "$line"
+        notify "Phase $phase" "$label"
+    fi
+done)
+BACKEND_RC=$?
+set -e
+
+if [[ "$BACKEND_RC" -ne 0 ]]; then
+    RETRY=$(ask_choice "Install hit an issue (exit $BACKEND_RC).\n\nWhat now?" "Retry" "Skip" "Quit")
+    case "$RETRY" in
+        Retry) exec bash "$0" ;;
+        Quit)  exit "$BACKEND_RC" ;;
+        # Skip: continue to Act 3
+    esac
+fi
+state_set silentBatch "done"
+
+# =============================================================================
+# ACT 3 — Manual finishing (deep-link dialogs only when human is needed)
+# =============================================================================
+notify "Almost done" "Final clicks coming up"
+
+# 3a. Claude Desktop sign-in (Pro/Max only)
+if [[ "$PRO_MAX" == "1" && -d "/Applications/Claude.app" ]] && [[ "$(state_get desktopSignedIn)" != "1" ]]; then
+    ANS=$(ask_choice "Sign in to Claude Desktop:\n\nClicking [Open Claude] launches the app. Sign in with your Anthropic account, then click [Done]." "Open Claude" "Done" "Skip")
+    case "$ANS" in
+        "Open Claude") open -a Claude; ANS=$(ask_choice "Signed in?" "Done" "Skip");;
+    esac
+    [[ "$ANS" == "Done" ]] && state_set desktopSignedIn "1"
+fi
+
+# 3b. Computer-use toggle (Pro/Max only)
+if [[ "$PRO_MAX" == "1" ]] && [[ "$(state_get computerUse)" != "1" ]]; then
+    ANS=$(ask_choice "(Optional) Enable Claude Desktop's computer-use:\n\n1. Click [Open Settings] below\n2. In Claude Desktop → Settings → General, toggle 'Allow Claude to use your computer'\n3. Click [Done]" "Open Settings" "Done" "Skip")
+    case "$ANS" in
+        "Open Settings")
+            open -a Claude
+            open "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility"
+            ANS=$(ask_choice "Toggle enabled?" "Done" "Skip")
+            ;;
+    esac
+    [[ "$ANS" == "Done" ]] && state_set computerUse "1"
+fi
+
+# 3c. VS Code Claude extension — auto-install if `code` on PATH
+if command -v code >/dev/null 2>&1 && [[ "$(state_get vsCodeExt)" != "1" ]]; then
+    if code --list-extensions 2>/dev/null | grep -q "anthropic.claude-code"; then
+        state_set vsCodeExt "1"
+    else
+        code --install-extension anthropic.claude-code >/dev/null 2>&1 && state_set vsCodeExt "1" || true
+    fi
+fi
+
+# 3d. WebStorm Claude plugin (engineer)
+if [[ "$ROLE" == "engineer" && -d "/Applications/WebStorm.app" ]] && [[ "$(state_get webstormPlugin)" != "1" ]]; then
+    ANS=$(ask_choice "(Optional) Install Claude Code plugin in WebStorm:\n\n1. Click [Open WebStorm]\n2. Settings → Plugins → Marketplace → search 'Claude Code' → Install\n3. Click [Done]" "Open WebStorm" "Done" "Skip")
+    case "$ANS" in
+        "Open WebStorm") open -a WebStorm; ANS=$(ask_choice "Plugin installed?" "Done" "Skip");;
+    esac
+    [[ "$ANS" == "Done" ]] && state_set webstormPlugin "1"
+fi
+
+# 3e. Final health check
+notify "Verifying..." "Running health check"
+HEALTH_OUT=""
+if [[ -f "$HOME/.claude/scripts/health.sh" ]]; then
+    HEALTH_OUT=$(bash "$HOME/.claude/scripts/health.sh" 2>&1 | tail -5 || true)
+fi
+
+# Final dialog
+FINAL_MSG="Setup complete! Role: $ROLE\n\n"
+FINAL_MSG+="Tools: git, node, pnpm, gh, claude, opencode\n"
+FINAL_MSG+="Repos: ~/kun"
+[[ "$ROLE" == "engineer" ]] && FINAL_MSG+=", ~/hogwarts, ~/codebase, +org repos"
+FINAL_MSG+="\nConfig: ~/.claude/ (agents, skills, MCP, hooks)\n\n"
+FINAL_MSG+="Next: open a new terminal and type 'c' to start Claude Code.\n\n"
+FINAL_MSG+="Mobile: install Claude on iPhone/Android with the same Anthropic account."
+
+ask_choice "$FINAL_MSG" "Done" "View Docs" >/dev/null
+
+if [[ "$(ask_choice "Open onboarding docs?" "Open" "Skip")" == "Open" ]]; then
+    open "https://github.com/databayt/kun/blob/main/content/docs/onboarding.mdx"
+fi
+
+state_set lastStep "done"
+state_set timestamp "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+notify "All done" "Open a new terminal to start"

--- a/.claude/scripts/installer.sh
+++ b/.claude/scripts/installer.sh
@@ -107,6 +107,48 @@ GIT_NAME_ARG=$(state_get gitName)
 GIT_EMAIL_ARG=$(state_get gitEmail)
 WITH_TAILSCALE=$(state_get withTailscale)
 PRO_MAX=$(state_get proMax)
+REPOS_DIR=$(state_get reposDir)
+HAS_GITHUB=$(state_get hasGithub)
+HAS_ANTHROPIC=$(state_get hasAnthropic)
+
+# Accounts: confirm or guide creation
+if [[ -z "$HAS_GITHUB" ]]; then
+    ANS=$(ask_choice "Do you have a GitHub account?\n\n(You'll use it to clone repos and authenticate.)" "Yes, I have one" "No, create one" "Skip")
+    case "$ANS" in
+        "No, create one")
+            open "https://github.com/join"
+            ask_choice "GitHub sign-up opened in browser.\n\nCreate the account, then come back and click Done." "Done" "Skip" >/dev/null
+            ;;
+    esac
+    state_set hasGithub "1"
+fi
+
+if [[ -z "$HAS_ANTHROPIC" ]]; then
+    ANS=$(ask_choice "Do you have an Anthropic account?\n\n(For Claude Desktop sign-in and the Claude Code CLI.)" "Yes, I have one" "No, create one" "Skip")
+    case "$ANS" in
+        "No, create one")
+            open "https://claude.ai/login"
+            ask_choice "Anthropic sign-in opened.\n\nCreate the account (or sign in), then click Done.\n\nNote: Pro/Max sub unlocks Desktop Chat/Cowork/Code tabs." "Done" "Skip" >/dev/null
+            ;;
+    esac
+    state_set hasAnthropic "1"
+fi
+
+# Repos directory: ask where to save databayt org repos
+if [[ -z "$REPOS_DIR" ]]; then
+    CHOICE=$(ask_choice "Where do you want databayt org repos saved?\n\nDefault: home root (~/kun, ~/hogwarts, ...)" "Home root (~/)" "~/databayt/" "Custom...")
+    case "$CHOICE" in
+        "Home root (~/)")   REPOS_DIR="$HOME" ;;
+        "~/databayt/")      REPOS_DIR="$HOME/databayt"; mkdir -p "$REPOS_DIR" ;;
+        "Custom...")
+            CUSTOM=$(ask_text "Enter absolute path:" "$HOME/projects/databayt")
+            [[ -z "$CUSTOM" ]] && CUSTOM="$HOME"
+            REPOS_DIR="$CUSTOM"; mkdir -p "$REPOS_DIR"
+            ;;
+        *) REPOS_DIR="$HOME" ;;
+    esac
+    state_set reposDir "$REPOS_DIR"
+fi
 
 # Role: auto-detect from existing mcp.json, else ask
 if [[ -z "$ROLE" ]]; then
@@ -168,6 +210,7 @@ notify "Starting install..." "~15-20 minutes"
 BACKEND_ARGS=("$ROLE")
 [[ -n "$GIST_ID" ]] && BACKEND_ARGS+=("$GIST_ID")
 BACKEND_ARGS+=("--quiet" "--name" "$GIT_NAME_ARG" "--email" "$GIT_EMAIL_ARG")
+[[ -n "$REPOS_DIR" && "$REPOS_DIR" != "$HOME" ]] && BACKEND_ARGS+=("--repos-dir" "$REPOS_DIR")
 [[ "$WITH_TAILSCALE" == "1" ]] && BACKEND_ARGS+=("--with-tailscale")
 
 echo ""

--- a/.claude/scripts/installer.sh
+++ b/.claude/scripts/installer.sh
@@ -6,7 +6,7 @@
 # Wraps onboarding-mac.sh in osascript dialogs with deep-link action buttons.
 #
 # Bootstrap:
-#   curl -fsSL https://kun.databayt.com/install | bash
+#   curl -fsSL https://kun.databayt.org/install | bash
 # Direct:
 #   bash <(curl -fsSL https://raw.githubusercontent.com/databayt/kun/main/.claude/scripts/installer.sh)
 #

--- a/.claude/scripts/lib/wizard-steps.json
+++ b/.claude/scripts/lib/wizard-steps.json
@@ -1,0 +1,192 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema#",
+  "title": "Databayt Quiet Wizard — Step Catalog",
+  "description": "Documentation-style catalog of every step the wrappers run. Wrappers currently hardcode these; future versions may read from this file. Source of truth for what each platform installer does.",
+  "version": 1,
+  "acts": {
+    "act1_preflight": {
+      "description": "Gather inputs; auto-detect existing state, dialog only what's missing",
+      "steps": [
+        {
+          "id": "welcome",
+          "type": "choice",
+          "prompt": "Welcome — this sets up a fresh machine for databayt. ~20 min.",
+          "buttons": ["Start", "Cancel"]
+        },
+        {
+          "id": "role",
+          "type": "list",
+          "prompt": "Pick your role:",
+          "options": ["engineer", "business", "content", "ops"],
+          "autoDetect": "Inspect ~/.claude/mcp.json for shadcn/linear/figma/posthog → infer role",
+          "persistAs": "role"
+        },
+        {
+          "id": "gitName",
+          "type": "text",
+          "prompt": "Your full name (for git commits):",
+          "autoDetect": "git config --global user.name",
+          "persistAs": "gitName"
+        },
+        {
+          "id": "gitEmail",
+          "type": "text",
+          "prompt": "Your email (for git commits):",
+          "autoDetect": "git config --global user.email",
+          "persistAs": "gitEmail"
+        },
+        {
+          "id": "gistId",
+          "type": "text",
+          "prompt": "Secrets Gist ID (or blank to skip):",
+          "persistAs": "gistId",
+          "optional": true
+        },
+        {
+          "id": "proMax",
+          "type": "yesno",
+          "prompt": "Do you have a Claude Pro or Max subscription?",
+          "platforms": ["mac", "windows"],
+          "persistAs": "proMax",
+          "note": "Skipped on Linux (no Claude Desktop)"
+        },
+        {
+          "id": "withTailscale",
+          "type": "yesno",
+          "prompt": "Enable Tailscale SSH? (Remote control from iPhone/laptop.)",
+          "persistAs": "withTailscale"
+        }
+      ]
+    },
+    "act2_silentBatch": {
+      "description": "Run the 8-phase platform backend in --quiet/-Quiet mode",
+      "backends": {
+        "mac": ".claude/scripts/onboarding-mac.sh <role> <gist> --quiet --name --email [--with-tailscale]",
+        "linux": ".claude/scripts/onboarding-linux.sh <role> <gist> --quiet --name --email [--with-tailscale]",
+        "windows": ".claude/scripts/onboarding-windows.ps1 -Role <r> -GistId <g> -Quiet -GitName -GitEmail [-WithTailscale]"
+      },
+      "phases": [
+        {"n": 1, "label": "System Foundation — build tools, git, Node 22, pnpm, gh CLI"},
+        {"n": 2, "label": "Applications — IDEs, Chrome"},
+        {"n": 3, "label": "GitHub — SSH key, gh auth, upload key"},
+        {"n": 4, "label": "Clone Repositories — kun + (engineer: hogwarts, codebase, all org repos)"},
+        {"n": 5, "label": "Claude — Code CLI + Desktop (Mac/Win) + OpenCode + AGENTS.md symlink"},
+        {"n": 6, "label": "Kun Engine — setup.sh + secrets.sh"},
+        {"n": 7, "label": "Hogwarts — pnpm install, prisma, seed, build (engineer only)"},
+        {"n": 8, "label": "Health Check"},
+        {"n": "9 (opt)", "label": "Tailscale — install + 'up --ssh' (--with-tailscale)"}
+      ],
+      "progressMarker": "PROGRESS:N/8:label streamed on stderr — wrappers parse for notifications"
+    },
+    "act3_manualFinishing": {
+      "description": "Deep-link dialogs only when human is unavoidably in the loop",
+      "steps": [
+        {
+          "id": "githubAuth",
+          "type": "auto-poll",
+          "command": "gh auth login --web",
+          "note": "Opens browser, blocks until success — no dialog needed"
+        },
+        {
+          "id": "anthropicAuth",
+          "type": "auto-poll",
+          "command": "claude (first-run opens browser)",
+          "note": "Same as GitHub — browser-based, no terminal prompt"
+        },
+        {
+          "id": "vsCodeExtension",
+          "type": "silent",
+          "command": "code --install-extension anthropic.claude-code",
+          "skip": "if extension already listed"
+        },
+        {
+          "id": "claudeDesktopSignIn",
+          "type": "dialog",
+          "platforms": ["mac", "windows"],
+          "prompt": "Sign in to Claude Desktop",
+          "buttons": ["Open Claude", "Done", "Skip"],
+          "deepLinks": {
+            "mac": "open -a Claude",
+            "windows": "Start-Process Claude.exe"
+          },
+          "gate": "proMax == 1"
+        },
+        {
+          "id": "computerUseToggle",
+          "type": "dialog",
+          "platforms": ["mac", "windows"],
+          "prompt": "Enable Claude Desktop computer-use (optional)",
+          "buttons": ["Open Settings", "Done", "Skip"],
+          "deepLinks": {
+            "mac": "open 'x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility'",
+            "windows": "Start-Process ms-settings:easeofaccess"
+          },
+          "gate": "proMax == 1"
+        },
+        {
+          "id": "webstormPlugin",
+          "type": "dialog",
+          "prompt": "Install Claude Code plugin in WebStorm (optional)",
+          "buttons": ["Open WebStorm", "Done", "Skip"],
+          "deepLinks": {
+            "mac": "open -a WebStorm",
+            "linux": "webstorm or snap run webstorm",
+            "windows": "Start-Process webstorm64.exe"
+          },
+          "gate": "role == engineer && WebStorm installed"
+        },
+        {
+          "id": "healthCheck",
+          "type": "auto",
+          "command": "bash ~/.claude/scripts/health.sh (Mac/Linux) or health.ps1 (Win)"
+        }
+      ]
+    }
+  },
+  "stateFile": {
+    "mac": "~/Library/Application Support/Databayt/installer-state.json",
+    "linux": "${XDG_CONFIG_HOME:-~/.config}/databayt/installer-state.json",
+    "windows": "%APPDATA%\\Databayt\\installer-state.json",
+    "schema": {
+      "role": "string",
+      "gitName": "string",
+      "gitEmail": "string",
+      "gistId": "string",
+      "proMax": "0|1",
+      "withTailscale": "0|1",
+      "silentBatch": "done",
+      "desktopSignedIn": "0|1",
+      "computerUse": "0|1",
+      "vsCodeExt": "0|1",
+      "webstormPlugin": "0|1",
+      "lastStep": "string",
+      "timestamp": "ISO-8601"
+    },
+    "behavior": "On wizard start, read state file. If present, skip already-completed steps."
+  },
+  "deepLinks": {
+    "accessibilitySettings": {
+      "mac": "open 'x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility'",
+      "windows": "Start-Process ms-settings:easeofaccess",
+      "linux": "gnome-control-center privacy || systemsettings5 kcm_accessibility"
+    },
+    "claudeDesktop": {
+      "mac": "open -a Claude",
+      "windows": "Start-Process Claude.exe",
+      "linux": "n/a — Claude Desktop not on Linux"
+    },
+    "vsCodeExtension": {
+      "all": "code --install-extension anthropic.claude-code || vscode:extension/anthropic.claude-code"
+    },
+    "githubDeviceFlow": {
+      "all": "gh auth login --web"
+    },
+    "anthropicConsole": {
+      "all": "https://console.anthropic.com/settings/keys"
+    },
+    "mobileApps": {
+      "iOS": "https://apps.apple.com/app/claude-by-anthropic/id6473753684",
+      "Android": "https://play.google.com/store/apps/details?id=com.anthropic.claude"
+    }
+  }
+}

--- a/.claude/scripts/onboarding-linux.sh
+++ b/.claude/scripts/onboarding-linux.sh
@@ -1,0 +1,563 @@
+#!/bin/bash
+# =============================================================================
+# Computer Onboarding — Linux
+# =============================================================================
+# Fresh Linux box to fully working dev environment in one command.
+# Auto-detects distro (Debian/Ubuntu, Fedora/RHEL, Arch/Manjaro, openSUSE).
+#
+# Usage:
+#   bash onboarding-linux.sh <role> [gist_id] [flags]
+#
+# Roles:
+#   engineer | business | content | ops
+#
+# Flags:
+#   --quiet            Skip terminal prompts (for wrapper/CI use)
+#   --name <name>      Pre-supply git identity (skips prompt)
+#   --email <email>    Pre-supply git email (skips prompt)
+#   --essentials-only  Clone only kun/hogwarts/codebase (default: all org repos)
+#   --with-tailscale   Install Tailscale + 'tailscale up --ssh'
+#
+# One-liner:
+#   git clone https://github.com/databayt/kun.git ~/kun && bash ~/kun/.claude/scripts/onboarding-linux.sh engineer
+#
+# NOTE: Claude Desktop is NOT available for Linux. Linux users get:
+#   Claude Code CLI, OpenCode CLI, claude.ai/code in browser,
+#   plus VS Code/WebStorm Claude plugins.
+# =============================================================================
+
+set -e
+
+# ── Args ────────────────────────────────────────────────────────
+ROLE="" GIST_ID="" QUIET=0 GIT_NAME_ARG="" GIT_EMAIL_ARG=""
+WITH_TAILSCALE=0 ALL_REPOS=1
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --quiet)            QUIET=1; shift ;;
+        --name)             GIT_NAME_ARG="$2"; shift 2 ;;
+        --email)            GIT_EMAIL_ARG="$2"; shift 2 ;;
+        --with-tailscale)   WITH_TAILSCALE=1; shift ;;
+        --essentials-only)  ALL_REPOS=0; shift ;;
+        --*)                echo "Unknown flag: $1" >&2; exit 1 ;;
+        *)
+            if [[ -z "$ROLE" ]]; then ROLE="$1"
+            elif [[ -z "$GIST_ID" ]]; then GIST_ID="$1"
+            fi
+            shift ;;
+    esac
+done
+
+# ── Colors ──────────────────────────────────────────────────────
+R='\033[0;31m' G='\033[0;32m' Y='\033[1;33m' B='\033[0;34m'
+D='\033[2m' BD='\033[1m' NC='\033[0m'
+
+ERRORS=0
+pass() { echo -e "  ${G}✓${NC} $1"; }
+fail() { echo -e "  ${R}✗${NC} $1"; ERRORS=$((ERRORS + 1)); }
+info() { echo -e "  ${D}·${NC} $1"; }
+step() {
+    echo ""
+    echo -e "${BD}[$1/8]${NC} ${B}$2${NC}"
+    echo "PROGRESS:$1/8:$2" >&2
+}
+
+# ── Validate ────────────────────────────────────────────────────
+if [[ -z "$ROLE" ]]; then
+    echo -e "${BD}Computer Onboarding — Linux${NC}"
+    echo ""
+    echo "Usage: bash onboarding-linux.sh <role> [gist_id] [flags]"
+    echo ""
+    echo "Roles: engineer | business | content | ops"
+    echo ""
+    echo "Flags:"
+    echo "  --quiet            Skip terminal prompts"
+    echo "  --name <name>      Pre-supply git identity"
+    echo "  --email <email>    Pre-supply git email"
+    echo "  --essentials-only  Skip optional org repos"
+    echo "  --with-tailscale   Install Tailscale + 'up --ssh'"
+    echo ""
+    echo "One-liner:"
+    echo "  git clone https://github.com/databayt/kun.git ~/kun && bash ~/kun/.claude/scripts/onboarding-linux.sh engineer"
+    exit 0
+fi
+
+if [[ "$(uname -s)" != "Linux" ]]; then
+    echo -e "${R}This script is for Linux. Use onboarding-mac.sh or onboarding-windows.ps1.${NC}"
+    exit 1
+fi
+
+if [[ "$ROLE" != "engineer" && "$ROLE" != "business" && "$ROLE" != "content" && "$ROLE" != "ops" ]]; then
+    echo -e "${R}Invalid role: $ROLE${NC}"
+    echo "Valid: engineer, business, content, ops"
+    exit 1
+fi
+
+# ── Distro detect ───────────────────────────────────────────────
+DISTRO_ID="unknown"
+PKG=""
+PKG_INSTALL=""
+PKG_REFRESH=""
+if [[ -r /etc/os-release ]]; then
+    # shellcheck disable=SC1091
+    . /etc/os-release
+    DISTRO_ID="${ID:-unknown}"
+fi
+case "$DISTRO_ID" in
+    debian|ubuntu|linuxmint|pop|elementary)
+        PKG="apt"; PKG_REFRESH="sudo apt-get update -y"; PKG_INSTALL="sudo DEBIAN_FRONTEND=noninteractive apt-get install -y" ;;
+    fedora|rhel|centos|rocky|almalinux)
+        PKG="dnf"; PKG_REFRESH="sudo dnf check-update -y || true"; PKG_INSTALL="sudo dnf install -y" ;;
+    arch|manjaro|endeavouros)
+        PKG="pacman"; PKG_REFRESH="sudo pacman -Sy --noconfirm"; PKG_INSTALL="sudo pacman -S --noconfirm --needed" ;;
+    opensuse*|suse|sles)
+        PKG="zypper"; PKG_REFRESH="sudo zypper refresh"; PKG_INSTALL="sudo zypper install -y" ;;
+    *)
+        echo -e "${R}Unsupported distro: $DISTRO_ID${NC}"
+        echo "Supported: Debian/Ubuntu/Mint, Fedora/RHEL/Rocky, Arch/Manjaro, openSUSE"
+        exit 1 ;;
+esac
+
+# Per-distro package name overrides
+pkg_name() {
+    local generic="$1"
+    case "$PKG:$generic" in
+        pacman:gh) echo "github-cli" ;;
+        apt:python3-pip) echo "python3-pip" ;;
+        *) echo "$generic" ;;
+    esac
+}
+
+echo ""
+echo -e "${BD}Computer Onboarding — Linux ($DISTRO_ID / $PKG)${NC}"
+echo -e "Role: ${G}$ROLE${NC}"
+echo ""
+
+# =============================================================================
+# PHASE 1: System Foundation
+# =============================================================================
+step "1" "System Foundation — build tools, git, Node.js, pnpm, gh CLI"
+
+info "Refreshing package index..."
+eval "$PKG_REFRESH" >/dev/null 2>&1 || true
+
+# Build essentials
+case "$PKG" in
+    apt)    $PKG_INSTALL build-essential curl ca-certificates >/dev/null 2>&1 ;;
+    dnf)    $PKG_INSTALL '@development-tools' curl ca-certificates >/dev/null 2>&1 ;;
+    pacman) $PKG_INSTALL base-devel curl ca-certificates >/dev/null 2>&1 ;;
+    zypper) $PKG_INSTALL -t pattern devel_basis; $PKG_INSTALL curl ca-certificates >/dev/null 2>&1 ;;
+esac
+pass "Build tools"
+
+# Git
+if ! command -v git >/dev/null 2>&1; then
+    $PKG_INSTALL git >/dev/null 2>&1
+    pass "Git installed"
+else
+    pass "Git ($(git --version | cut -d' ' -f3))"
+fi
+
+# GitHub CLI (gh)
+if ! command -v gh >/dev/null 2>&1; then
+    info "Installing GitHub CLI..."
+    case "$PKG" in
+        apt)
+            # Use the official gh apt repo for current version
+            (type -p curl >/dev/null) && \
+            curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg >/dev/null 2>&1 && \
+            sudo chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg && \
+            echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null && \
+            sudo apt-get update -y >/dev/null 2>&1 && \
+            $PKG_INSTALL gh >/dev/null 2>&1
+            ;;
+        *)  $PKG_INSTALL "$(pkg_name gh)" >/dev/null 2>&1 ;;
+    esac
+    pass "GitHub CLI installed"
+else
+    pass "GitHub CLI"
+fi
+
+# Node.js via nvm (distro packages often lag — nvm gives us LTS reliably)
+if ! command -v node >/dev/null 2>&1; then
+    info "Installing nvm + Node 22 LTS..."
+    if [[ ! -d "$HOME/.nvm" ]]; then
+        curl -fsSL https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.1/install.sh | bash >/dev/null 2>&1
+    fi
+    export NVM_DIR="$HOME/.nvm"
+    # shellcheck disable=SC1091
+    [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"
+    nvm install --lts >/dev/null 2>&1
+    nvm use --lts >/dev/null 2>&1
+    pass "Node.js installed ($(node --version))"
+else
+    pass "Node.js ($(node --version))"
+fi
+
+# pnpm
+if ! command -v pnpm >/dev/null 2>&1; then
+    npm install -g pnpm >/dev/null 2>&1
+    pass "pnpm installed"
+else
+    pass "pnpm ($(pnpm --version))"
+fi
+
+# =============================================================================
+# PHASE 2: Applications (snap-first; fall back to direct install)
+# =============================================================================
+step "2" "Applications — VS Code, WebStorm, Chrome"
+
+# snap availability — preferred for desktop apps on Linux
+HAS_SNAP=0
+command -v snap >/dev/null 2>&1 && HAS_SNAP=1
+
+if [[ "$ROLE" == "engineer" ]]; then
+    # VS Code
+    if ! command -v code >/dev/null 2>&1; then
+        if [[ "$HAS_SNAP" == "1" ]]; then
+            sudo snap install code --classic >/dev/null 2>&1 && pass "VS Code (snap)" || info "VS Code snap install failed — install manually"
+        else
+            info "snap not available — install VS Code manually from https://code.visualstudio.com/"
+        fi
+    else
+        pass "VS Code"
+    fi
+
+    # WebStorm
+    if ! command -v webstorm >/dev/null 2>&1 && [[ ! -d "/snap/webstorm" ]]; then
+        if [[ "$HAS_SNAP" == "1" ]]; then
+            sudo snap install webstorm --classic >/dev/null 2>&1 && pass "WebStorm (snap)" || info "WebStorm snap install failed — install manually from jetbrains.com"
+        else
+            info "snap not available — install WebStorm manually from https://www.jetbrains.com/webstorm/"
+        fi
+    else
+        pass "WebStorm"
+    fi
+fi
+
+# Chrome — only via snap or manual install (no official package in most distros)
+if ! command -v google-chrome >/dev/null 2>&1 && ! command -v chromium >/dev/null 2>&1; then
+    case "$PKG" in
+        apt)
+            # Add Google's repo
+            curl -fsSL https://dl.google.com/linux/linux_signing_key.pub | sudo gpg --dearmor -o /usr/share/keyrings/google-chrome.gpg 2>/dev/null && \
+            echo "deb [arch=amd64 signed-by=/usr/share/keyrings/google-chrome.gpg] https://dl.google.com/linux/chrome/deb/ stable main" | sudo tee /etc/apt/sources.list.d/google-chrome.list >/dev/null && \
+            sudo apt-get update -y >/dev/null 2>&1 && \
+            $PKG_INSTALL google-chrome-stable >/dev/null 2>&1 && pass "Chrome installed" || info "Chrome skipped — install manually"
+            ;;
+        *)
+            info "Chrome — install from https://www.google.com/chrome/ (Chromium also available via $PKG)"
+            ;;
+    esac
+else
+    pass "Browser (Chrome/Chromium)"
+fi
+
+# =============================================================================
+# PHASE 3: GitHub
+# =============================================================================
+step "3" "GitHub — SSH key, authentication, git config"
+
+# Git identity
+GIT_NAME=$(git config --global user.name 2>/dev/null || echo "")
+if [[ -z "$GIT_NAME" ]]; then
+    if [[ -n "$GIT_NAME_ARG" ]]; then
+        GIT_NAME="$GIT_NAME_ARG"; GIT_EMAIL="$GIT_EMAIL_ARG"
+    elif [[ "$QUIET" == "1" ]]; then
+        GIT_NAME="$(whoami)"; GIT_EMAIL="$(whoami)@$(hostname -s).local"
+        info "Quiet mode — placeholder git identity (override via 'git config --global')"
+    else
+        read -p "  Full name (for git commits): " GIT_NAME
+        read -p "  Email (for git commits): " GIT_EMAIL
+    fi
+    git config --global user.name "$GIT_NAME"
+    git config --global user.email "$GIT_EMAIL"
+    pass "Git config: $GIT_NAME <$GIT_EMAIL>"
+else
+    pass "Git config: $GIT_NAME"
+fi
+
+# SSH key
+if [[ ! -f "$HOME/.ssh/id_ed25519" ]]; then
+    GIT_EMAIL_USE=$(git config --global user.email)
+    mkdir -p "$HOME/.ssh"
+    chmod 700 "$HOME/.ssh"
+    ssh-keygen -t ed25519 -C "$GIT_EMAIL_USE" -f "$HOME/.ssh/id_ed25519" -N "" >/dev/null
+    eval "$(ssh-agent -s)" >/dev/null
+    ssh-add "$HOME/.ssh/id_ed25519" 2>/dev/null
+    pass "SSH key generated"
+else
+    pass "SSH key exists"
+fi
+
+# GitHub auth
+if ! gh auth status >/dev/null 2>&1; then
+    info "Logging into GitHub (browser will open)..."
+    gh auth login -p ssh -w
+    pass "GitHub authenticated"
+else
+    GH_USER=$(gh api user --jq '.login' 2>/dev/null || echo "unknown")
+    pass "GitHub authenticated ($GH_USER)"
+fi
+
+# Push SSH key to GitHub
+KEY_FP=$(ssh-keygen -lf "$HOME/.ssh/id_ed25519.pub" 2>/dev/null | awk '{print $2}')
+if ! gh ssh-key list 2>/dev/null | grep -q "$KEY_FP"; then
+    HOSTNAME=$(hostname -s)
+    gh ssh-key add "$HOME/.ssh/id_ed25519.pub" --title "databayt-$HOSTNAME" 2>/dev/null && \
+        pass "SSH key on GitHub" || info "SSH key may already be on GitHub"
+else
+    pass "SSH key on GitHub"
+fi
+
+# =============================================================================
+# PHASE 4: Clone Repositories
+# =============================================================================
+step "4" "Clone Repositories"
+
+clone_repo() {
+    local repo="$1" dir="$HOME/$repo"
+    if [[ ! -d "$dir" ]]; then
+        git clone "git@github.com:databayt/$repo.git" "$dir" 2>/dev/null && pass "$repo" || {
+            git clone "https://github.com/databayt/$repo.git" "$dir" 2>/dev/null && pass "$repo (HTTPS)" || fail "$repo clone failed"
+        }
+    else
+        pass "$repo (exists)"
+    fi
+}
+
+clone_repo "kun"
+if [[ "$ROLE" == "engineer" ]]; then
+    clone_repo "hogwarts"
+    clone_repo "codebase"
+    if [[ "$ALL_REPOS" == "1" ]]; then
+        for repo in shadcn radix souq mkan shifa swift-app distributed-computer marketing; do
+            clone_repo "$repo"
+        done
+    fi
+fi
+
+# =============================================================================
+# PHASE 5: Claude Ecosystem (no Desktop on Linux)
+# =============================================================================
+step "5" "Claude — Code CLI + OpenCode (no Desktop on Linux)"
+
+# Claude Code CLI
+if ! command -v claude >/dev/null 2>&1; then
+    info "Installing Claude Code CLI..."
+    curl -fsSL https://claude.ai/install.sh | sh >/dev/null 2>&1
+    export PATH="$HOME/.local/bin:$PATH"
+    if ! grep -q ".local/bin" "$HOME/.bashrc" 2>/dev/null; then
+        printf '\n# Claude Code\nexport PATH="$HOME/.local/bin:$PATH"\n' >> "$HOME/.bashrc"
+    fi
+    pass "Claude Code CLI"
+else
+    pass "Claude Code CLI"
+fi
+
+# OpenCode (OSS alternative)
+if ! command -v opencode >/dev/null 2>&1; then
+    info "Installing OpenCode..."
+    curl -fsSL https://opencode.ai/install | bash >/dev/null 2>&1 || true
+    export PATH="$HOME/.opencode/bin:$PATH"
+    if ! grep -q ".opencode/bin" "$HOME/.bashrc" 2>/dev/null; then
+        printf '\n# OpenCode\nexport PATH="$HOME/.opencode/bin:$PATH"\n' >> "$HOME/.bashrc"
+    fi
+    command -v opencode >/dev/null 2>&1 && pass "OpenCode" || info "OpenCode install needs manual verify"
+else
+    pass "OpenCode"
+fi
+
+# `c` function in shell rc (bash + zsh if present)
+for RC in "$HOME/.bashrc" "$HOME/.zshrc"; do
+    [[ ! -f "$RC" ]] && continue
+    if ! grep -q "function c " "$RC" 2>/dev/null; then
+        cat >> "$RC" <<'CFUNC'
+
+# Claude Code
+function c  { claude --dangerously-skip-permissions "$@"; }
+function cc { claude "$@"; }
+[ -f "$HOME/.claude/.env" ] && set -a && . "$HOME/.claude/.env" && set +a
+CFUNC
+    fi
+done
+pass "Shell helpers (c, cc)"
+
+# AGENTS.md symlink for OpenCode
+if [[ -f "$HOME/kun/CLAUDE.md" && ! -e "$HOME/kun/AGENTS.md" ]]; then
+    ln -sf "$HOME/kun/CLAUDE.md" "$HOME/kun/AGENTS.md"
+    pass "AGENTS.md → CLAUDE.md symlink"
+fi
+
+# =============================================================================
+# PHASE 6: Kun Engine
+# =============================================================================
+step "6" "Kun Engine — agents, skills, MCP, rules"
+
+KUN_DIR="$HOME/kun"
+if [[ -f "$KUN_DIR/.claude/scripts/setup.sh" ]]; then
+    bash "$KUN_DIR/.claude/scripts/setup.sh" "$ROLE"
+    pass "Kun Engine ($ROLE)"
+else
+    fail "Kun repo missing setup.sh"
+fi
+
+# Secrets
+if [[ -n "$GIST_ID" && -f "$KUN_DIR/.claude/scripts/secrets.sh" ]]; then
+    bash "$KUN_DIR/.claude/scripts/secrets.sh" "$GIST_ID"
+    pass "Secrets loaded"
+else
+    info "Secrets skipped — run later: bash ~/kun/.claude/scripts/secrets.sh <GIST_ID>"
+fi
+
+# =============================================================================
+# PHASE 7: Hogwarts Local Dev
+# =============================================================================
+step "7" "Hogwarts — dependencies, database, seed"
+
+HOGWARTS_DIR="$HOME/hogwarts"
+
+if [[ "$ROLE" == "engineer" && -d "$HOGWARTS_DIR" ]]; then
+    cd "$HOGWARTS_DIR"
+
+    if [[ ! -f ".env" ]]; then
+        if [[ -f "$HOME/.claude/.env" ]]; then
+            cp "$HOME/.claude/.env" ".env"
+            pass ".env from secrets"
+        else
+            info ".env missing — need gist ID"
+        fi
+    else
+        pass ".env exists"
+    fi
+
+    info "Installing dependencies..."
+    pnpm install 2>&1 | tail -1
+    pass "pnpm install"
+
+    info "Generating Prisma client..."
+    npx prisma generate 2>&1 | tail -1
+    pass "Prisma client"
+
+    if grep -q "DATABASE_URL" ".env" 2>/dev/null; then
+        info "Pushing schema to database..."
+        npx prisma db push --skip-generate 2>&1 | tail -3
+        pass "Database schema"
+
+        info "Seeding database..."
+        pnpm db:seed 2>&1 | tail -3 || info "Seed may need manual run"
+    else
+        info "Database setup skipped — no DATABASE_URL"
+    fi
+
+    info "Testing build..."
+    if pnpm build 2>&1 | tail -3; then
+        pass "Build passes"
+    else
+        info "Build issues — run 'pnpm build' for details"
+    fi
+
+    cd "$HOME"
+else
+    if [[ "$ROLE" == "engineer" ]]; then
+        info "Hogwarts not cloned — skipped"
+    else
+        info "Hogwarts skipped (role: $ROLE)"
+    fi
+fi
+
+# =============================================================================
+# PHASE 8: Health Check
+# =============================================================================
+step "8" "Health Check"
+
+ERRORS=0
+command -v git >/dev/null 2>&1     && pass "git"      || fail "git"
+command -v node >/dev/null 2>&1    && pass "node"     || fail "node"
+command -v pnpm >/dev/null 2>&1    && pass "pnpm"     || fail "pnpm"
+command -v gh >/dev/null 2>&1      && pass "gh"       || fail "gh"
+command -v claude >/dev/null 2>&1  && pass "claude"   || fail "claude"
+command -v opencode >/dev/null 2>&1 && pass "opencode" || info "opencode (optional)"
+
+[[ -f "$HOME/.ssh/id_ed25519" ]]    && pass "SSH key"     || fail "SSH key"
+gh auth status >/dev/null 2>&1      && pass "GitHub auth" || fail "GitHub auth"
+
+[[ -d "$HOME/kun" ]]                && pass "kun repo"    || fail "kun"
+if [[ "$ROLE" == "engineer" ]]; then
+    [[ -d "$HOME/hogwarts" ]]       && pass "hogwarts"     || fail "hogwarts"
+    [[ -d "$HOME/codebase" ]]       && pass "codebase"     || fail "codebase"
+fi
+
+[[ -f "$HOME/.claude/CLAUDE.md" ]]   && pass "Kun CLAUDE.md"  || fail "Kun CLAUDE.md"
+[[ -f "$HOME/.claude/settings.json" ]] && pass "settings.json" || fail "settings.json"
+[[ -f "$HOME/.claude/mcp.json" ]]    && pass "mcp.json"        || fail "mcp.json"
+
+# =============================================================================
+# PHASE 9 (OPTIONAL): Tailscale
+# =============================================================================
+if [[ "$WITH_TAILSCALE" == "1" ]]; then
+    echo ""
+    echo -e "${BD}[+]${NC} ${B}Tailscale — remote SSH (optional)${NC}"
+    if ! command -v tailscale >/dev/null 2>&1; then
+        info "Installing Tailscale..."
+        curl -fsSL https://tailscale.com/install.sh | sh >/dev/null 2>&1 && pass "Tailscale installed" || info "Tailscale install skipped"
+    else
+        pass "Tailscale"
+    fi
+    if command -v tailscale >/dev/null 2>&1; then
+        if [[ "$QUIET" == "1" ]]; then
+            info "Run 'sudo tailscale up --ssh' after this completes (needs auth URL)"
+        else
+            sudo tailscale up --ssh 2>/dev/null && pass "Tailscale up" || info "Run 'sudo tailscale up --ssh' to enable"
+        fi
+    fi
+fi
+
+# =============================================================================
+# Done
+# =============================================================================
+echo ""
+echo -e "${BD}════════════════════════════════════════════${NC}"
+if [[ $ERRORS -eq 0 ]]; then
+    echo -e "${G}${BD}Linux onboarding complete!${NC} Role: $ROLE ($DISTRO_ID)"
+else
+    echo -e "${Y}${BD}Onboarding complete with $ERRORS issue(s)${NC}"
+fi
+echo -e "${BD}════════════════════════════════════════════${NC}"
+echo ""
+echo -e "${BD}Next steps:${NC}"
+echo "  1. Restart shell (or: source ~/.bashrc)"
+echo "  2. Run 'claude' → log in with Anthropic account"
+if command -v opencode >/dev/null 2>&1; then
+    echo "  3. (Optional) Configure OpenCode: 'opencode' → /connect → paste API key"
+fi
+if [[ -z "$GIST_ID" ]]; then
+    echo "  4. Load secrets later: bash ~/kun/.claude/scripts/secrets.sh <GIST_ID>"
+fi
+
+echo ""
+echo -e "${BD}Claude Desktop note:${NC}"
+echo "  Not available on Linux. Use:"
+echo "  • CLI: 'claude' / 'c' / 'opencode'"
+echo "  • Browser: https://claude.ai/code (same projects as CLI)"
+echo "  • IDE: install Claude plugin from VS Code/WebStorm Marketplace"
+
+if [[ "$ROLE" == "engineer" ]]; then
+    echo ""
+    echo -e "${BD}Run hogwarts:${NC}"
+    echo "  cd ~/hogwarts && pnpm dev"
+    echo "  http://localhost:3000  — login: admin@kingfahad.edu / 1234"
+fi
+
+echo ""
+echo -e "${BD}Mobile (Claude on iPhone/Android):${NC}"
+echo "  iOS:     https://apps.apple.com/app/claude-by-anthropic/id6473753684"
+echo "  Android: https://play.google.com/store/apps/details?id=com.anthropic.claude"
+
+if [[ "$WITH_TAILSCALE" != "1" ]]; then
+    echo ""
+    echo -e "${BD}Remote SSH (optional):${NC}"
+    echo "  Re-run with --with-tailscale to enable Tailscale SSH"
+fi
+
+echo ""
+echo -e "${D}Re-run: bash ~/kun/.claude/scripts/onboarding-linux.sh $ROLE${NC}"

--- a/.claude/scripts/onboarding-linux.sh
+++ b/.claude/scripts/onboarding-linux.sh
@@ -30,12 +30,13 @@ set -e
 
 # ── Args ────────────────────────────────────────────────────────
 ROLE="" GIST_ID="" QUIET=0 GIT_NAME_ARG="" GIT_EMAIL_ARG=""
-WITH_TAILSCALE=0 ALL_REPOS=1
+WITH_TAILSCALE=0 ALL_REPOS=1 REPOS_DIR="$HOME"
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --quiet)            QUIET=1; shift ;;
         --name)             GIT_NAME_ARG="$2"; shift 2 ;;
         --email)            GIT_EMAIL_ARG="$2"; shift 2 ;;
+        --repos-dir)        REPOS_DIR="$2"; shift 2 ;;
         --with-tailscale)   WITH_TAILSCALE=1; shift ;;
         --essentials-only)  ALL_REPOS=0; shift ;;
         --*)                echo "Unknown flag: $1" >&2; exit 1 ;;
@@ -46,6 +47,7 @@ while [[ $# -gt 0 ]]; do
             shift ;;
     esac
 done
+mkdir -p "$REPOS_DIR" 2>/dev/null || true
 
 # ── Colors ──────────────────────────────────────────────────────
 R='\033[0;31m' G='\033[0;32m' Y='\033[1;33m' B='\033[0;34m'
@@ -74,6 +76,7 @@ if [[ -z "$ROLE" ]]; then
     echo "  --name <name>      Pre-supply git identity"
     echo "  --email <email>    Pre-supply git email"
     echo "  --essentials-only  Skip optional org repos"
+    echo "  --repos-dir <dir>  Where to save databayt repos (default: \$HOME)"
     echo "  --with-tailscale   Install Tailscale + 'up --ssh'"
     echo ""
     echo "One-liner:"
@@ -315,7 +318,7 @@ fi
 step "4" "Clone Repositories"
 
 clone_repo() {
-    local repo="$1" dir="$HOME/$repo"
+    local repo="$1" dir="$REPOS_DIR/$repo"
     if [[ ! -d "$dir" ]]; then
         git clone "git@github.com:databayt/$repo.git" "$dir" 2>/dev/null && pass "$repo" || {
             git clone "https://github.com/databayt/$repo.git" "$dir" 2>/dev/null && pass "$repo (HTTPS)" || fail "$repo clone failed"
@@ -324,14 +327,20 @@ clone_repo() {
         pass "$repo (exists)"
     fi
 }
+symlink_home() {
+    local repo="$1"
+    [[ "$REPOS_DIR" == "$HOME" ]] && return
+    [[ -d "$REPOS_DIR/$repo" && ! -e "$HOME/$repo" ]] && \
+        ln -sf "$REPOS_DIR/$repo" "$HOME/$repo" && info "~/$repo → $REPOS_DIR/$repo"
+}
 
-clone_repo "kun"
+clone_repo "kun"; symlink_home "kun"
 if [[ "$ROLE" == "engineer" ]]; then
-    clone_repo "hogwarts"
-    clone_repo "codebase"
+    clone_repo "hogwarts"; symlink_home "hogwarts"
+    clone_repo "codebase"; symlink_home "codebase"
     if [[ "$ALL_REPOS" == "1" ]]; then
         for repo in shadcn radix souq mkan shifa swift-app distributed-computer marketing; do
-            clone_repo "$repo"
+            clone_repo "$repo"; symlink_home "$repo"
         done
     fi
 fi
@@ -414,7 +423,7 @@ fi
 # =============================================================================
 step "7" "Hogwarts — dependencies, database, seed"
 
-HOGWARTS_DIR="$HOME/hogwarts"
+HOGWARTS_DIR="$REPOS_DIR/hogwarts"
 
 if [[ "$ROLE" == "engineer" && -d "$HOGWARTS_DIR" ]]; then
     cd "$HOGWARTS_DIR"
@@ -481,10 +490,10 @@ command -v opencode >/dev/null 2>&1 && pass "opencode" || info "opencode (option
 [[ -f "$HOME/.ssh/id_ed25519" ]]    && pass "SSH key"     || fail "SSH key"
 gh auth status >/dev/null 2>&1      && pass "GitHub auth" || fail "GitHub auth"
 
-[[ -d "$HOME/kun" ]]                && pass "kun repo"    || fail "kun"
+[[ -d "$REPOS_DIR/kun" ]]                && pass "kun repo"    || fail "kun"
 if [[ "$ROLE" == "engineer" ]]; then
-    [[ -d "$HOME/hogwarts" ]]       && pass "hogwarts"     || fail "hogwarts"
-    [[ -d "$HOME/codebase" ]]       && pass "codebase"     || fail "codebase"
+    [[ -d "$REPOS_DIR/hogwarts" ]]       && pass "hogwarts"     || fail "hogwarts"
+    [[ -d "$REPOS_DIR/codebase" ]]       && pass "codebase"     || fail "codebase"
 fi
 
 [[ -f "$HOME/.claude/CLAUDE.md" ]]   && pass "Kun CLAUDE.md"  || fail "Kun CLAUDE.md"

--- a/.claude/scripts/onboarding-mac.sh
+++ b/.claude/scripts/onboarding-mac.sh
@@ -26,8 +26,28 @@
 
 set -e
 
-ROLE="${1:-}"
-GIST_ID="${2:-}"
+# Parse args — supports positional <role> [gist_id] plus optional --quiet/--name/--email
+ROLE="" GIST_ID="" QUIET=0 GIT_NAME_ARG="" GIT_EMAIL_ARG=""
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --quiet) QUIET=1; shift ;;
+        --name)  GIT_NAME_ARG="$2"; shift 2 ;;
+        --email) GIT_EMAIL_ARG="$2"; shift 2 ;;
+        --*)     echo "Unknown flag: $1" >&2; exit 1 ;;
+        *)
+            if [[ -z "$ROLE" ]]; then ROLE="$1"
+            elif [[ -z "$GIST_ID" ]]; then GIST_ID="$1"
+            fi
+            shift ;;
+    esac
+done
+
+# Wrapper-friendly progress marker (parsed by installer.sh for the progress dialog)
+if [[ "$QUIET" == "1" ]]; then
+    export NONINTERACTIVE=1
+    export HOMEBREW_NO_AUTO_UPDATE=1
+    export HOMEBREW_NO_ENV_HINTS=1
+fi
 
 # Colors
 R='\033[0;31m' G='\033[0;32m' Y='\033[1;33m' B='\033[0;34m'
@@ -36,19 +56,29 @@ D='\033[2m' BD='\033[1m' NC='\033[0m'
 pass() { echo -e "  ${G}✓${NC} $1"; }
 fail() { echo -e "  ${R}✗${NC} $1"; ERRORS=$((ERRORS + 1)); }
 info() { echo -e "  ${D}·${NC} $1"; }
-step() { echo ""; echo -e "${BD}[$1/8]${NC} ${B}$2${NC}"; }
+step() {
+    echo ""
+    echo -e "${BD}[$1/8]${NC} ${B}$2${NC}"
+    # Machine-parseable progress line for wrapper UIs (stderr so it doesn't pollute stdout)
+    echo "PROGRESS:$1/8:$2" >&2
+}
 
 # ── Validate ────────────────────────────────────────────────────
 if [[ -z "$ROLE" ]]; then
     echo -e "${BD}Computer Onboarding — macOS${NC}"
     echo ""
-    echo "Usage: bash onboarding-mac.sh <role> [gist_id]"
+    echo "Usage: bash onboarding-mac.sh <role> [gist_id] [--quiet] [--name <n>] [--email <e>]"
     echo ""
     echo "Roles:"
     echo "  engineer  — WebStorm, all repos, full Claude Code, hogwarts local dev"
     echo "  content   — Claude Desktop, translation, content tools"
     echo "  ops       — Monitoring, costs, incident tools"
     echo "  business  — Proposals, pricing, client workflows"
+    echo ""
+    echo "Flags:"
+    echo "  --quiet           Skip all terminal prompts (for wrapper/CI use)"
+    echo "  --name <name>     Pre-supply git identity (skips prompt)"
+    echo "  --email <email>   Pre-supply git email (skips prompt)"
     echo ""
     echo "One-liner:"
     echo "  git clone https://github.com/databayt/kun.git ~/kun && bash ~/kun/.claude/scripts/onboarding-mac.sh engineer"
@@ -81,9 +111,17 @@ step "1" "System Foundation — Xcode CLT, Homebrew, Git, Node.js, pnpm"
 # Xcode Command Line Tools
 if ! xcode-select -p &>/dev/null; then
     info "Installing Xcode Command Line Tools..."
-    xcode-select --install 2>/dev/null || true
-    echo -e "  ${Y}Xcode installer opened. Accept the license and wait for install.${NC}"
-    read -p "  Press Enter when done..."
+    if [[ "$QUIET" == "1" ]]; then
+        # Headless install — auto-accept license
+        touch /tmp/.com.apple.dt.CommandLineTools.installondemand.in-progress 2>/dev/null || true
+        PROD=$(softwareupdate -l 2>/dev/null | grep -E 'Command Line Tools' | awk -F'*' '{print $2}' | sed -e 's/^ *//' | head -1)
+        [[ -n "$PROD" ]] && softwareupdate -i "$PROD" --verbose 2>/dev/null || true
+        rm -f /tmp/.com.apple.dt.CommandLineTools.installondemand.in-progress
+    else
+        xcode-select --install 2>/dev/null || true
+        echo -e "  ${Y}Xcode installer opened. Accept the license and wait for install.${NC}"
+        read -p "  Press Enter when done..."
+    fi
 else
     pass "Xcode CLT"
 fi
@@ -91,7 +129,7 @@ fi
 # Homebrew
 if ! command -v brew &>/dev/null; then
     info "Installing Homebrew..."
-    /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+    NONINTERACTIVE=1 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
     if [[ -f "/opt/homebrew/bin/brew" ]]; then
         eval "$(/opt/homebrew/bin/brew shellenv)"
         echo 'eval "$(/opt/homebrew/bin/brew shellenv)"' >> "$HOME/.zprofile"
@@ -172,11 +210,18 @@ fi
 # =============================================================================
 step "3" "GitHub — SSH key, authentication, git config"
 
-# Git identity
+# Git identity — wrapper can pre-supply via --name/--email; quiet mode uses defaults if missing
 GIT_NAME=$(git config --global user.name 2>/dev/null || echo "")
 if [[ -z "$GIT_NAME" ]]; then
-    read -p "  Full name (for git commits): " GIT_NAME
-    read -p "  Email (for git commits): " GIT_EMAIL
+    if [[ -n "$GIT_NAME_ARG" ]]; then
+        GIT_NAME="$GIT_NAME_ARG"; GIT_EMAIL="$GIT_EMAIL_ARG"
+    elif [[ "$QUIET" == "1" ]]; then
+        GIT_NAME="$(whoami)"; GIT_EMAIL="$(whoami)@$(hostname -s).local"
+        info "Quiet mode — using placeholder git identity (override later via 'git config --global')"
+    else
+        read -p "  Full name (for git commits): " GIT_NAME
+        read -p "  Email (for git commits): " GIT_EMAIL
+    fi
     git config --global user.name "$GIT_NAME"
     git config --global user.email "$GIT_EMAIL"
     pass "Git config: $GIT_NAME <$GIT_EMAIL>"

--- a/.claude/scripts/onboarding-mac.sh
+++ b/.claude/scripts/onboarding-mac.sh
@@ -252,9 +252,9 @@ if [[ "$ROLE" == "engineer" ]]; then
 fi
 
 # =============================================================================
-# PHASE 5: Claude Ecosystem
+# PHASE 5: Claude Ecosystem + OpenCode
 # =============================================================================
-step "5" "Claude — CLI + Desktop"
+step "5" "Claude — CLI + Desktop + OpenCode (OSS alternative)"
 
 # Claude Code CLI
 if ! command -v claude &>/dev/null; then
@@ -278,6 +278,28 @@ if [[ ! -d "/Applications/Claude.app" ]]; then
     pass "Claude Desktop"
 else
     pass "Claude Desktop"
+fi
+
+# OpenCode — OSS alternative CLI (works with Anthropic API key or other providers)
+if ! command -v opencode &>/dev/null; then
+    info "Installing OpenCode (OSS alternative)..."
+    curl -fsSL https://opencode.ai/install | bash 2>&1 | tail -3 || true
+    # OpenCode installs to ~/.opencode/bin by default
+    export PATH="$HOME/.opencode/bin:$PATH"
+    if ! grep -q ".opencode/bin" "$HOME/.zshrc" 2>/dev/null; then
+        echo '' >> "$HOME/.zshrc"
+        echo '# OpenCode' >> "$HOME/.zshrc"
+        echo 'export PATH="$HOME/.opencode/bin:$PATH"' >> "$HOME/.zshrc"
+    fi
+    command -v opencode &>/dev/null && pass "OpenCode" || info "OpenCode install needs manual verify"
+else
+    pass "OpenCode"
+fi
+
+# Symlink AGENTS.md in kun repo so OpenCode reads the same doctrine as Claude Code
+if [[ -f "$HOME/kun/CLAUDE.md" && ! -e "$HOME/kun/AGENTS.md" ]]; then
+    ln -sf "$HOME/kun/CLAUDE.md" "$HOME/kun/AGENTS.md"
+    pass "AGENTS.md → CLAUDE.md symlink"
 fi
 
 # =============================================================================
@@ -376,6 +398,7 @@ command -v node &>/dev/null       && pass "node"       || fail "node"
 command -v pnpm &>/dev/null       && pass "pnpm"       || fail "pnpm"
 command -v gh &>/dev/null         && pass "gh"         || fail "gh"
 command -v claude &>/dev/null     && pass "claude"     || fail "claude"
+command -v opencode &>/dev/null   && pass "opencode"   || info "opencode (optional)"
 
 # Auth
 [[ -f "$HOME/.ssh/id_ed25519" ]]  && pass "SSH key"    || fail "SSH key"
@@ -411,14 +434,21 @@ fi
 echo -e "${BD}════════════════════════════════════════════${NC}"
 echo ""
 echo -e "${BD}Next steps:${NC}"
-echo "  1. Restart terminal"
+echo "  1. Restart terminal (or: . ~/.zshrc)"
 echo "  2. Run 'claude' → log in with Anthropic account"
 echo "  3. Open Claude Desktop → sign in"
+if command -v opencode &>/dev/null; then
+    echo "  4. (Optional) Configure OpenCode: 'opencode' → /connect → paste API key"
+fi
 if [[ -z "$GIST_ID" ]]; then
-    echo "  4. Get secrets gist ID from Abdout:"
+    echo "  5. Load secrets when you have the gist ID:"
     echo "     bash ~/kun/.claude/scripts/secrets.sh <GIST_ID>"
 fi
 if [[ "$ROLE" == "engineer" ]]; then
+    echo ""
+    echo -e "${BD}IDE plugins (manual install from Marketplace):${NC}"
+    echo "  • WebStorm: Settings → Plugins → search 'Claude Code' → Install"
+    echo "  • VS Code: Extensions → search 'Claude Code' → Install"
     echo ""
     echo -e "${BD}Run hogwarts:${NC}"
     echo "  cd ~/hogwarts && pnpm dev"

--- a/.claude/scripts/onboarding-mac.sh
+++ b/.claude/scripts/onboarding-mac.sh
@@ -28,12 +28,13 @@ set -e
 
 # Parse args — positional <role> [gist_id] plus optional flags
 ROLE="" GIST_ID="" QUIET=0 GIT_NAME_ARG="" GIT_EMAIL_ARG=""
-WITH_TAILSCALE=0 ALL_REPOS=1   # all-repos on by default; pass --essentials-only to skip
+WITH_TAILSCALE=0 ALL_REPOS=1 REPOS_DIR="$HOME"
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --quiet)            QUIET=1; shift ;;
         --name)             GIT_NAME_ARG="$2"; shift 2 ;;
-        --email)            GIT_EMAIL_ARG="$2"; shift 2 ;;
+        --email)             GIT_EMAIL_ARG="$2"; shift 2 ;;
+        --repos-dir)        REPOS_DIR="$2"; shift 2 ;;
         --with-tailscale)   WITH_TAILSCALE=1; shift ;;
         --essentials-only)  ALL_REPOS=0; shift ;;
         --*)                echo "Unknown flag: $1" >&2; exit 1 ;;
@@ -44,6 +45,7 @@ while [[ $# -gt 0 ]]; do
             shift ;;
     esac
 done
+mkdir -p "$REPOS_DIR" 2>/dev/null || true
 
 # Wrapper-friendly progress marker (parsed by installer.sh for the progress dialog)
 if [[ "$QUIET" == "1" ]]; then
@@ -83,6 +85,7 @@ if [[ -z "$ROLE" ]]; then
     echo "  --name <name>      Pre-supply git identity (skips prompt)"
     echo "  --email <email>    Pre-supply git email (skips prompt)"
     echo "  --essentials-only  Clone only kun/hogwarts/codebase (default: all org repos)"
+    echo "  --repos-dir <dir>  Where to save databayt org repos (default: \$HOME)"
     echo "  --with-tailscale   Install Tailscale + 'tailscale up --ssh' for remote/mobile"
     echo ""
     echo "One-liner:"
@@ -282,9 +285,9 @@ fi
 step "4" "Clone Repositories"
 
 clone_repo() {
-    local repo="$1" dir="$HOME/$repo"
+    local repo="$1" dir="$REPOS_DIR/$repo"
     if [[ ! -d "$dir" ]]; then
-        info "Cloning $repo..."
+        info "Cloning $repo → $dir..."
         git clone "git@github.com:databayt/$repo.git" "$dir" 2>/dev/null && \
             pass "$repo" || {
             git clone "https://github.com/databayt/$repo.git" "$dir" 2>/dev/null && \
@@ -295,16 +298,24 @@ clone_repo() {
     fi
 }
 
-clone_repo "kun"
-if [[ "$ROLE" == "engineer" ]]; then
-    clone_repo "hogwarts"
-    clone_repo "codebase"
+# Symlink helper — keeps ~/kun, ~/hogwarts etc working when REPOS_DIR is elsewhere
+symlink_home() {
+    local repo="$1"
+    [[ "$REPOS_DIR" == "$HOME" ]] && return
+    [[ -d "$REPOS_DIR/$repo" && ! -e "$HOME/$repo" ]] && \
+        ln -sf "$REPOS_DIR/$repo" "$HOME/$repo" && info "~/$repo → $REPOS_DIR/$repo"
+}
 
-    # Sync remaining databayt org repos via sync-repos.sh (idempotent — skips clones we already have)
-    if [[ "$ALL_REPOS" == "1" && -f "$HOME/kun/.claude/scripts/sync-repos.sh" ]]; then
-        info "Syncing remaining databayt org repos..."
+clone_repo "kun"; symlink_home "kun"
+
+if [[ "$ROLE" == "engineer" ]]; then
+    clone_repo "hogwarts"; symlink_home "hogwarts"
+    clone_repo "codebase"; symlink_home "codebase"
+
+    if [[ "$ALL_REPOS" == "1" ]]; then
+        info "Cloning remaining databayt org repos..."
         for repo in shadcn radix souq mkan shifa swift-app distributed-computer marketing; do
-            bash "$HOME/kun/.claude/scripts/sync-repos.sh" "$repo" >/dev/null 2>&1 && pass "$repo" || info "$repo skipped"
+            clone_repo "$repo"; symlink_home "$repo"
         done
     fi
 fi
@@ -408,7 +419,7 @@ fi
 # =============================================================================
 step "7" "Hogwarts — dependencies, database, seed"
 
-HOGWARTS_DIR="$HOME/hogwarts"
+HOGWARTS_DIR="$REPOS_DIR/hogwarts"
 
 if [[ "$ROLE" == "engineer" && -d "$HOGWARTS_DIR" ]]; then
     cd "$HOGWARTS_DIR"

--- a/.claude/scripts/onboarding-mac.sh
+++ b/.claude/scripts/onboarding-mac.sh
@@ -26,14 +26,17 @@
 
 set -e
 
-# Parse args — supports positional <role> [gist_id] plus optional --quiet/--name/--email
+# Parse args — positional <role> [gist_id] plus optional flags
 ROLE="" GIST_ID="" QUIET=0 GIT_NAME_ARG="" GIT_EMAIL_ARG=""
+WITH_TAILSCALE=0 ALL_REPOS=1   # all-repos on by default; pass --essentials-only to skip
 while [[ $# -gt 0 ]]; do
     case "$1" in
-        --quiet) QUIET=1; shift ;;
-        --name)  GIT_NAME_ARG="$2"; shift 2 ;;
-        --email) GIT_EMAIL_ARG="$2"; shift 2 ;;
-        --*)     echo "Unknown flag: $1" >&2; exit 1 ;;
+        --quiet)            QUIET=1; shift ;;
+        --name)             GIT_NAME_ARG="$2"; shift 2 ;;
+        --email)            GIT_EMAIL_ARG="$2"; shift 2 ;;
+        --with-tailscale)   WITH_TAILSCALE=1; shift ;;
+        --essentials-only)  ALL_REPOS=0; shift ;;
+        --*)                echo "Unknown flag: $1" >&2; exit 1 ;;
         *)
             if [[ -z "$ROLE" ]]; then ROLE="$1"
             elif [[ -z "$GIST_ID" ]]; then GIST_ID="$1"
@@ -76,9 +79,11 @@ if [[ -z "$ROLE" ]]; then
     echo "  business  — Proposals, pricing, client workflows"
     echo ""
     echo "Flags:"
-    echo "  --quiet           Skip all terminal prompts (for wrapper/CI use)"
-    echo "  --name <name>     Pre-supply git identity (skips prompt)"
-    echo "  --email <email>   Pre-supply git email (skips prompt)"
+    echo "  --quiet            Skip all terminal prompts (for wrapper/CI use)"
+    echo "  --name <name>      Pre-supply git identity (skips prompt)"
+    echo "  --email <email>    Pre-supply git email (skips prompt)"
+    echo "  --essentials-only  Clone only kun/hogwarts/codebase (default: all org repos)"
+    echo "  --with-tailscale   Install Tailscale + 'tailscale up --ssh' for remote/mobile"
     echo ""
     echo "One-liner:"
     echo "  git clone https://github.com/databayt/kun.git ~/kun && bash ~/kun/.claude/scripts/onboarding-mac.sh engineer"
@@ -294,6 +299,14 @@ clone_repo "kun"
 if [[ "$ROLE" == "engineer" ]]; then
     clone_repo "hogwarts"
     clone_repo "codebase"
+
+    # Sync remaining databayt org repos via sync-repos.sh (idempotent — skips clones we already have)
+    if [[ "$ALL_REPOS" == "1" && -f "$HOME/kun/.claude/scripts/sync-repos.sh" ]]; then
+        info "Syncing remaining databayt org repos..."
+        for repo in shadcn radix souq mkan shifa swift-app distributed-computer marketing; do
+            bash "$HOME/kun/.claude/scripts/sync-repos.sh" "$repo" >/dev/null 2>&1 && pass "$repo" || info "$repo skipped"
+        done
+    fi
 fi
 
 # =============================================================================
@@ -345,6 +358,28 @@ fi
 if [[ -f "$HOME/kun/CLAUDE.md" && ! -e "$HOME/kun/AGENTS.md" ]]; then
     ln -sf "$HOME/kun/CLAUDE.md" "$HOME/kun/AGENTS.md"
     pass "AGENTS.md → CLAUDE.md symlink"
+fi
+
+# Wire Claude Desktop MCP config to the same servers Claude Code uses
+# So Desktop's Chat/Cowork/Code tabs see the kun MCP fleet (shadcn, neon, github, etc.)
+DESKTOP_CFG_DIR="$HOME/Library/Application Support/Claude"
+DESKTOP_CFG="$DESKTOP_CFG_DIR/claude_desktop_config.json"
+if [[ -d "/Applications/Claude.app" && -f "$HOME/.claude/mcp.json" ]]; then
+    mkdir -p "$DESKTOP_CFG_DIR"
+    if [[ ! -e "$DESKTOP_CFG" ]]; then
+        ln -sf "$HOME/.claude/mcp.json" "$DESKTOP_CFG"
+        pass "Claude Desktop MCP config → ~/.claude/mcp.json"
+    elif [[ -L "$DESKTOP_CFG" ]]; then
+        pass "Claude Desktop MCP config (already symlinked)"
+    else
+        info "Claude Desktop config exists — leaving in place (delete to re-link to kun)"
+    fi
+fi
+
+# Ensure Apple Notes "Dispatch" folder exists so dispatch.sh has somewhere to write
+if [[ -d "/Applications/Notes.app" ]]; then
+    osascript -e 'tell application "Notes" to if not (exists folder "Dispatch") then make new folder with properties {name:"Dispatch"}' 2>/dev/null && \
+        pass "Apple Notes Dispatch folder" || info "Apple Notes Dispatch folder skipped"
 fi
 
 # =============================================================================
@@ -467,6 +502,28 @@ fi
 [[ -f "$HOME/.claude/mcp.json" ]]          && pass "mcp.json"        || fail "mcp.json"
 
 # =============================================================================
+# PHASE 9 (OPTIONAL): Tailscale — remote SSH for the iPhone / web Code lane
+# =============================================================================
+if [[ "$WITH_TAILSCALE" == "1" ]]; then
+    echo ""
+    echo -e "${BD}[+]${NC} ${B}Tailscale — remote SSH (optional)${NC}"
+    if ! command -v tailscale &>/dev/null; then
+        info "Installing Tailscale..."
+        brew install --cask tailscale 2>/dev/null && pass "Tailscale installed" || info "Tailscale install skipped"
+    else
+        pass "Tailscale"
+    fi
+    # tailscale up needs auth; in quiet mode print the auth URL and continue
+    if command -v tailscale &>/dev/null; then
+        if [[ "$QUIET" == "1" ]]; then
+            info "Run 'sudo tailscale up --ssh' after this completes (needs admin + auth URL)"
+        else
+            sudo tailscale up --ssh 2>/dev/null && pass "Tailscale up" || info "Run 'sudo tailscale up --ssh' to enable"
+        fi
+    fi
+fi
+
+# =============================================================================
 # Done
 # =============================================================================
 echo ""
@@ -500,5 +557,18 @@ if [[ "$ROLE" == "engineer" ]]; then
     echo "  http://localhost:3000"
     echo "  Admin: admin@kingfahad.edu / 1234"
 fi
+
+echo ""
+echo -e "${BD}Mobile (Claude on iPhone/Android):${NC}"
+echo "  iOS:     https://apps.apple.com/app/claude-by-anthropic/id6473753684"
+echo "  Android: https://play.google.com/store/apps/details?id=com.anthropic.claude"
+echo "  Sign in with the same Anthropic account → same projects everywhere"
+
+if [[ "$WITH_TAILSCALE" != "1" ]]; then
+    echo ""
+    echo -e "${BD}Remote SSH (optional):${NC}"
+    echo "  Re-run with --with-tailscale to enable Tailscale SSH for mobile/remote control"
+fi
+
 echo ""
 echo -e "${D}Re-run: bash ~/kun/.claude/scripts/onboarding-mac.sh $ROLE${NC}"

--- a/.claude/scripts/onboarding-windows.ps1
+++ b/.claude/scripts/onboarding-windows.ps1
@@ -24,7 +24,9 @@ param(
     [string]$GistId,
     [switch]$Quiet,
     [string]$GitName,
-    [string]$GitEmail
+    [string]$GitEmail,
+    [switch]$EssentialsOnly,    # default: clone all org repos
+    [switch]$WithTailscale       # optional: enable Tailscale SSH
 )
 
 $ErrorActionPreference = "Stop"
@@ -262,6 +264,14 @@ Clone-Repo "kun"
 if ($Role -eq "engineer") {
     Clone-Repo "hogwarts"
     Clone-Repo "codebase"
+
+    # Sync remaining databayt org repos (idempotent)
+    if (-not $EssentialsOnly) {
+        Info "Syncing remaining databayt org repos..."
+        foreach ($repo in @("shadcn", "radix", "souq", "mkan", "shifa", "swift-app", "distributed-computer", "marketing")) {
+            Clone-Repo $repo
+        }
+    }
 }
 
 # =============================================================================
@@ -322,6 +332,25 @@ if ((Test-Path $kunClaudeMd) -and -not (Test-Path $kunAgentsMd)) {
     } catch {
         Copy-Item $kunClaudeMd $kunAgentsMd
         Pass "AGENTS.md copied from CLAUDE.md"
+    }
+}
+
+# Wire Claude Desktop MCP config to the same servers Claude Code uses
+$desktopCfgDir = "$env:APPDATA\Claude"
+$desktopCfg = "$desktopCfgDir\claude_desktop_config.json"
+$kunMcp = "$CLAUDE_DIR\mcp.json"
+if ((Test-Path $kunMcp) -and ((Test-Path "$HOME_DIR\AppData\Local\Programs\claude-desktop\Claude.exe") -or (Test-Path "${env:ProgramFiles}\Claude\Claude.exe"))) {
+    New-Item -ItemType Directory -Force -Path $desktopCfgDir | Out-Null
+    if (-not (Test-Path $desktopCfg)) {
+        try {
+            New-Item -ItemType SymbolicLink -Path $desktopCfg -Target $kunMcp -EA Stop | Out-Null
+            Pass "Claude Desktop MCP -> ~/.claude/mcp.json"
+        } catch {
+            Copy-Item $kunMcp $desktopCfg
+            Pass "Claude Desktop MCP config copied"
+        }
+    } else {
+        Info "Claude Desktop config exists - leaving in place"
     }
 }
 
@@ -441,6 +470,27 @@ if (Test-Path "$CLAUDE_DIR\settings.json")   { Pass "settings.json" }  else { Fa
 if (Test-Path "$CLAUDE_DIR\mcp.json")        { Pass "mcp.json" }      else { Fail "mcp.json" }
 
 # =============================================================================
+# PHASE 9 (OPTIONAL): Tailscale - remote SSH for mobile / web Code lane
+# =============================================================================
+if ($WithTailscale) {
+    Write-Host ""
+    Write-Host "[+] Tailscale - remote SSH (optional)" -ForegroundColor Cyan
+    $hasTailscale = Get-Command tailscale -EA SilentlyContinue
+    if (-not $hasTailscale) {
+        Info "Installing Tailscale..."
+        winget install --id Tailscale.Tailscale @WingetFlags 2>$null
+        if ($?) { Pass "Tailscale installed" } else { Info "Tailscale install skipped" }
+    } else {
+        Pass "Tailscale"
+    }
+    if ($Quiet) {
+        Info "Run 'tailscale up --ssh' after this completes (needs admin)"
+    } else {
+        Start-Process "tailscale" "up --ssh" -Wait -NoNewWindow 2>$null
+    }
+}
+
+# =============================================================================
 # Done
 # =============================================================================
 Write-Host ""
@@ -474,5 +524,18 @@ if ($Role -eq "engineer") {
     Write-Host "  http://localhost:3000"
     Write-Host "  Admin: admin@kingfahad.edu / 1234"
 }
+
+Write-Host ""
+Write-Host "Mobile (Claude on iPhone/Android):" -ForegroundColor Cyan
+Write-Host "  iOS:     https://apps.apple.com/app/claude-by-anthropic/id6473753684"
+Write-Host "  Android: https://play.google.com/store/apps/details?id=com.anthropic.claude"
+Write-Host "  Sign in with the same Anthropic account -> same projects everywhere"
+
+if (-not $WithTailscale) {
+    Write-Host ""
+    Write-Host "Remote SSH (optional):" -ForegroundColor Cyan
+    Write-Host "  Re-run with -WithTailscale to enable Tailscale SSH for mobile/remote control"
+}
+
 Write-Host ""
 Write-Host "Re-run: & ~\kun\.claude\scripts\onboarding-windows.ps1 -Role $Role" -ForegroundColor DarkGray

--- a/.claude/scripts/onboarding-windows.ps1
+++ b/.claude/scripts/onboarding-windows.ps1
@@ -26,7 +26,8 @@ param(
     [string]$GitName,
     [string]$GitEmail,
     [switch]$EssentialsOnly,    # default: clone all org repos
-    [switch]$WithTailscale       # optional: enable Tailscale SSH
+    [switch]$WithTailscale,      # optional: enable Tailscale SSH
+    [string]$ReposDir = $env:USERPROFILE
 )
 
 $ErrorActionPreference = "Stop"
@@ -244,10 +245,12 @@ if ($keyContent) {
 # =============================================================================
 Step "4" "Clone Repositories"
 
+if (-not (Test-Path $ReposDir)) { New-Item -ItemType Directory -Force -Path $ReposDir | Out-Null }
+
 function Clone-Repo($repo) {
-    $dir = "$HOME_DIR\$repo"
+    $dir = "$ReposDir\$repo"
     if (-not (Test-Path $dir)) {
-        Info "Cloning $repo..."
+        Info "Cloning $repo -> $dir..."
         git clone "git@github.com:databayt/$repo.git" $dir 2>$null
         if (-not $?) {
             git clone "https://github.com/databayt/$repo.git" $dir 2>$null
@@ -259,17 +262,24 @@ function Clone-Repo($repo) {
         Pass "$repo (exists)"
     }
 }
+function Symlink-Home($repo) {
+    if ($ReposDir -eq $HOME_DIR) { return }
+    $target = "$ReposDir\$repo"
+    $link = "$HOME_DIR\$repo"
+    if ((Test-Path $target) -and -not (Test-Path $link)) {
+        try { New-Item -ItemType SymbolicLink -Path $link -Target $target -EA Stop | Out-Null; Info "$link -> $target" } catch {}
+    }
+}
 
-Clone-Repo "kun"
+Clone-Repo "kun"; Symlink-Home "kun"
 if ($Role -eq "engineer") {
-    Clone-Repo "hogwarts"
-    Clone-Repo "codebase"
+    Clone-Repo "hogwarts"; Symlink-Home "hogwarts"
+    Clone-Repo "codebase"; Symlink-Home "codebase"
 
-    # Sync remaining databayt org repos (idempotent)
     if (-not $EssentialsOnly) {
-        Info "Syncing remaining databayt org repos..."
+        Info "Cloning remaining databayt org repos..."
         foreach ($repo in @("shadcn", "radix", "souq", "mkan", "shifa", "swift-app", "distributed-computer", "marketing")) {
-            Clone-Repo $repo
+            Clone-Repo $repo; Symlink-Home $repo
         }
     }
 }
@@ -383,7 +393,7 @@ if ($GistId) {
 # =============================================================================
 Step "7" "Hogwarts — dependencies, database, seed"
 
-$HOGWARTS_DIR = "$HOME_DIR\hogwarts"
+$HOGWARTS_DIR = "$ReposDir\hogwarts"
 
 if ($Role -eq "engineer" -and (Test-Path $HOGWARTS_DIR)) {
     Push-Location $HOGWARTS_DIR

--- a/.claude/scripts/onboarding-windows.ps1
+++ b/.claude/scripts/onboarding-windows.ps1
@@ -241,9 +241,9 @@ if ($Role -eq "engineer") {
 }
 
 # =============================================================================
-# PHASE 5: Claude Ecosystem
+# PHASE 5: Claude Ecosystem + OpenCode
 # =============================================================================
-Step "5" "Claude — CLI + Desktop"
+Step "5" "Claude — CLI + Desktop + OpenCode (OSS alternative)"
 
 # Claude Code CLI
 $hasClaude = Get-Command claude -EA SilentlyContinue
@@ -264,6 +264,41 @@ if (-not (Test-Path $claudeDesktop) -and -not (Test-Path $claudeDesktop2)) {
     if ($?) { Pass "Claude Desktop" } else { Info "Claude Desktop — install from claude.ai/download" }
 } else {
     Pass "Claude Desktop"
+}
+
+# OpenCode — OSS alternative CLI (works with Anthropic API key or other providers)
+$hasOpenCode = Get-Command opencode -EA SilentlyContinue
+if (-not $hasOpenCode) {
+    Info "Installing OpenCode (OSS alternative)..."
+    $hasScoop = Get-Command scoop -EA SilentlyContinue
+    if ($hasScoop) {
+        scoop install opencode 2>$null
+    } else {
+        # Try winget; fall back to manual instructions
+        winget install --id sst.opencode -e --accept-source-agreements --accept-package-agreements 2>$null
+    }
+    $env:Path = [System.Environment]::GetEnvironmentVariable("Path", "Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path", "User")
+    if (Get-Command opencode -EA SilentlyContinue) {
+        Pass "OpenCode"
+    } else {
+        Info "OpenCode — install manually: scoop install opencode (or choco install opencode)"
+    }
+} else {
+    Pass "OpenCode"
+}
+
+# Symlink AGENTS.md in kun repo so OpenCode reads the same doctrine as Claude Code
+$kunClaudeMd = "$KUN_DIR\CLAUDE.md"
+$kunAgentsMd = "$KUN_DIR\AGENTS.md"
+if ((Test-Path $kunClaudeMd) -and -not (Test-Path $kunAgentsMd)) {
+    # SymbolicLink requires admin or Developer Mode; fall back to copy
+    try {
+        New-Item -ItemType SymbolicLink -Path $kunAgentsMd -Target $kunClaudeMd -EA Stop | Out-Null
+        Pass "AGENTS.md -> CLAUDE.md symlink"
+    } catch {
+        Copy-Item $kunClaudeMd $kunAgentsMd
+        Pass "AGENTS.md copied from CLAUDE.md"
+    }
 }
 
 # =============================================================================
@@ -360,6 +395,7 @@ if (Get-Command node -EA SilentlyContinue)   { Pass "node" }   else { Fail "node
 if (Get-Command pnpm -EA SilentlyContinue)   { Pass "pnpm" }   else { Fail "pnpm" }
 if (Get-Command gh -EA SilentlyContinue)     { Pass "gh" }     else { Fail "gh" }
 if (Get-Command claude -EA SilentlyContinue) { Pass "claude" } else { Fail "claude" }
+if (Get-Command opencode -EA SilentlyContinue) { Pass "opencode" } else { Info "opencode (optional)" }
 
 # Auth
 if (Test-Path "$HOME_DIR\.ssh\id_ed25519")   { Pass "SSH key" }    else { Fail "SSH key" }
@@ -393,14 +429,21 @@ if ($ERRORS -eq 0) {
 Write-Host ("=" * 45) -ForegroundColor Cyan
 Write-Host ""
 Write-Host "Next steps:" -ForegroundColor Cyan
-Write-Host "  1. Restart PowerShell"
+Write-Host "  1. Restart PowerShell (or: . `$PROFILE)"
 Write-Host "  2. Run 'claude' -> log in with Anthropic account"
 Write-Host "  3. Open Claude Desktop -> sign in"
+if (Get-Command opencode -EA SilentlyContinue) {
+    Write-Host "  4. (Optional) Configure OpenCode: 'opencode' -> /connect -> paste API key"
+}
 if (-not $GistId) {
-    Write-Host "  4. Get secrets gist ID from Abdout:"
+    Write-Host "  5. Load secrets when you have the gist ID:"
     Write-Host "     & ~\kun\.claude\scripts\secrets.ps1 -GistId <ID>"
 }
 if ($Role -eq "engineer") {
+    Write-Host ""
+    Write-Host "IDE plugins (manual install from Marketplace):" -ForegroundColor Cyan
+    Write-Host "  - WebStorm: Settings -> Plugins -> search 'Claude Code' -> Install"
+    Write-Host "  - VS Code:  Extensions -> search 'Claude Code' -> Install"
     Write-Host ""
     Write-Host "Run hogwarts:" -ForegroundColor Cyan
     Write-Host "  cd ~\hogwarts; pnpm dev"

--- a/.claude/scripts/onboarding-windows.ps1
+++ b/.claude/scripts/onboarding-windows.ps1
@@ -21,7 +21,10 @@
 param(
     [ValidateSet("engineer", "business", "content", "ops")]
     [string]$Role,
-    [string]$GistId
+    [string]$GistId,
+    [switch]$Quiet,
+    [string]$GitName,
+    [string]$GitEmail
 )
 
 $ErrorActionPreference = "Stop"
@@ -29,13 +32,18 @@ $ErrorActionPreference = "Stop"
 if (-not $Role) {
     Write-Host "Computer Onboarding — Windows" -ForegroundColor Cyan
     Write-Host ""
-    Write-Host "Usage: .\onboarding-windows.ps1 -Role <role> [-GistId <id>]"
+    Write-Host "Usage: .\onboarding-windows.ps1 -Role <role> [-GistId <id>] [-Quiet] [-GitName <n>] [-GitEmail <e>]"
     Write-Host ""
     Write-Host "Roles:"
     Write-Host "  engineer  — WebStorm, all repos, Claude Code CLI, hogwarts local dev"
     Write-Host "  content   — Claude Desktop, translation, content tools"
     Write-Host "  ops       — Monitoring, costs, incident tools"
     Write-Host "  business  — Proposals, pricing, client workflows"
+    Write-Host ""
+    Write-Host "Flags:"
+    Write-Host "  -Quiet                  Skip terminal prompts (for wrapper/CI use)"
+    Write-Host "  -GitName <name>         Pre-supply git identity (skips prompt)"
+    Write-Host "  -GitEmail <email>       Pre-supply git email (skips prompt)"
     Write-Host ""
     Write-Host "One-liner:"
     Write-Host '  git clone https://github.com/databayt/kun.git $HOME\kun; & $HOME\kun\.claude\scripts\onboarding-windows.ps1 -Role engineer'
@@ -50,11 +58,20 @@ $KUN_DIR = "$HOME_DIR\kun"
 function Pass($msg) { Write-Host "  + $msg" -ForegroundColor Green }
 function Fail($msg) { Write-Host "  x $msg" -ForegroundColor Red; $script:ERRORS++ }
 function Info($msg) { Write-Host "  . $msg" -ForegroundColor DarkGray }
-function Step($num, $msg) { Write-Host ""; Write-Host "[$num/8] $msg" -ForegroundColor Cyan }
+function Step($num, $msg) {
+    Write-Host ""
+    Write-Host "[$num/8] $msg" -ForegroundColor Cyan
+    # Machine-parseable progress line for wrapper UIs (stderr)
+    [Console]::Error.WriteLine("PROGRESS:${num}/8:${msg}")
+}
 function Pause-For($msg) {
+    if ($Quiet) { Info "$msg (quiet mode — skipped)"; return }
     Write-Host "  ! $msg" -ForegroundColor Yellow
     Read-Host "  Press Enter when done"
 }
+# Common winget flags; --silent + --disable-interactivity for unattended mode in -Quiet
+$WingetFlags = @("-e", "--accept-source-agreements", "--accept-package-agreements")
+if ($Quiet) { $WingetFlags += @("--silent", "--disable-interactivity") }
 
 Write-Host ""
 Write-Host "Computer Onboarding — Windows" -ForegroundColor Cyan
@@ -161,11 +178,18 @@ if (-not (Test-Path $chromePath) -and -not (Test-Path $chromePath86)) {
 # =============================================================================
 Step "3" "GitHub — SSH key, authentication, git config"
 
-# Git identity
+# Git identity — wrapper can pre-supply via -GitName/-GitEmail; quiet mode uses defaults if missing
 $gitName = git config --global user.name 2>$null
 if (-not $gitName) {
-    $gitName = Read-Host "  Full name (for git commits)"
-    $gitEmail = Read-Host "  Email (for git commits)"
+    if ($GitName) {
+        $gitName = $GitName; $gitEmail = $GitEmail
+    } elseif ($Quiet) {
+        $gitName = $env:USERNAME; $gitEmail = "$env:USERNAME@$env:COMPUTERNAME.local"
+        Info "Quiet mode — using placeholder git identity (override later via 'git config --global')"
+    } else {
+        $gitName = Read-Host "  Full name (for git commits)"
+        $gitEmail = Read-Host "  Email (for git commits)"
+    }
     git config --global user.name $gitName
     git config --global user.email $gitEmail
     Pass "Git config: $gitName <$gitEmail>"

--- a/content/docs/onboarding.mdx
+++ b/content/docs/onboarding.mdx
@@ -136,7 +136,7 @@ If something's missing the wizard skips that step and lists it under "things to 
 
 ---
 
-## Which repos you get {#which-repos-you-get}
+## Which repos you get
 
 The wizard clones every active databayt org repo to your chosen directory (`~/`, `~/databayt/`, or custom). Engineer role gets everything; other roles get just `kun`.
 

--- a/content/docs/onboarding.mdx
+++ b/content/docs/onboarding.mdx
@@ -18,8 +18,8 @@ Paste in a terminal. The wizard takes over.
 
 | OS | Command |
 |---|---|
-| **macOS / Linux** | `curl -fsSL https://kun.databayt.com/install \| bash` |
-| **Windows** (PowerShell) | `iwr https://kun.databayt.com/install.ps1 \| iex` |
+| **macOS / Linux** | `curl -fsSL https://kun.databayt.org/install \| bash` |
+| **Windows** (PowerShell) | `iwr https://kun.databayt.org/install.ps1 \| iex` |
 
 The bootstrap URL auto-detects your OS and dispatches to the right installer. No need to pick. Re-run anytime — it auto-resumes from where it left off via a state file.
 

--- a/content/docs/onboarding.mdx
+++ b/content/docs/onboarding.mdx
@@ -1,109 +1,242 @@
 ---
 title: Onboarding
-description: Install Cowork, let it do the rest
+description: Fresh machine to fully working dev environment in one paste
 ---
 
 # Onboarding
 
-> One install, one paste, one watch. Cowork drives every other step.
+> One install. One paste. One verify.
+> Every Claude surface working. Every tool installed. Every repo cloned. Every dotfile in place.
 
-The fastest path to running databayt on a fresh Windows laptop: install Claude Desktop (Cowork), turn on computer use, paste the team prompt, watch your machine set itself up.
-
-Plan ~60 minutes. **Pro or Max plan required** — computer use isn't on Team or Enterprise. Manual fallback at the bottom.
-
-## What you end up with
-
-- Claude Code CLI on `PATH`
-- Full `~/.claude/` config — every agent, skill, MCP server, hook, bin script
-- The `c` function — `claude --dangerously-skip-permissions` in one keystroke
-- WebStorm with the Claude Code [Beta] plugin
-- Every active databayt repo cloned to `%USERPROFILE%\projects\databayt\`
-- `claude doctor` green
+This guide takes a fresh laptop (Mac or Windows) to a fully provisioned databayt dev environment. The easy path uses Claude Desktop's computer-use to drive the rest. There is a script-driven path for engineers and a manual fallback that works without Pro/Max.
 
 ---
 
-## 1. Install Cowork
+## What you end up with
 
-Download and run the [Windows x64 installer](https://claude.ai/api/desktop/win32/x64/setup/latest/redirect) (or [ARM64](https://claude.ai/api/desktop/win32/arm64/setup/latest/redirect)).
+| Category | What |
+|---|---|
+| **Side-tools** | git, Node 22, pnpm, gh CLI, Chrome |
+| **IDEs** | WebStorm (with Claude plugin), VS Code (with Claude extension) |
+| **Claude — official** | Desktop (Chat/Cowork/Code tabs), Claude Code CLI, IDE integrations, `claude.ai/code` in browser |
+| **Claude — OSS alternative** | OpenCode CLI (free, multi-provider via API key) |
+| **Dotfiles** | SSH key (uploaded to GitHub), `~/.zshrc` (or `$PROFILE` on Windows) with the `c` function, `~/.gitconfig`, `~/.ssh/config` (Keychain on Mac) |
+| **Config** | `~/.claude/` — full kun engine config: agents, skills, MCP servers, hooks, rules, memory |
+| **Repos** | databayt org cloned to `~/<repo>` — kun, hogwarts, codebase (engineer role) |
+| **Secrets** | `~/.claude/.env` populated from the team's private Gist |
+| **Verified** | `claude doctor` green · `bash ~/.claude/scripts/health.sh` passes |
 
-Launch it, sign in with your Anthropic account. Confirm the bottom-left shows **Pro** or **Max**.
+---
 
-## 2. Turn on computer use
+## 0. Before you sit down (admin checklist)
 
-Settings → General → scroll to **Desktop app** → toggle **Allow Claude to use your computer**.
+What your inviter needs to grant or hand over *before* the install runs:
 
-First time Claude tries to control the screen, Windows prompts for accessibility access. Grant it. Reference: [Anthropic — computer use in Desktop](https://code.claude.com/docs/en/desktop#let-claude-use-your-computer).
+- [ ] **GitHub** — invite to the `databayt` org
+- [ ] **Anthropic account** — Pro/Max sub for the full Claude Desktop + CLI experience. Free is OK if you plan to use OpenCode + API key.
+- [ ] **Anthropic API key** — only if you'll use OpenCode (or want CLI access without Pro/Max)
+- [ ] **Secrets Gist ID** — handed over out-of-band (Signal, Notes, 1Password)
+- [ ] **Slack** — invite to `hogwarts-wve9301`
+- [ ] **AWS IAM** — `hogwarts-s3-uploader` access keys (engineer role only)
+- [ ] **Vercel** — team invite (engineer role only)
 
-## 3. Open the Code tab and paste this
+If something is missing you can still run the install — the script skips what it can't authenticate and lists what's left.
 
-Claude Desktop has three tabs — **Chat**, **Cowork**, **Code**. Computer use lives in **Code**. Start a new Code session and paste the prompt below.
+---
+
+## Choose your path
+
+| Path | Time | Requires | Best for |
+|---|---|---|---|
+| **Cowork-driven** | ~30 min, hands-off | Pro/Max sub | Anyone with Pro/Max — paste a prompt, Cowork drives the rest |
+| **Script-driven** | ~15-20 min | Nothing | Engineers; full control, no Pro/Max needed |
+| **Manual** | ~60 min | Nothing | Auditing what gets installed, or learning what each step does |
+
+---
+
+## Path A — Cowork-driven (easiest)
+
+### A.1 Install Claude Desktop
+
+| OS | Installer |
+|---|---|
+| Mac | [Universal](https://claude.ai/api/desktop/darwin/universal/setup/latest/redirect) |
+| Windows x64 | [x64](https://claude.ai/api/desktop/win32/x64/setup/latest/redirect) |
+| Windows ARM64 | [ARM64](https://claude.ai/api/desktop/win32/arm64/setup/latest/redirect) |
+
+Sign in with your Anthropic account. Confirm the bottom-left shows **Pro** or **Max**.
+
+### A.2 Enable computer-use in the Code tab
+
+Settings → General → scroll to **Desktop app** → toggle **Allow Claude to use your computer**. Grant accessibility access when prompted.
+
+Reference: [Anthropic — computer use in Desktop](https://code.claude.com/docs/en/desktop#let-claude-use-your-computer).
+
+### A.3 Open the Code tab and paste the prompt for your OS
+
+Claude Desktop has three tabs — **Chat**, **Cowork**, **Code**. Computer-use lives in **Code**. Start a new Code session and paste:
+
+#### Mac prompt
 
 ```text
-Set up this fresh Windows laptop for databayt with computer use.
+Set up this fresh Mac for databayt using computer-use.
 
 End state I want:
-- GitHub, JetBrains, and Claude (Pro/Max) accounts ready
-- Side-tools installed: git, Node 22, pnpm, gh CLI, PowerShell 7
+- git, Node 22, pnpm, gh CLI, Chrome, WebStorm, VS Code installed via Homebrew
+- SSH key generated and uploaded to GitHub
 - Claude Code CLI installed and signed in
-- The `c` function added to my $PROFILE so it survives new terminals
-- The databayt config installed at %USERPROFILE%\.claude\ (install.ps1 + secrets.ps1)
-- WebStorm installed with the Claude Code [Beta] plugin
-- Every active databayt repo cloned via sync-repos.ps1
-- `claude doctor` all green
+- OpenCode CLI installed (free OSS alternative)
+- Claude Desktop signed in (already done above)
+- Claude extension installed in VS Code
+- WebStorm opened so I can install the Claude plugin from the Marketplace
+- All databayt repos cloned to ~/
+- Kun engine config installed at ~/.claude/
+- Secrets loaded
+- `c` function added to ~/.zshrc
 
-Walk me through each step. Open the right app for me. Pause at every OAuth
-or browser screen so I sign in myself — your browser is view-only. Ask for
-my confirmation before any destructive command. I can press Esc to stop you.
+One-liner to do most of the work:
 
-One-liners you can use when you reach them:
+  git clone https://github.com/databayt/kun.git ~/kun && \
+    bash ~/kun/.claude/scripts/onboarding-mac.sh engineer <GIST_ID>
 
-  winget install Git.Git OpenJS.NodeJS.LTS GitHub.cli Microsoft.PowerShell
-  npm install -g pnpm
-  winget install Anthropic.ClaudeCode
-  irm https://raw.githubusercontent.com/databayt/codebase/main/.claude/scripts/install.ps1 | iex
-  & "$env:USERPROFILE\.claude\scripts\secrets.ps1" -GistId 68453b25fa9d28c94426c55c179b3838
-  winget install JetBrains.WebStorm
-  & "$env:USERPROFILE\.claude\scripts\sync-repos.ps1"
+Walk me through it. Pause at every OAuth or browser screen so I sign in myself.
+Press Esc to stop you anywhere. When done, run `claude doctor` and
+`bash ~/.claude/scripts/health.sh` and screenshot the results.
+```
 
-The `c` function block for $PROFILE:
+#### Windows prompt
 
-  function c  { claude --dangerously-skip-permissions $args }
-  function cc { claude $args }
-  if (Test-Path "$env:USERPROFILE\.claude\.env") {
-      Get-Content "$env:USERPROFILE\.claude\.env" | ForEach-Object {
-          if ($_ -and -not $_.StartsWith("#")) {
-              $parts = $_ -split "=", 2
-              if ($parts.Length -eq 2) {
-                  [Environment]::SetEnvironmentVariable($parts[0], $parts[1], "Process")
-              }
-          }
-      }
-  }
-  $env:Path = "$env:USERPROFILE\.claude\bin;" + $env:Path
+```text
+Set up this fresh Windows laptop for databayt using computer-use.
 
-When done, run `claude doctor`, screenshot the result, and list anything
-still pending or anything I owe (OAuth completions, plan upgrades, etc.).
+End state I want:
+- git, Node 22, pnpm, gh CLI, PowerShell 7, Chrome, WebStorm, VS Code installed
+- SSH key generated and uploaded to GitHub
+- Claude Code CLI installed and signed in
+- OpenCode CLI installed (free OSS alternative)
+- Claude Desktop signed in (already done above)
+- Claude extension installed in VS Code
+- WebStorm opened so I can install the Claude plugin from the Marketplace
+- All databayt repos cloned to %USERPROFILE%\
+- Kun engine config installed at %USERPROFILE%\.claude\
+- Secrets loaded
+- `c` function added to $PROFILE so it survives new terminals
+
+One-liner to do most of the work:
+
+  git clone https://github.com/databayt/kun.git $env:USERPROFILE\kun
+  & $env:USERPROFILE\kun\.claude\scripts\onboarding-windows.ps1 -Role engineer -GistId <GIST_ID>
+
+Walk me through it. Pause at every OAuth or browser screen so I sign in myself.
+Press Esc to stop you anywhere. When done, run `claude doctor` and
+`bash $env:USERPROFILE\.claude\scripts\health.ps1` and screenshot the results.
 ```
 
 Press **Esc** anywhere on screen to abort. Claude releases control and unhides your apps.
 
 ---
 
-## Manual fallback
+## Path B — Script-driven (engineer-friendly)
 
-For Team or Enterprise plans (no computer use), or when you'd rather type. Run these in PowerShell.
+### Mac
+
+```bash
+git clone https://github.com/databayt/kun.git ~/kun && \
+  bash ~/kun/.claude/scripts/onboarding-mac.sh engineer <GIST_ID>
+```
+
+### Windows
 
 ```powershell
-# Side-tools
-winget install Git.Git OpenJS.NodeJS.LTS GitHub.cli Microsoft.PowerShell
+git clone https://github.com/databayt/kun.git $env:USERPROFILE\kun
+& $env:USERPROFILE\kun\.claude\scripts\onboarding-windows.ps1 -Role engineer -GistId <GIST_ID>
+```
+
+The script runs 8 phases (~15-20 min): system foundation → applications → GitHub auth → clone repos → Claude + OpenCode → kun engine config → hogwarts local dev → health check.
+
+Re-run the same command anytime to update — it's idempotent.
+
+### Roles
+
+| Role | Skills | MCP servers | Hogwarts local | Best for |
+|---|---|---|---|---|
+| **engineer** | All 25 | All 18 | Yes | Building features, full agent fleet |
+| **business** | 11 (Cowork + Stripe + proposals) | 8 | No | Sales, deals, client workflows |
+| **content** | 11 (Cowork + translate + Figma) | 8 | No | Translation, content, R&D |
+| **ops** | 11 (monitor + costs + incident) | 9 | No | Infra, monitoring, incidents |
+
+---
+
+## Path C — Manual fallback
+
+For Team/Enterprise plans (no computer-use), no Pro/Max sub, or auditing what's installed.
+
+### Mac
+
+```bash
+# Side-tools via Homebrew
+brew install git node pnpm gh
+brew install --cask google-chrome webstorm visual-studio-code claude
+
+# Claude Code CLI (official)
+curl -fsSL https://claude.ai/install.sh | sh
+
+# OpenCode (OSS alternative — works with any LLM provider via API key)
+curl -fsSL https://opencode.ai/install | bash
+
+# Shell helpers — `c` function + PATH for Claude
+cat >> ~/.zshrc <<'EOF'
+
+# Claude Code
+function c  { claude --dangerously-skip-permissions "$@"; }
+function cc { claude "$@"; }
+export PATH="$HOME/.local/bin:$PATH"
+[ -f "$HOME/.claude/.env" ] && set -a && . "$HOME/.claude/.env" && set +a
+EOF
+. ~/.zshrc
+
+# GitHub auth + SSH key
+ssh-keygen -t ed25519 -C "you@databayt"
+gh auth login -p ssh -w
+gh ssh-key add ~/.ssh/id_ed25519.pub --title "databayt-$(hostname -s)"
+
+# Clone repos
+git clone git@github.com:databayt/kun.git ~/kun
+git clone git@github.com:databayt/hogwarts.git ~/hogwarts
+git clone git@github.com:databayt/codebase.git ~/codebase
+
+# Kun engine config (role-scoped)
+cd ~/kun && bash .claude/scripts/setup.sh engineer
+
+# Secrets (from the team's private Gist)
+bash ~/kun/.claude/scripts/secrets.sh <GIST_ID>
+
+# Verify
+claude doctor
+bash ~/.claude/scripts/health.sh
+```
+
+For Claude inside your editor: install the Claude extension from the VS Code Marketplace (`anthropic.claude-code`) and the Claude Code [Beta] plugin from the WebStorm Marketplace.
+
+### Windows
+
+```powershell
+# Side-tools via winget
+winget install Git.Git OpenJS.NodeJS.LTS GitHub.cli Microsoft.PowerShell Google.Chrome
+winget install JetBrains.WebStorm Microsoft.VisualStudioCode
 npm install -g pnpm
-gh auth login                                   # browser auth
 
-# Claude Code CLI
+# Claude Code CLI (official)
 winget install Anthropic.ClaudeCode
-claude                                          # browser sign-in
+claude    # first-run browser sign-in
 
-# c function — paste into $PROFILE, then `. $PROFILE`
+# OpenCode (OSS alternative)
+scoop install opencode    # or: choco install opencode
+
+# Shell helpers — `c` function via $PROFILE
+@'
+
+# Claude Code
 function c  { claude --dangerously-skip-permissions $args }
 function cc { claude $args }
 if (Test-Path "$env:USERPROFILE\.claude\.env") {
@@ -117,24 +250,73 @@ if (Test-Path "$env:USERPROFILE\.claude\.env") {
     }
 }
 $env:Path = "$env:USERPROFILE\.claude\bin;" + $env:Path
+'@ | Add-Content $PROFILE
+. $PROFILE
 
-# databayt config + secrets
-irm https://raw.githubusercontent.com/databayt/codebase/main/.claude/scripts/install.ps1 | iex
-& "$env:USERPROFILE\.claude\scripts\secrets.ps1" -GistId 68453b25fa9d28c94426c55c179b3838
+# GitHub auth + SSH key
+ssh-keygen -t ed25519 -C "you@databayt"
+gh auth login -p ssh -w
+gh ssh-key add "$env:USERPROFILE\.ssh\id_ed25519.pub" --title "databayt-$env:COMPUTERNAME"
 
-# WebStorm + plugin (install plugin from the Marketplace inside WebStorm)
-winget install JetBrains.WebStorm
+# Clone repos
+git clone git@github.com:databayt/kun.git $env:USERPROFILE\kun
+git clone git@github.com:databayt/hogwarts.git $env:USERPROFILE\hogwarts
+git clone git@github.com:databayt/codebase.git $env:USERPROFILE\codebase
 
-# Clone every active databayt repo
-& "$env:USERPROFILE\.claude\scripts\sync-repos.ps1"
+# Kun engine config (role-scoped)
+Set-Location $env:USERPROFILE\kun
+& .\.claude\scripts\setup.ps1 -Role engineer
+
+# Secrets
+& $env:USERPROFILE\kun\.claude\scripts\secrets.ps1 -GistId <GIST_ID>
 
 # Verify
-claude --version
 claude doctor
-Get-Command c
+& $env:USERPROFILE\.claude\scripts\health.ps1
 ```
 
-For hogwarts, your team contact shares the `.env` out-of-band (no `.env.example`).
+For hogwarts, your team contact shares the `.env` out-of-band — there is no `.env.example`.
+
+---
+
+## Surfaces — when to use which
+
+After install you have **seven Claude surfaces** plus **OpenCode** as a parallel CLI. Each has a sweet spot:
+
+| When you want to... | Use | Why |
+|---|---|---|
+| Plan, research, strategize | Desktop **Cowork** tab | Cloud agents — runs while you do other things |
+| Drive your own machine (install apps, fill forms, screenshots) | Desktop **Code** tab | Local computer-use |
+| Quick question, no tools | Desktop **Chat** | Fastest, no agents |
+| Build, deploy, fix code in terminal | **Claude Code CLI** — `claude` or `c` | Full kun config — agents, MCP, hooks, memory |
+| Inline AI in your editor | **VS Code** Claude extension or **WebStorm** Claude plugin | Edit + suggest in-place |
+| Mobile, web, or shared link | **claude.ai/code** in browser | Same projects as the CLI, no install needed |
+| OSS-aligned, multi-provider, pay-per-use | **OpenCode** — `opencode` | No Pro/Max needed; works with Anthropic API key, OpenAI, OpenRouter, others |
+
+Cowork and Claude Code share `~/.claude/` — same brain, two modes. Handoff happens via `~/.claude/bridge.md` and GitHub Issues. See [Cowork ↔ Code bridge](/docs/cowork).
+
+OpenCode reads `AGENTS.md` from the project root (kun ships one symlinked to `CLAUDE.md`). MCP servers configured in `~/.claude/mcp.json` work for both CLIs.
+
+---
+
+## Verify everything
+
+```bash
+# Kun config (cross-platform, ~5 sec)
+bash ~/.claude/scripts/health.sh
+
+# Claude CLI
+claude doctor
+
+# OpenCode CLI
+opencode --version
+
+# Hogwarts (engineer)
+cd ~/hogwarts && pnpm dev
+# Open http://localhost:3000  — login: admin@kingfahad.edu / 1234
+```
+
+`health.sh --report` posts your config status to a shared GitHub issue (`databayt/kun`, label `config-health`) for the team to see drift across machines.
 
 ---
 
@@ -142,7 +324,8 @@ For hogwarts, your team contact shares the `.env` out-of-band (no `.env.example`
 
 | Action | How |
 |--------|-----|
-| Open Claude in WebStorm | `Ctrl+Esc` or `Alt+Shift+C` |
+| Open Claude in WebStorm | `Cmd+Esc` (Mac) · `Ctrl+Esc` or `Alt+Shift+C` (Windows) |
+| Open Claude in VS Code | `Cmd+Shift+P` → `Claude: Chat` |
 | Start Claude in any terminal | `c` |
 | Synthesize company status | `c "/captain"` |
 | Capture an idea | `c "/idea <description>"` |
@@ -150,6 +333,7 @@ For hogwarts, your team contact shares the `.env` out-of-band (no `.env.example`
 | Send a note to the team | `c "/dispatch <message>"` |
 | Open a GitHub issue | `c "/issue"` |
 | Verify a production deploy | `c "/watch"` |
+| OSS alternative | `opencode` (in any repo with `AGENTS.md` or `CLAUDE.md`) |
 
 Full keyword list: [keywords](/docs/keywords).
 
@@ -157,13 +341,16 @@ Full keyword list: [keywords](/docs/keywords).
 
 ## Reference
 
-- [Computer use in Desktop](https://code.claude.com/docs/en/desktop#let-claude-use-your-computer)
-- [Claude Code — install detail](/docs/claude-code)
-- [Captain — decisions and delegation](/docs/captain)
+- [Claude Code — install detail and config](/docs/claude-code)
 - [Cowork ↔ Code bridge](/docs/cowork)
+- [Apps — Claude in Slack, Figma, Asana](/docs/apps)
+- [Captain — decisions and delegation](/docs/captain)
 - [Connectors — MCP catalog](/docs/connectors)
-- [Anthropic Directory](https://claude.ai/directory)
-- [Keywords — full vocabulary](/docs/keywords)
-- [Team — roles](/docs/team)
+- [Secrets — Gist-based provisioning](/docs/secrets)
+- [Self-hosting — Tailscale / tmux / Docker (optional)](/docs/self-hosting)
 - [Repositories — full org map](/docs/repositories)
+- [Keywords — full vocabulary](/docs/keywords)
+- [Computer-use in Desktop (Anthropic)](https://code.claude.com/docs/en/desktop#let-claude-use-your-computer)
+- [OpenCode](https://opencode.ai)
+- [Anthropic Directory](https://claude.ai/directory)
 - [Contributing — github-workflow rule](https://github.com/databayt/kun/blob/main/.claude/rules/github-workflow.md)

--- a/content/docs/onboarding.mdx
+++ b/content/docs/onboarding.mdx
@@ -5,235 +5,362 @@ description: Fresh machine to fully working dev environment in one paste
 
 # Onboarding
 
-> One install. One paste. One verify.
-> Every Claude surface working. Every tool installed. Every repo cloned. Every dotfile in place.
+> One paste. ~20 minutes mostly silent. ≤3 clicks at the end.
+> A fresh Mac, Windows, or Linux laptop becomes a fully provisioned databayt environment — every tool installed, every repo cloned, every Claude surface working.
 
-This guide takes a fresh laptop (Mac or Windows) to a fully provisioned databayt dev environment. The easy path uses Claude Desktop's computer-use to drive the rest. There is a script-driven path for engineers and a manual fallback that works without Pro/Max.
+This is the single source of truth for joining databayt. It covers every OS, every Claude surface, every dotfile, every external account. If something here doesn't match what you see on your machine, that's a bug — file an issue.
+
+---
+
+## The one-liner
+
+Paste in a terminal. The wizard takes over.
+
+| OS | Command |
+|---|---|
+| **macOS / Linux** | `curl -fsSL https://kun.databayt.com/install \| bash` |
+| **Windows** (PowerShell) | `iwr https://kun.databayt.com/install.ps1 \| iex` |
+
+The bootstrap URL auto-detects your OS and dispatches to the right installer. No need to pick. Re-run anytime — it auto-resumes from where it left off via a state file.
 
 ---
 
 ## What you end up with
 
+After the wizard finishes:
+
 | Category | What |
 |---|---|
-| **Side-tools** | git, Node 22, pnpm, gh CLI, Chrome |
-| **IDEs** | WebStorm (with Claude plugin), VS Code (with Claude extension) |
-| **Claude — official** | Desktop (Chat/Cowork/Code tabs), Claude Code CLI, IDE integrations, `claude.ai/code` in browser |
+| **Side-tools** | git, Node 22 LTS, pnpm, gh CLI, Chrome |
+| **IDEs** | WebStorm (+ Claude plugin), VS Code (+ Claude extension) |
+| **Claude — official** | Desktop (Chat / Cowork / Code tabs), Claude Code CLI, IDE integrations, `claude.ai/code` in browser, Mobile (iOS/Android) |
 | **Claude — OSS alternative** | OpenCode CLI (free, multi-provider via API key) |
-| **Dotfiles** | SSH key (uploaded to GitHub), `~/.zshrc` (or `$PROFILE` on Windows) with the `c` function, `~/.gitconfig`, `~/.ssh/config` (Keychain on Mac) |
-| **Config** | `~/.claude/` — full kun engine config: agents, skills, MCP servers, hooks, rules, memory |
-| **Repos** | databayt org cloned to `~/<repo>` — kun, hogwarts, codebase (engineer role) |
-| **Secrets** | `~/.claude/.env` populated from the team's private Gist |
-| **Verified** | `claude doctor` green · `bash ~/.claude/scripts/health.sh` passes |
+| **Dotfiles** | SSH key (uploaded to GitHub), `~/.zshrc` / `~/.bashrc` / `$PROFILE` with `c` function, `~/.gitconfig`, `~/.ssh/config` (Keychain on Mac) |
+| **Claude config** | `~/.claude/` — agents, skills, MCP servers, hooks, rules, memory; secrets in `~/.claude/.env` |
+| **Desktop ↔ CLI parity** | `claude_desktop_config.json` symlinked to `~/.claude/mcp.json` so Desktop tabs see the same MCP fleet |
+| **Repos** | The full databayt org cloned to your chosen directory (default: `~/<repo>`) — see [Repos table below](#which-repos-you-get) |
+| **Optional** | Tailscale SSH (remote control from phone/laptop), Apple Notes Dispatch folder (Mac) |
+| **Verified** | `claude doctor` green · `health.sh` reports 0 errors |
 
 ---
 
-## 0. Before you sit down (admin checklist)
+## Three paths
 
-What your inviter needs to grant or hand over *before* the install runs:
+Pick the one that fits.
+
+| Path | Time | Pro/Max needed? | Best for |
+|---|---|---|---|
+| **Wizard** (recommended) | ~5 min active, ~20 min wall | No | Anyone — guided UX, auto-resume, deep links to right OS surface |
+| **Script** | ~2 min active, ~15-20 min wall | No | Engineers who want one bash command, no dialogs |
+| **Manual** | ~60 min | No | Auditing what gets installed, or learning the parts |
+
+---
+
+## The wizard — three acts
+
+The wizard runs in three acts. Most is silent; you click only when a human is unavoidably needed.
+
+### Act 1 — Pre-flight (~60 seconds, dialog burst)
+
+The wizard auto-detects what it can and only asks for what it can't:
+
+| Question | Auto-detected when |
+|---|---|
+| Welcome / start | always shown |
+| GitHub account? | always asked (opens `github.com/join` if "No") |
+| Anthropic account? | always asked (opens `claude.ai/login` if "No") |
+| Role: engineer / business / content / ops | inferred from `~/.claude/mcp.json` if exists |
+| Full name, email (for git commits) | inferred from `git config --global` if set |
+| Secrets Gist ID | asked once, then persisted |
+| Pro/Max subscription? (affects Desktop tabs) | asked once |
+| Where to save databayt repos? | asked once: `Home root` / `~/databayt/` / `Custom...` |
+| Tailscale SSH? (remote control) | asked once |
+
+All answers persist in a state file. Re-runs skip questions already answered.
+
+### Act 2 — Silent batch (~15-20 minutes, progress notifications)
+
+Eight phases run in the background. You can minimize the terminal and do other work — the wizard fires native OS notifications as each phase advances.
+
+| Phase | What |
+|---|---|
+| 1 | System Foundation — build tools, git, Node 22 LTS, pnpm, gh CLI |
+| 2 | Applications — WebStorm, VS Code, Chrome (engineer role) |
+| 3 | GitHub — SSH key, `gh auth login --web`, key uploaded |
+| 4 | Clone Repositories — kun + (engineer: hogwarts, codebase, all org repos) |
+| 5 | Claude — Code CLI, Desktop (Mac/Win), OpenCode, Desktop MCP symlink, AGENTS.md, `c` function in shell |
+| 6 | Kun Engine — `setup.sh <role>` populates `~/.claude/`, `secrets.sh` pulls `.env` |
+| 7 | Hogwarts — pnpm install, prisma generate + push + seed, build verify (engineer only) |
+| 8 | Health Check — every tool / repo / config verified |
+| 9 (opt) | Tailscale — install + `up --ssh` if you opted in |
+
+Each phase emits `PROGRESS:N/8:label` to stderr; wrappers parse this and fire `osascript display notification` (Mac), `zenity --notification` (Linux), or `NotifyIcon` balloon (Windows).
+
+### Act 3 — Manual finishing (~3 clicks)
+
+What's left needs a human at the keyboard. Auto-polling OAuth means the only **manual clicks** are:
+
+| Step | Click count | Skipped when |
+|---|---|---|
+| Sign in to Claude Desktop | 1 (open + sign in) | not Pro/Max, or Linux |
+| Toggle computer-use in Desktop Settings | 1 | not Pro/Max, or Linux |
+| Install Claude Code plugin in WebStorm | 1 (if not auto) | not engineer role |
+| VS Code Claude extension | **0** | auto-installed via `code --install-extension` |
+| GitHub OAuth | **0** | `gh auth login --web` polls until done |
+| Anthropic CLI OAuth | **0** | `claude` first-run polls until done |
+
+The wizard uses **deep links** so each action button drops you exactly where you need to act:
+
+| Action | Mac | Windows | Linux |
+|---|---|---|---|
+| Accessibility settings | `open "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility"` | `Start-Process ms-settings:easeofaccess` | `gnome-control-center privacy` |
+| Claude Desktop | `open -a Claude` | `Start-Process "Claude.exe"` | n/a (no Linux app) |
+| WebStorm | `open -a WebStorm` | `Start-Process webstorm64.exe` | `webstorm` or `snap run webstorm` |
+| GitHub device flow | `open "https://github.com/login/device"` | `Start-Process` | `xdg-open` |
+
+---
+
+## Before you sit down — admin checklist
+
+What the inviter needs to grant or hand over before paste-time:
 
 - [ ] **GitHub** — invite to the `databayt` org
-- [ ] **Anthropic account** — Pro/Max sub for the full Claude Desktop + CLI experience. Free is OK if you plan to use OpenCode + API key.
-- [ ] **Anthropic API key** — only if you'll use OpenCode (or want CLI access without Pro/Max)
+- [ ] **Anthropic account** — Pro/Max sub for full Desktop + CLI experience (free works with OpenCode + API key)
+- [ ] **Anthropic API key** — only if using OpenCode (or no Pro/Max)
 - [ ] **Secrets Gist ID** — handed over out-of-band (Signal, Notes, 1Password)
 - [ ] **Slack** — invite to `hogwarts-wve9301`
-- [ ] **AWS IAM** — `hogwarts-s3-uploader` access keys (engineer role only)
+- [ ] **AWS IAM** — `hogwarts-s3-uploader` keys (engineer role only)
 - [ ] **Vercel** — team invite (engineer role only)
 
-If something is missing you can still run the install — the script skips what it can't authenticate and lists what's left.
+If something's missing the wizard skips that step and lists it under "things to do later" at the end.
 
 ---
 
-## Choose your path
+## Which repos you get {#which-repos-you-get}
 
-| Path | Time | Requires | Best for |
-|---|---|---|---|
-| **Cowork-driven** | ~30 min, hands-off | Pro/Max sub | Anyone with Pro/Max — paste a prompt, Cowork drives the rest |
-| **Script-driven** | ~15-20 min | Nothing | Engineers; full control, no Pro/Max needed |
-| **Manual** | ~60 min | Nothing | Auditing what gets installed, or learning what each step does |
+The wizard clones every active databayt org repo to your chosen directory (`~/`, `~/databayt/`, or custom). Engineer role gets everything; other roles get just `kun`.
+
+| Repo | Engineer | Business | Content | Ops |
+|---|:-:|:-:|:-:|:-:|
+| **kun** — the engine config | ✓ | ✓ | ✓ | ✓ |
+| **hogwarts** — multi-tenant LMS (flagship) | ✓ | | | |
+| **codebase** — patterns, agents, blocks | ✓ | | | |
+| **shadcn** — UI component library | ✓ | | | |
+| **radix** — UI primitives | ✓ | | | |
+| **souq** — e-commerce marketplace | ✓ | | | |
+| **mkan** — rentals + booking | ✓ | | | |
+| **shifa** — medical platform | ✓ | | | |
+| **swift-app** — iOS/Swift mobile | ✓ | | | |
+| **distributed-computer** — infra | ✓ | | | |
+| **marketing** — landing pages | ✓ | | | |
+
+When you pick a custom directory, the wizard symlinks `~/kun`, `~/hogwarts`, etc. back to it so all existing tooling that hard-codes `~/kun` keeps working.
+
+To skip the optional repos: pass `--essentials-only` (Mac/Linux) or `-EssentialsOnly` (Windows) — keeps just kun, hogwarts, codebase.
 
 ---
 
-## Path A — Cowork-driven (easiest)
+## The seven Claude surfaces
 
-### A.1 Install Claude Desktop
+After install you have **seven Claude surfaces** plus **OpenCode** as a parallel CLI. Each has a sweet spot:
 
-| OS | Installer |
+| Surface | When to use |
 |---|---|
-| Mac | [Universal](https://claude.ai/api/desktop/darwin/universal/setup/latest/redirect) |
-| Windows x64 | [x64](https://claude.ai/api/desktop/win32/x64/setup/latest/redirect) |
-| Windows ARM64 | [ARM64](https://claude.ai/api/desktop/win32/arm64/setup/latest/redirect) |
+| **Desktop Chat** | Quick question, no tools. Fastest reply. |
+| **Desktop Cowork** | Plan, research, strategize. Cloud agents — runs while you do other things. |
+| **Desktop Code** | Drive your own machine (install apps, fill forms, screenshots). Local computer-use. |
+| **Claude Code CLI** (`claude` / `c`) | Build, deploy, fix code in terminal. Full kun config — agents, MCP, hooks, memory. |
+| **VS Code extension** | Inline AI in your editor. `Cmd+Shift+P` → "Claude". |
+| **WebStorm plugin** | Inline AI in WebStorm. `Cmd+Esc` opens panel. |
+| **claude.ai/code** | Mobile, web, or shared link. Same projects as the CLI, no install needed. |
+| **OpenCode** (`opencode`) | OSS-aligned. Works with any LLM provider via API key. No Pro/Max needed. Reads kun's `AGENTS.md` (symlinked to `CLAUDE.md`) for project doctrine. |
 
-Sign in with your Anthropic account. Confirm the bottom-left shows **Pro** or **Max**.
+Cowork and Claude Code share `~/.claude/` — same brain, two modes. Handoff happens via `~/.claude/bridge.md` and GitHub Issues. See [Cowork ↔ Code bridge](/docs/cowork).
 
-### A.2 Enable computer-use in the Code tab
-
-Settings → General → scroll to **Desktop app** → toggle **Allow Claude to use your computer**. Grant accessibility access when prompted.
-
-Reference: [Anthropic — computer use in Desktop](https://code.claude.com/docs/en/desktop#let-claude-use-your-computer).
-
-### A.3 Open the Code tab and paste the prompt for your OS
-
-Claude Desktop has three tabs — **Chat**, **Cowork**, **Code**. Computer-use lives in **Code**. Start a new Code session and paste:
-
-#### Mac prompt
-
-```text
-Set up this fresh Mac for databayt using computer-use.
-
-End state I want:
-- git, Node 22, pnpm, gh CLI, Chrome, WebStorm, VS Code installed via Homebrew
-- SSH key generated and uploaded to GitHub
-- Claude Code CLI installed and signed in
-- OpenCode CLI installed (free OSS alternative)
-- Claude Desktop signed in (already done above)
-- Claude extension installed in VS Code
-- WebStorm opened so I can install the Claude plugin from the Marketplace
-- All databayt repos cloned to ~/
-- Kun engine config installed at ~/.claude/
-- Secrets loaded
-- `c` function added to ~/.zshrc
-
-One-liner to do most of the work:
-
-  git clone https://github.com/databayt/kun.git ~/kun && \
-    bash ~/kun/.claude/scripts/onboarding-mac.sh engineer <GIST_ID>
-
-Walk me through it. Pause at every OAuth or browser screen so I sign in myself.
-Press Esc to stop you anywhere. When done, run `claude doctor` and
-`bash ~/.claude/scripts/health.sh` and screenshot the results.
-```
-
-#### Windows prompt
-
-```text
-Set up this fresh Windows laptop for databayt using computer-use.
-
-End state I want:
-- git, Node 22, pnpm, gh CLI, PowerShell 7, Chrome, WebStorm, VS Code installed
-- SSH key generated and uploaded to GitHub
-- Claude Code CLI installed and signed in
-- OpenCode CLI installed (free OSS alternative)
-- Claude Desktop signed in (already done above)
-- Claude extension installed in VS Code
-- WebStorm opened so I can install the Claude plugin from the Marketplace
-- All databayt repos cloned to %USERPROFILE%\
-- Kun engine config installed at %USERPROFILE%\.claude\
-- Secrets loaded
-- `c` function added to $PROFILE so it survives new terminals
-
-One-liner to do most of the work:
-
-  git clone https://github.com/databayt/kun.git $env:USERPROFILE\kun
-  & $env:USERPROFILE\kun\.claude\scripts\onboarding-windows.ps1 -Role engineer -GistId <GIST_ID>
-
-Walk me through it. Pause at every OAuth or browser screen so I sign in myself.
-Press Esc to stop you anywhere. When done, run `claude doctor` and
-`bash $env:USERPROFILE\.claude\scripts\health.ps1` and screenshot the results.
-```
-
-Press **Esc** anywhere on screen to abort. Claude releases control and unhides your apps.
+Claude Desktop's three tabs share the same MCP fleet as the CLI because the wizard symlinks `claude_desktop_config.json` to `~/.claude/mcp.json`.
 
 ---
 
-## Path B — Script-driven (engineer-friendly)
+## Mobile (iOS + Android)
 
-### Mac
+After Claude Desktop is signed in, install the Claude mobile app and sign in with the same Anthropic account — your projects, conversations, and Cowork sessions are available everywhere.
+
+| Store | Link |
+|---|---|
+| iOS | https://apps.apple.com/app/claude-by-anthropic/id6473753684 |
+| Android | https://play.google.com/store/apps/details?id=com.anthropic.claude |
+
+Mobile is read-friendly for reviewing Cowork output on the go. For driving anything (typing prompts, kicking off agents), the desktop surfaces are still best.
+
+---
+
+## WebStorm Settings Sync
+
+To share team-standardized editor settings (code style, keymaps, inspection profiles, file templates):
+
+1. Open WebStorm → top-right account icon → **Sign in to your JetBrains Account**
+2. Sign in (your personal JetBrains account, or use the team account if you have one)
+3. Settings → **Backup and Sync** → **Enable Settings Sync** → choose what to sync
+
+Your settings then follow you to any machine where you sign in to the same JetBrains account. The team uses this for consistent code style across reviews — no need to re-configure per machine.
+
+Recommended sync scope: Code style, Inspection profiles, Live templates, Plugins, Keymaps. Skip system settings (per-machine).
+
+---
+
+## Remote control via Tailscale (optional)
+
+If you opt in (`--with-tailscale` / `-WithTailscale`), the wizard installs Tailscale and runs `tailscale up --ssh`. Once on the tailnet, you can:
+
+- SSH into your dev box from any device: `ssh you@<tailscale-name>`
+- Drive your laptop from your phone via Tailscale SSH + tmux
+- Run `claude` remotely as if you were at your desk
+
+Setup details: [Self-hosting — Tailscale / tmux / Docker](/docs/self-hosting).
+
+---
+
+## Apple Notes Dispatch (Mac only)
+
+The wizard creates a `Dispatch` folder in Apple Notes so `dispatch.sh` has somewhere to write captain-status notes. These sync to your iPhone via iCloud — you can read captain summaries on the go without opening Claude.
+
+See [Dispatch — Apple Notes bridge](/docs/dispatch).
+
+---
+
+## Script path (engineer)
+
+If you'd rather skip the wizard and run the silent backend directly:
 
 ```bash
+# Mac
 git clone https://github.com/databayt/kun.git ~/kun && \
   bash ~/kun/.claude/scripts/onboarding-mac.sh engineer <GIST_ID>
-```
 
-### Windows
+# Linux
+git clone https://github.com/databayt/kun.git ~/kun && \
+  bash ~/kun/.claude/scripts/onboarding-linux.sh engineer <GIST_ID>
 
-```powershell
+# Windows (PowerShell)
 git clone https://github.com/databayt/kun.git $env:USERPROFILE\kun
 & $env:USERPROFILE\kun\.claude\scripts\onboarding-windows.ps1 -Role engineer -GistId <GIST_ID>
 ```
 
-The script runs 8 phases (~15-20 min): system foundation → applications → GitHub auth → clone repos → Claude + OpenCode → kun engine config → hogwarts local dev → health check.
+Useful backend flags (Mac + Linux):
 
-Re-run the same command anytime to update — it's idempotent.
+| Flag | Purpose |
+|---|---|
+| `--quiet` | Skip terminal prompts (wrapper/CI use) |
+| `--name <name>` / `--email <email>` | Pre-supply git identity |
+| `--repos-dir <path>` | Where to save databayt repos (default: `$HOME`) |
+| `--essentials-only` | Skip optional org repos (just kun/hogwarts/codebase) |
+| `--with-tailscale` | Install Tailscale + `up --ssh` |
 
-### Roles
+PowerShell equivalents: `-Quiet`, `-GitName`, `-GitEmail`, `-ReposDir`, `-EssentialsOnly`, `-WithTailscale`.
 
-| Role | Skills | MCP servers | Hogwarts local | Best for |
-|---|---|---|---|---|
-| **engineer** | All 25 | All 18 | Yes | Building features, full agent fleet |
-| **business** | 11 (Cowork + Stripe + proposals) | 8 | No | Sales, deals, client workflows |
-| **content** | 11 (Cowork + translate + Figma) | 8 | No | Translation, content, R&D |
-| **ops** | 11 (monitor + costs + incident) | 9 | No | Infra, monitoring, incidents |
+Re-run anytime; idempotent.
 
 ---
 
-## Path C — Manual fallback
+## Manual fallback
 
-For Team/Enterprise plans (no computer-use), no Pro/Max sub, or auditing what's installed.
+For learning what the wizard does, or if both other paths fail. Pick your OS.
 
-### Mac
+### macOS
 
 ```bash
-# Side-tools via Homebrew
+# Side-tools
 brew install git node pnpm gh
 brew install --cask google-chrome webstorm visual-studio-code claude
 
-# Claude Code CLI (official)
+# Claude Code CLI
 curl -fsSL https://claude.ai/install.sh | sh
 
-# OpenCode (OSS alternative — works with any LLM provider via API key)
+# OpenCode (OSS alternative)
 curl -fsSL https://opencode.ai/install | bash
 
-# Shell helpers — `c` function + PATH for Claude
+# Shell helpers
 cat >> ~/.zshrc <<'EOF'
-
 # Claude Code
 function c  { claude --dangerously-skip-permissions "$@"; }
 function cc { claude "$@"; }
-export PATH="$HOME/.local/bin:$PATH"
+export PATH="$HOME/.local/bin:$HOME/.opencode/bin:$PATH"
 [ -f "$HOME/.claude/.env" ] && set -a && . "$HOME/.claude/.env" && set +a
 EOF
 . ~/.zshrc
 
-# GitHub auth + SSH key
+# GitHub auth + SSH
 ssh-keygen -t ed25519 -C "you@databayt"
 gh auth login -p ssh -w
 gh ssh-key add ~/.ssh/id_ed25519.pub --title "databayt-$(hostname -s)"
 
-# Clone repos
+# Repos
 git clone git@github.com:databayt/kun.git ~/kun
 git clone git@github.com:databayt/hogwarts.git ~/hogwarts
 git clone git@github.com:databayt/codebase.git ~/codebase
 
-# Kun engine config (role-scoped)
+# Kun config + secrets
 cd ~/kun && bash .claude/scripts/setup.sh engineer
-
-# Secrets (from the team's private Gist)
 bash ~/kun/.claude/scripts/secrets.sh <GIST_ID>
+
+# Desktop MCP parity
+ln -sf ~/.claude/mcp.json "$HOME/Library/Application Support/Claude/claude_desktop_config.json"
 
 # Verify
 claude doctor
 bash ~/.claude/scripts/health.sh
 ```
 
-For Claude inside your editor: install the Claude extension from the VS Code Marketplace (`anthropic.claude-code`) and the Claude Code [Beta] plugin from the WebStorm Marketplace.
+### Linux (Debian/Ubuntu shown — adapt for your distro)
 
-### Windows
+```bash
+# Side-tools
+sudo apt update && sudo apt install -y git curl build-essential ca-certificates
+
+# Node 22 via nvm
+curl -fsSL https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.1/install.sh | bash
+export NVM_DIR="$HOME/.nvm"; . "$NVM_DIR/nvm.sh"
+nvm install --lts && nvm use --lts
+npm install -g pnpm
+
+# GitHub CLI (Debian/Ubuntu)
+curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg
+echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list
+sudo apt update && sudo apt install -y gh
+
+# IDEs (snap)
+sudo snap install code --classic
+sudo snap install webstorm --classic
+
+# Claude Code + OpenCode (Claude Desktop NOT available on Linux)
+curl -fsSL https://claude.ai/install.sh | sh
+curl -fsSL https://opencode.ai/install | bash
+
+# Shell helpers (same as Mac block, but append to ~/.bashrc instead of ~/.zshrc)
+
+# GitHub auth, repos, kun config, secrets — same as Mac block
+
+# Verify
+claude doctor
+bash ~/.claude/scripts/health.sh
+```
+
+### Windows (PowerShell)
 
 ```powershell
-# Side-tools via winget
+# Side-tools
 winget install Git.Git OpenJS.NodeJS.LTS GitHub.cli Microsoft.PowerShell Google.Chrome
 winget install JetBrains.WebStorm Microsoft.VisualStudioCode
 npm install -g pnpm
 
-# Claude Code CLI (official)
+# Claude Code CLI
 winget install Anthropic.ClaudeCode
-claude    # first-run browser sign-in
+claude    # browser sign-in
 
-# OpenCode (OSS alternative)
+# OpenCode
 scoop install opencode    # or: choco install opencode
 
-# Shell helpers — `c` function via $PROFILE
+# Shell helpers — append to $PROFILE
 @'
 
 # Claude Code
@@ -253,22 +380,7 @@ $env:Path = "$env:USERPROFILE\.claude\bin;" + $env:Path
 '@ | Add-Content $PROFILE
 . $PROFILE
 
-# GitHub auth + SSH key
-ssh-keygen -t ed25519 -C "you@databayt"
-gh auth login -p ssh -w
-gh ssh-key add "$env:USERPROFILE\.ssh\id_ed25519.pub" --title "databayt-$env:COMPUTERNAME"
-
-# Clone repos
-git clone git@github.com:databayt/kun.git $env:USERPROFILE\kun
-git clone git@github.com:databayt/hogwarts.git $env:USERPROFILE\hogwarts
-git clone git@github.com:databayt/codebase.git $env:USERPROFILE\codebase
-
-# Kun engine config (role-scoped)
-Set-Location $env:USERPROFILE\kun
-& .\.claude\scripts\setup.ps1 -Role engineer
-
-# Secrets
-& $env:USERPROFILE\kun\.claude\scripts\secrets.ps1 -GistId <GIST_ID>
+# GitHub auth, repos, kun config, secrets — see PowerShell parallels in onboarding-windows.ps1
 
 # Verify
 claude doctor
@@ -279,44 +391,25 @@ For hogwarts, your team contact shares the `.env` out-of-band — there is no `.
 
 ---
 
-## Surfaces — when to use which
-
-After install you have **seven Claude surfaces** plus **OpenCode** as a parallel CLI. Each has a sweet spot:
-
-| When you want to... | Use | Why |
-|---|---|---|
-| Plan, research, strategize | Desktop **Cowork** tab | Cloud agents — runs while you do other things |
-| Drive your own machine (install apps, fill forms, screenshots) | Desktop **Code** tab | Local computer-use |
-| Quick question, no tools | Desktop **Chat** | Fastest, no agents |
-| Build, deploy, fix code in terminal | **Claude Code CLI** — `claude` or `c` | Full kun config — agents, MCP, hooks, memory |
-| Inline AI in your editor | **VS Code** Claude extension or **WebStorm** Claude plugin | Edit + suggest in-place |
-| Mobile, web, or shared link | **claude.ai/code** in browser | Same projects as the CLI, no install needed |
-| OSS-aligned, multi-provider, pay-per-use | **OpenCode** — `opencode` | No Pro/Max needed; works with Anthropic API key, OpenAI, OpenRouter, others |
-
-Cowork and Claude Code share `~/.claude/` — same brain, two modes. Handoff happens via `~/.claude/bridge.md` and GitHub Issues. See [Cowork ↔ Code bridge](/docs/cowork).
-
-OpenCode reads `AGENTS.md` from the project root (kun ships one symlinked to `CLAUDE.md`). MCP servers configured in `~/.claude/mcp.json` work for both CLIs.
-
----
-
 ## Verify everything
 
 ```bash
 # Kun config (cross-platform, ~5 sec)
-bash ~/.claude/scripts/health.sh
+bash ~/.claude/scripts/health.sh         # Mac/Linux
+& $env:USERPROFILE\.claude\scripts\health.ps1     # Windows
 
 # Claude CLI
 claude doctor
 
-# OpenCode CLI
+# OpenCode
 opencode --version
 
 # Hogwarts (engineer)
 cd ~/hogwarts && pnpm dev
-# Open http://localhost:3000  — login: admin@kingfahad.edu / 1234
+# Open http://localhost:3000 — login: admin@kingfahad.edu / 1234
 ```
 
-`health.sh --report` posts your config status to a shared GitHub issue (`databayt/kun`, label `config-health`) for the team to see drift across machines.
+`health.sh --report` posts your config status to a shared GitHub issue (`databayt/kun`, label `config-health`) so the team can see drift across machines.
 
 ---
 
@@ -324,18 +417,49 @@ cd ~/hogwarts && pnpm dev
 
 | Action | How |
 |--------|-----|
-| Open Claude in WebStorm | `Cmd+Esc` (Mac) · `Ctrl+Esc` or `Alt+Shift+C` (Windows) |
+| Open Claude in WebStorm | `Cmd+Esc` (Mac) · `Ctrl+Esc` or `Alt+Shift+C` (Windows/Linux) |
 | Open Claude in VS Code | `Cmd+Shift+P` → `Claude: Chat` |
 | Start Claude in any terminal | `c` |
 | Synthesize company status | `c "/captain"` |
 | Capture an idea | `c "/idea <description>"` |
-| Run the full pipeline | `c "/feature <name> [product]"` |
+| Run the full feature pipeline | `c "/feature <name> [product]"` |
 | Send a note to the team | `c "/dispatch <message>"` |
 | Open a GitHub issue | `c "/issue"` |
 | Verify a production deploy | `c "/watch"` |
-| OSS alternative | `opencode` (in any repo with `AGENTS.md` or `CLAUDE.md`) |
+| OSS alternative CLI | `opencode` (in any repo with `AGENTS.md` or `CLAUDE.md`) |
+| Mobile / browser | https://claude.ai/code |
 
 Full keyword list: [keywords](/docs/keywords).
+
+---
+
+## Auto-resume
+
+The wizard persists every choice to a state file so re-runs skip what's done:
+
+| OS | State file path |
+|---|---|
+| macOS | `~/Library/Application Support/Databayt/installer-state.json` |
+| Linux | `${XDG_CONFIG_HOME:-~/.config}/databayt/installer-state.json` |
+| Windows | `%APPDATA%\Databayt\installer-state.json` |
+
+To reset and start fresh: delete the state file, then re-run the bootstrap.
+
+---
+
+## Troubleshooting
+
+| Symptom | Fix |
+|---|---|
+| "command not found: c" | Restart shell or `source ~/.zshrc` (Mac/Linux), `. $PROFILE` (Windows) |
+| `claude doctor` red | Re-run `claude` to re-auth; check `~/.claude/settings.json` exists |
+| Hogwarts won't build | Confirm `.env` is present; re-run `secrets.sh <GIST_ID>` |
+| Claude Desktop tabs missing MCP servers | Check `claude_desktop_config.json` is a symlink to `~/.claude/mcp.json`; if not, fix manually |
+| GitHub clone fails on private repos | Run `gh auth login -p ssh -w` again, confirm the SSH key is on your GitHub account |
+| Wizard dialogs not appearing on Linux | Install `zenity` (`sudo apt install zenity`) or pass `--no-gui` for terminal mode |
+| Windows: "running scripts is disabled" | Bootstrap uses `Set-ExecutionPolicy Bypass -Scope Process` automatically; for direct invocations: `powershell -ExecutionPolicy Bypass -File <script>` |
+
+For anything else, file an issue at https://github.com/databayt/kun/issues.
 
 ---
 
@@ -348,9 +472,9 @@ Full keyword list: [keywords](/docs/keywords).
 - [Connectors — MCP catalog](/docs/connectors)
 - [Secrets — Gist-based provisioning](/docs/secrets)
 - [Self-hosting — Tailscale / tmux / Docker (optional)](/docs/self-hosting)
+- [Dispatch — Apple Notes bridge](/docs/dispatch)
 - [Repositories — full org map](/docs/repositories)
 - [Keywords — full vocabulary](/docs/keywords)
-- [Computer-use in Desktop (Anthropic)](https://code.claude.com/docs/en/desktop#let-claude-use-your-computer)
 - [OpenCode](https://opencode.ai)
 - [Anthropic Directory](https://claude.ai/directory)
 - [Contributing — github-workflow rule](https://github.com/databayt/kun/blob/main/.claude/rules/github-workflow.md)

--- a/src/app/install.ps1/route.ts
+++ b/src/app/install.ps1/route.ts
@@ -1,0 +1,25 @@
+// Serves the Windows bootstrap shim at https://kun.databayt.org/install.ps1
+//   iwr https://kun.databayt.org/install.ps1 | iex
+// Canonical copy also lives at web/install.ps1 for reference.
+
+const SHIM = `# Databayt - Windows installer dispatcher
+# https://kun.databayt.org/install.ps1
+$ErrorActionPreference = "Stop"
+
+$installerUrl = "https://raw.githubusercontent.com/databayt/kun/main/.claude/scripts/installer.ps1"
+
+Write-Host "Detected Windows - launching installer..." -ForegroundColor Cyan
+
+Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass -Force
+
+Invoke-WebRequest -UseBasicParsing -Uri $installerUrl | Invoke-Expression
+`;
+
+export function GET() {
+  return new Response(SHIM, {
+    headers: {
+      "Content-Type": "text/plain; charset=utf-8",
+      "Cache-Control": "no-cache, no-store, must-revalidate",
+    },
+  });
+}

--- a/src/app/install/route.ts
+++ b/src/app/install/route.ts
@@ -1,17 +1,10 @@
-#!/usr/bin/env bash
-# =============================================================================
-# Databayt — OS-detect installer dispatcher
-# =============================================================================
-# Hosted at https://kun.databayt.org/install
-# Detects uname and curl-pipes the right platform installer.
-#
-# Bootstrap (Mac / Linux):
-#   curl -fsSL https://kun.databayt.org/install | bash
-#
-# For Windows, use:
-#   iwr https://kun.databayt.org/install.ps1 | iex
-# =============================================================================
+// Serves the OS-detect bootstrap shim at https://kun.databayt.org/install
+//   curl -fsSL https://kun.databayt.org/install | bash
+// Canonical copy also lives at web/install.sh for reference.
 
+const SHIM = `#!/usr/bin/env bash
+# Databayt — OS-detect installer dispatcher
+# https://kun.databayt.org/install
 set -e
 
 REPO_RAW="https://raw.githubusercontent.com/databayt/kun/main"
@@ -38,5 +31,14 @@ case "$(uname -s)" in
         ;;
 esac
 
-# Stream the platform installer through bash. Pass any extra args via $@.
 curl -fsSL "$URL" | bash -s -- "$@"
+`;
+
+export function GET() {
+  return new Response(SHIM, {
+    headers: {
+      "Content-Type": "text/x-shellscript; charset=utf-8",
+      "Cache-Control": "no-cache, no-store, must-revalidate",
+    },
+  });
+}

--- a/web/install.ps1
+++ b/web/install.ps1
@@ -1,0 +1,21 @@
+# =============================================================================
+# Databayt - Windows installer dispatcher
+# =============================================================================
+# Hosted at https://kun.databayt.com/install.ps1
+# Downloads and runs the WPF installer wrapper.
+#
+# Bootstrap:
+#   iwr https://kun.databayt.com/install.ps1 | iex
+# =============================================================================
+
+$ErrorActionPreference = "Stop"
+
+$installerUrl = "https://raw.githubusercontent.com/databayt/kun/main/.claude/scripts/installer.ps1"
+
+Write-Host "Detected Windows - launching installer..." -ForegroundColor Cyan
+
+# Bypass execution policy for this session only (safer than persistent change)
+Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass -Force
+
+# Download + execute. Using iex on raw script keeps the bootstrap one-line.
+Invoke-WebRequest -UseBasicParsing -Uri $installerUrl | Invoke-Expression

--- a/web/install.ps1
+++ b/web/install.ps1
@@ -1,11 +1,11 @@
 # =============================================================================
 # Databayt - Windows installer dispatcher
 # =============================================================================
-# Hosted at https://kun.databayt.com/install.ps1
+# Hosted at https://kun.databayt.org/install.ps1
 # Downloads and runs the WPF installer wrapper.
 #
 # Bootstrap:
-#   iwr https://kun.databayt.com/install.ps1 | iex
+#   iwr https://kun.databayt.org/install.ps1 | iex
 # =============================================================================
 
 $ErrorActionPreference = "Stop"

--- a/web/install.sh
+++ b/web/install.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# =============================================================================
+# Databayt — OS-detect installer dispatcher
+# =============================================================================
+# Hosted at https://kun.databayt.com/install
+# Detects uname and curl-pipes the right platform installer.
+#
+# Bootstrap (Mac / Linux):
+#   curl -fsSL https://kun.databayt.com/install | bash
+#
+# For Windows, use:
+#   iwr https://kun.databayt.com/install.ps1 | iex
+# =============================================================================
+
+set -e
+
+REPO_RAW="https://raw.githubusercontent.com/databayt/kun/main"
+
+case "$(uname -s)" in
+    Darwin)
+        URL="$REPO_RAW/.claude/scripts/installer.sh"
+        echo "Detected macOS — launching installer..."
+        ;;
+    Linux)
+        URL="$REPO_RAW/.claude/scripts/installer-linux.sh"
+        echo "Detected Linux — launching installer..."
+        ;;
+    MINGW*|CYGWIN*|MSYS*)
+        echo "Detected Windows shell environment." >&2
+        echo "Please run from PowerShell instead:" >&2
+        echo "  iwr https://kun.databayt.com/install.ps1 | iex" >&2
+        exit 1
+        ;;
+    *)
+        echo "Unsupported OS: $(uname -s)" >&2
+        echo "Supported: macOS, Linux. For Windows, use install.ps1." >&2
+        exit 1
+        ;;
+esac
+
+# Stream the platform installer through bash. Pass any extra args via $@.
+curl -fsSL "$URL" | bash -s -- "$@"


### PR DESCRIPTION
## Summary

Silent-first guided onboarding wizard for **Mac, Windows, and Linux**, replacing the unreliable Cowork-driven Windows flow. One bootstrap one-liner auto-detects OS; most of the install runs silently; a human is only needed for ≤3 unavoidable clicks. Also serves the bootstrap shim from the kun app at **kun.databayt.org/install**.

> Supersedes PR #52 (auto-closed when its stacked base branch merged). Rebased onto `main`.

## What ships

**Backends (silent worker layer):**
- `onboarding-mac.sh` / `onboarding-windows.ps1` — `--quiet`/`-Quiet`, `--repos-dir`, `--with-tailscale`, `--essentials-only`, git-identity flags. All-org repo clone, Claude Desktop MCP symlink, Apple Notes Dispatch folder, optional Tailscale phase, PROGRESS:N/8 stderr stream.
- **NEW** `onboarding-linux.sh` — distro-detect (apt/dnf/pacman/zypper), Node via nvm, snap IDEs, no Claude Desktop.

**Wrappers (UX layer, 3-act flow, zero new deps):**
- **NEW** `installer.sh` (Mac, osascript), `installer-linux.sh` (zenity/kdialog/TUI), `installer.ps1` (WPF). Pre-flight auto-detection, silent batch with notifications, deep-link finishing dialogs, state-file auto-resume.

**Bootstrap + serving:**
- **NEW** `web/install.sh` + `web/install.ps1` OS-detect shims
- **NEW** `src/app/install/route.ts` + `src/app/install.ps1/route.ts` — serve the shim at kun.databayt.org/install with correct Content-Type (verified on preview via `vercel curl`)
- **NEW** `lib/wizard-steps.json` step catalog

**Account + repo-location guidance (Act 1):** GitHub + Anthropic account checks (open signup if missing), "where to save repos" choice (home / ~/databayt/ / custom) threaded through all backends with home-root symlinks.

**Docs:** `content/docs/onboarding.mdx` rewritten as the single source of truth (one-liner, what-you-get, three paths, three-act walkthrough, repos-per-role, seven Claude surfaces, mobile, WebStorm Settings Sync, Tailscale, Dispatch, per-OS manual fallback, troubleshooting).

## Live activation

`kun.databayt.org` is attached to the kun Vercel project. Merging this PR to `main` auto-deploys, making the bootstrap live:
```bash
curl -fsSL https://kun.databayt.org/install | bash      # Mac/Linux
iwr https://kun.databayt.org/install.ps1 | iex          # Windows
```

## Test plan

- [x] `pnpm build` passes; `/install` + `/install.ps1` compile as dynamic routes
- [x] Both routes verified serving correct shim on preview deploy (`vercel curl`)
- [x] All bash scripts pass `bash -n`; wizard-steps.json parses
- [ ] Bootstrap on fresh Mac / Ubuntu / Fedora / Win11 VMs
- [ ] Re-run resumes from state file; pre-set git config / mcp.json skip prompts
- [ ] Custom repos-dir lands repos there with working ~/kun symlink

## Follow-up

- DNS for `.com` (on Cloudflare, no token access) if ever wanted — currently `.org`
- Ship team-standardized WebStorm config at `.claude/webstorm-config/`
- Real-VM validation across distros

Closes #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)