### PR TITLE
fix(scripts): shellcheck cleanup — split local, wire health output

### DIFF
--- a/.claude/scripts/installer-linux.sh
+++ b/.claude/scripts/installer-linux.sh
@@ -291,12 +291,13 @@ fi
 
 # 3c. Final verify
 notify "Verifying" "Health check"
-HEALTH_OUT=""
+HEALTH_STATUS="(health.sh not found)"
 if [[ -f "$HOME/.claude/scripts/health.sh" ]]; then
-    HEALTH_OUT=$(bash "$HOME/.claude/scripts/health.sh" 2>&1 | tail -5 || true)
+    HEALTH_STATUS=$(bash "$HOME/.claude/scripts/health.sh" 2>&1 | head -1 || true)
 fi
 
 FINAL_MSG="Setup complete! Role: $ROLE\n\n"
+FINAL_MSG+="Config health: $HEALTH_STATUS\n\n"
 FINAL_MSG+="Tools: git, node, pnpm, gh, claude, opencode\n"
 FINAL_MSG+="Repos: ~/kun"
 [[ "$ROLE" == "engineer" ]] && FINAL_MSG+=", ~/hogwarts, ~/codebase, +org repos"

--- a/.claude/scripts/installer.sh
+++ b/.claude/scripts/installer.sh
@@ -291,13 +291,14 @@ fi
 
 # 3e. Final health check
 notify "Verifying..." "Running health check"
-HEALTH_OUT=""
+HEALTH_STATUS="(health.sh not found)"
 if [[ -f "$HOME/.claude/scripts/health.sh" ]]; then
-    HEALTH_OUT=$(bash "$HOME/.claude/scripts/health.sh" 2>&1 | tail -5 || true)
+    HEALTH_STATUS=$(bash "$HOME/.claude/scripts/health.sh" 2>&1 | head -1 || true)
 fi
 
 # Final dialog
 FINAL_MSG="Setup complete! Role: $ROLE\n\n"
+FINAL_MSG+="Config health: $HEALTH_STATUS\n\n"
 FINAL_MSG+="Tools: git, node, pnpm, gh, claude, opencode\n"
 FINAL_MSG+="Repos: ~/kun"
 [[ "$ROLE" == "engineer" ]] && FINAL_MSG+=", ~/hogwarts, ~/codebase, +org repos"

--- a/.claude/scripts/onboarding-linux.sh
+++ b/.claude/scripts/onboarding-linux.sh
@@ -318,7 +318,8 @@ fi
 step "4" "Clone Repositories"
 
 clone_repo() {
-    local repo="$1" dir="$REPOS_DIR/$repo"
+    local repo="$1"
+    local dir="$REPOS_DIR/$repo"
     if [[ ! -d "$dir" ]]; then
         git clone "git@github.com:databayt/$repo.git" "$dir" 2>/dev/null && pass "$repo" || {
             git clone "https://github.com/databayt/$repo.git" "$dir" 2>/dev/null && pass "$repo (HTTPS)" || fail "$repo clone failed"

--- a/.claude/scripts/onboarding-mac.sh
+++ b/.claude/scripts/onboarding-mac.sh
@@ -285,7 +285,8 @@ fi
 step "4" "Clone Repositories"
 
 clone_repo() {
-    local repo="$1" dir="$REPOS_DIR/$repo"
+    local repo="$1"
+    local dir="$REPOS_DIR/$repo"
     if [[ ! -d "$dir" ]]; then
         info "Cloning $repo → $dir..."
         git clone "git@github.com:databayt/$repo.git" "$dir" 2>/dev/null && \


### PR DESCRIPTION
## Summary

Static validation via shellcheck (Docker/container runtime unavailable on the dev machine, so shellcheck substituted for the smoke-test). **The scripts are fundamentally sound** — no syntax or critical bugs. Fixed two legit warnings:

- **SC2318** — `clone_repo()` split `local repo=.. dir=..` into two `local` statements (onboarding-mac.sh, onboarding-linux.sh)
- **SC2034** — `installer.sh` / `installer-linux.sh` now surface the health status line in the final dialog (was captured but unused)

SC2088 tilde warnings left as-is — intentional dialog labels mapped to `$HOME`.

## Test plan

- [x] `shellcheck -S warning` clean except intentional SC2088
- [x] `bash -n` passes on all four scripts

Closes #62

🤖 Generated with [Claude Code](https://claude.com/claude-code)