### PR TITLE
docs(team): expand to 6 humans (Ibrahim + Mutaz), reconcile role drifts

### DIFF
--- a/content/docs/agents.mdx
+++ b/content/docs/agents.mdx
@@ -21,7 +21,7 @@ captain (Tier 0 — company brain)
 
 | Agent | Scope |
 |-------|-------|
-| **captain** | CEO brain — weekly allocation, revenue strategy, team coordination across 5 products and 4 humans. Never writes code. Always delegates. |
+| **captain** | CEO brain — weekly allocation, revenue strategy, team coordination across 5 products and 6 humans. Never writes code. Always delegates. |
 
 ## Tier 1 — Business (3)
 

--- a/content/docs/architecture.mdx
+++ b/content/docs/architecture.mdx
@@ -32,10 +32,12 @@ Layer 1: Foundation (Anthropic-provided)
 
 | Member | Role |
 |--------|------|
-| **Abdout** | Builder |
+| **Abdout** | Founder & Tech Lead |
+| **Ibrahim** | Senior Fullstack Engineer |
 | **Ali** | QA Engineer + Sales |
-| **Samia** | R&D & Kun Caretaker |
-| **Sedon** | Executor |
+| **Mutaz** | Product Engineer (business) |
+| **Samia** | R&D |
+| **Sedon** | Facilitator |
 
 ## Layer 3: The Engine (Kun's Core)
 
@@ -142,10 +144,12 @@ Shared state: `~/.claude/` (agents, memory, settings, rules). Same brain, two mo
 
 | Member | Role | Primary Workflows |
 |--------|------|-------------------|
-| **Abdout** | Builder | dev → build → push → deploy |
+| **Abdout** | Founder & Tech Lead | dev → build → push → deploy |
+| **Ibrahim** | Senior Fullstack | feature build, code review, architecture |
 | **Ali** | QA + Sales | Testing, issue reports, outreach (sales@databayt.org) |
-| **Samia** | R&D | Claude/Anthropic research, sharing economy, Kun care |
-| **Sedon** | Executor | Clear task maps, Saudi operations |
+| **Mutaz** | Product Engineer (business) | Specs, customer feedback, sales+onboarding alongside Ali |
+| **Samia** | R&D | Claude/Anthropic research, sharing economy |
+| **Sedon** | Facilitator | Facilitates business team (Ali + Mutaz), clears blockers |
 
 ### Hogwarts Pilot (King Fahad Schools)
 

--- a/content/docs/captain.mdx
+++ b/content/docs/captain.mdx
@@ -1,6 +1,6 @@
 ---
 title: Captain
-description: CEO brain — delegates across 40 agents and 4 humans
+description: CEO brain — delegates across 40 agents and 6 humans
 ---
 
 # Captain

--- a/content/docs/configuration.mdx
+++ b/content/docs/configuration.mdx
@@ -86,7 +86,7 @@ Operational configuration: 100+ keyword-to-action mappings, MCP trigger table, s
 
 | Agent | Scope |
 |-------|-------|
-| captain | CEO brain — weekly allocation, revenue strategy, team coordination across 5 products and 4 humans |
+| captain | CEO brain — weekly allocation, revenue strategy, team coordination across 5 products and 6 humans |
 
 ### Tier 1 — Business (3)
 
@@ -350,8 +350,8 @@ cd ~/kun; .\.claude\scripts\install.ps1
 
 | Role | Skills | MCP | Hooks | Primary Human |
 |------|--------|-----|-------|---------------|
-| **engineer** | All 25 | All 18 | All 5 | Abdout |
-| **business** | 11 (core + business) | 8 (mcp-business.json) | Prettier only | Ali |
+| **engineer** | All 25 | All 18 | All 5 | Abdout, Ibrahim |
+| **business** | 11 (core + business) | 8 (mcp-business.json) | Prettier only | Ali, Mutaz |
 | **content** | 11 (core + content) | 8 (mcp-content.json) | Prettier only | Samia |
 | **ops** | 11 (core + ops) | 9 (mcp-ops.json) | All 5 | Sedon |
 

--- a/content/docs/connectors.mdx
+++ b/content/docs/connectors.mdx
@@ -44,7 +44,7 @@ The deepest integration. Used for:
 | Priority | P0-critical, P1-high, P2-medium, P3-low |
 | Type | agent, skill, mcp, hook, rule, memory, docs, infra |
 | Scope | captain, business, product, tech, specialist, cross-repo |
-| Assign | abdout, ali, samia, sedon, captain |
+| Assign | abdout, ibrahim, ali, mutaz, samia, sedon, captain |
 
 ## Figma Integration
 

--- a/content/docs/slack.mdx
+++ b/content/docs/slack.mdx
@@ -13,7 +13,7 @@ Team communication hub for Databayt. Connected to Claude Code via MCP for notifi
 |----------|-------|
 | Workspace | `hogwarts-wve9301` |
 | Invite Link | [Join Slack](https://join.slack.com/t/hogwarts-wve9301/shared_invite/zt-3tzetcgoi-Py59bwMs68bgw4fxxg3imQ) |
-| Team | Abdout, Ali, Samia, Sedon |
+| Team | Abdout, Ibrahim, Ali, Mutaz, Samia, Sedon |
 
 Share the invite link with team members to join.
 

--- a/content/docs/team.mdx
+++ b/content/docs/team.mdx
@@ -1,25 +1,31 @@
 ---
 title: Team
-description: 4 roles with tailored MCP configs and agent indexes
+description: 6 humans with tailored MCP configs and agent indexes
 ---
 
 # Team
 
-4 humans with tailored tools. Each role gets a specific MCP config, skill set, and agent index — so everyone has exactly the tools they need, nothing more.
+6 humans with tailored tools. Each role gets a specific MCP config, skill set, and agent index — so everyone has exactly the tools they need, nothing more.
 
 ## Team Members
 
-### Abdout — Builder
+### Abdout — Founder & Tech Lead
 Engineering everything. Architecture, full-stack, deployment.
+
+### Ibrahim — Senior Fullstack Engineer
+Ships product features across the stack. Code review, architecture sparring, complex end-to-end work alongside Abdout.
 
 ### Ali — QA Engineer + Sales
 Tests features (reports issues on GitHub), manages sales@databayt.org. Outreach for schools, sponsors, investors, early adopters, leads, clients, contributors.
 
-### Samia — R&D & Kun Caretaker
-Research on Claude/Anthropic products, sharing economy models, revenue distribution. Taking care of Kun engine. Core vision contributor.
+### Mutaz — Product Engineer (business)
+Owns product surface AND operates as a business peer of Ali — turns ideas into shippable specs, runs customer-facing motion (sales + onboarding), tightens the engineer ↔ business loop.
 
-### Sedon — Executor
-Clear task maps, reliable delivery. Saudi operations: bank account, physical presence, payments.
+### Samia — R&D
+Research on Claude/Anthropic products, sharing economy models, revenue distribution. Core vision contributor.
+
+### Sedon — Facilitator
+Facilitates the business team (Ali + Mutaz) — clears blockers, runs the ops cadence. Saudi operations: bank account, physical presence, payments.
 
 ## Role-Specific MCP Configs
 
@@ -55,7 +61,7 @@ Re-run anytime to update config after pulling latest from git.
 | Layer | Common (all roles) | Scoped (per role) |
 |-------|-------------------|-------------------|
 | **CLAUDE.md** | Shared instructions | — |
-| **Agents** | All 45 agent definitions | Role-specific index |
+| **Agents** | All 40 agent definitions | Role-specific index |
 | **Commands** | docs, repos, screenshot, codebase | Role-specific skills |
 | **Rules** | All rules | — |
 | **Memory** | Team, company data | — |
@@ -74,6 +80,16 @@ Re-run anytime to update config after pulling latest from git.
 > "deploy"                 # Ship to Vercel
 ```
 
+### Ibrahim — Senior Fullstack
+
+```
+> "dev"                    # Start dev server
+> [build features]         # Full agent fleet
+> Code review on PRs       # Architecture + correctness pass
+> "build"                  # Validate
+> "push"                   # Commit + push
+```
+
 ### Ali — QA + Sales
 
 ```
@@ -87,6 +103,15 @@ Sales (sales@databayt.org):
 > Draft proposals, follow up leads
 ```
 
+### Mutaz — Product Engineer (business)
+
+```
+> Translate ideas → specs (issue + acceptance criteria)
+> Customer interviews / feedback synthesis
+> Partner with Ali on outbound + onboarding
+> Shape the engineer ↔ business handoff
+```
+
 ### Samia — R&D
 
 ```
@@ -94,13 +119,13 @@ Cowork:
 > Research Claude/Anthropic products
 > Study sharing economy models
 > Investigate revenue distribution
-> Take care of Kun engine
+> Contribute to core vision
 ```
 
-### Sedon — Executor
+### Sedon — Facilitator
 
 ```
-> [clear task map]         # Well-defined tasks with steps
+> Facilitate business team # Unblock Ali + Mutaz
 > Saudi operations         # Bank, payments, physical presence
 > Batch weekly             # Monday map, Friday delivery
 ```


### PR DESCRIPTION
## Summary

- Ship the team expansion: **4 → 6 humans** (+ Ibrahim Senior Fullstack, + Mutaz Product Engineer)
- Reconcile the role drifts confirmed during planning:
  - Agent count `team.mdx`: **45 → 40**
  - **Mutaz**: Product Engineer → **Product Engineer (business)** (hybrid — product + business peer of Ali)
  - **Samia**: drop "& Kun Caretaker" → **R&D**
  - **Sedon**: Executor → **Facilitator** (facilitates Ali + Mutaz)

## Changes

7 docs: `team.mdx` (headings, descriptions, workflow blocks, agent count), `architecture.mdx` (both team tables), `captain.mdx` / `configuration.mdx` / `connectors.mdx` / `slack.mdx` / `agents.mdx` (4→6 wording + label/role updates).

`mcp.mdx` (the `/mcp-doctor` Playwright troubleshooting section) is intentionally **not** in this PR — separate concern.

## Test plan

- [x] No "Kun Caretaker" / "45 agent" / bare "Executor" left in team docs
- [x] Role wording consistent across team.mdx + architecture.mdx + configuration.mdx (business = Ali, Mutaz)
- [ ] Vercel build green (renders MDX)

Closes #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)