### PR TITLE
feat: responsive docs header with mobile hamburger navigation

### DIFF
--- a/src/components/docs/docs-config.ts
+++ b/src/components/docs/docs-config.ts
@@ -1,0 +1,62 @@
+// Single source of truth for kun docs navigation.
+// Consumed by both the desktop sidebar (docs-sidebar.tsx) and the mobile
+// hamburger (template/mobile-nav.tsx) so the two never drift.
+// Order must match content/docs/meta.json.
+
+export type DocEntry = { href: string; label: string }
+export type DocSection = { title: string; items: DocEntry[] }
+
+export const docsNav: (DocEntry | DocSection)[] = [
+  { href: "/docs", label: "Introduction" },
+  {
+    title: "Engine",
+    items: [
+      { href: "/docs/claude-md", label: "CLAUDE.md" },
+      { href: "/docs/agents", label: "Agents" },
+      { href: "/docs/skills", label: "Skills" },
+      { href: "/docs/commands", label: "Commands" },
+      { href: "/docs/mcp", label: "MCP" },
+      { href: "/docs/hooks", label: "Hooks" },
+      { href: "/docs/rules", label: "Rules" },
+      { href: "/docs/memory", label: "Memory" },
+    ],
+  },
+  {
+    title: "Operations",
+    items: [
+      { href: "/docs/captain", label: "Captain" },
+      { href: "/docs/team", label: "Team" },
+      { href: "/docs/share-economy", label: "Share Economy" },
+      { href: "/docs/onboarding", label: "Onboarding" },
+      { href: "/docs/dispatch", label: "Dispatch" },
+      { href: "/docs/context", label: "Context" },
+      { href: "/docs/cowork", label: "Cowork" },
+      { href: "/docs/voice", label: "Voice" },
+      { href: "/docs/credentials", label: "Credentials" },
+      { href: "/docs/connectors", label: "Connectors" },
+      { href: "/docs/apps", label: "Apps" },
+      { href: "/docs/issue", label: "Issue" },
+    ],
+  },
+  {
+    title: "Reference",
+    items: [
+      { href: "/docs/keywords", label: "Keywords" },
+      { href: "/docs/tips", label: "Tips" },
+      { href: "/docs/tweets", label: "Tweets" },
+      { href: "/docs/configuration", label: "Configuration" },
+      { href: "/docs/architecture", label: "Architecture" },
+      { href: "/docs/workflows", label: "Workflows" },
+      { href: "/docs/products", label: "Products" },
+      { href: "/docs/prd", label: "PRD" },
+      { href: "/docs/epics", label: "Epics" },
+      { href: "/docs/claude-code", label: "Claude Code" },
+      { href: "/docs/secrets", label: "Secrets" },
+      { href: "/docs/slack", label: "Slack" },
+      { href: "/docs/stack", label: "Stack" },
+      { href: "/docs/repositories", label: "Repositories" },
+      { href: "/docs/projects", label: "Projects" },
+      { href: "/docs/self-hosting", label: "Self-Hosting" },
+    ],
+  },
+]

--- a/src/components/docs/docs-sidebar.tsx
+++ b/src/components/docs/docs-sidebar.tsx
@@ -4,6 +4,7 @@ import Link from "next/link"
 import { usePathname } from "next/navigation"
 
 import type { docsSource } from "@/lib/source"
+import { docsNav, type DocEntry } from "./docs-config"
 import {
   Sidebar,
   SidebarContent,
@@ -14,63 +15,6 @@ import {
   SidebarMenuButton,
   SidebarMenuItem,
 } from "@/components/ui/sidebar"
-
-// Configuration for kun docs navigation — must match content/docs/meta.json
-type DocEntry = { href: string; label: string }
-type DocSection = { title: string; items: DocEntry[] }
-
-const DOCS_NAV: (DocEntry | DocSection)[] = [
-  { href: "/docs", label: "Introduction" },
-  {
-    title: "Engine",
-    items: [
-      { href: "/docs/claude-md", label: "CLAUDE.md" },
-      { href: "/docs/agents", label: "Agents" },
-      { href: "/docs/skills", label: "Skills" },
-      { href: "/docs/commands", label: "Commands" },
-      { href: "/docs/mcp", label: "MCP" },
-      { href: "/docs/hooks", label: "Hooks" },
-      { href: "/docs/rules", label: "Rules" },
-      { href: "/docs/memory", label: "Memory" },
-    ],
-  },
-  {
-    title: "Operations",
-    items: [
-      { href: "/docs/captain", label: "Captain" },
-      { href: "/docs/team", label: "Team" },
-      { href: "/docs/dispatch", label: "Dispatch" },
-      { href: "/docs/context", label: "Context" },
-      { href: "/docs/cowork", label: "Cowork" },
-      { href: "/docs/voice", label: "Voice" },
-      { href: "/docs/credentials", label: "Credentials" },
-      { href: "/docs/connectors", label: "Connectors" },
-      { href: "/docs/apps", label: "Apps" },
-      { href: "/docs/issue", label: "Issue" },
-    ],
-  },
-  {
-    title: "Reference",
-    items: [
-      { href: "/docs/keywords", label: "Keywords" },
-      { href: "/docs/tips", label: "Tips" },
-      { href: "/docs/tweets", label: "Tweets" },
-      { href: "/docs/configuration", label: "Configuration" },
-      { href: "/docs/architecture", label: "Architecture" },
-      { href: "/docs/workflows", label: "Workflows" },
-      { href: "/docs/products", label: "Products" },
-      { href: "/docs/prd", label: "PRD" },
-      { href: "/docs/epics", label: "Epics" },
-      { href: "/docs/claude-code", label: "Claude Code" },
-      { href: "/docs/secrets", label: "Secrets" },
-      { href: "/docs/slack", label: "Slack" },
-      { href: "/docs/stack", label: "Stack" },
-      { href: "/docs/repositories", label: "Repositories" },
-      { href: "/docs/projects", label: "Projects" },
-      { href: "/docs/self-hosting", label: "Self-Hosting" },
-    ],
-  },
-]
 
 export function DocsSidebar({
   tree,
@@ -108,7 +52,7 @@ export function DocsSidebar({
     >
       <SidebarContent className="no-scrollbar overflow-x-hidden">
         <div className="pb-4 pt-2 pl-0">
-          {DOCS_NAV.map((entry, i) => {
+          {docsNav.map((entry, i) => {
             if ("title" in entry) {
               return (
                 <SidebarGroup key={entry.title} className="p-0 pt-4">

--- a/src/components/template/config.ts
+++ b/src/components/template/config.ts
@@ -1,0 +1,11 @@
+// Top-level site navigation, shared by the desktop header nav and the mobile
+// hamburger so the two never drift.
+
+export type SiteNavItem = { href: string; label: string }
+
+export const siteNav: SiteNavItem[] = [
+  { href: "/docs", label: "Docs" },
+  { href: "/incantations", label: "Incantations" },
+  { href: "/team", label: "Team" },
+  { href: "/context", label: "Context" },
+]

--- a/src/components/template/mobile-nav.tsx
+++ b/src/components/template/mobile-nav.tsx
@@ -1,0 +1,182 @@
+"use client"
+
+import * as React from "react"
+import Link, { LinkProps } from "next/link"
+import { usePathname, useRouter } from "next/navigation"
+
+import { cn } from "@/lib/utils"
+import { Button } from "@/components/ui/button"
+import { Separator } from "@/components/ui/separator"
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover"
+import type { DocEntry, DocSection } from "@/components/docs/docs-config"
+import type { SiteNavItem } from "./config"
+import { GitHubLink } from "./github-link"
+import { LangSwitcher } from "./lang-switcher"
+import { ModeSwitcher } from "./mode-switcher"
+import { UserButton } from "./user-button"
+
+interface MobileNavProps {
+  items?: SiteNavItem[]
+  sections?: (DocEntry | DocSection)[]
+  className?: string
+  lang?: string
+}
+
+export function MobileNav({
+  items = [],
+  sections,
+  className,
+  lang = "en",
+}: MobileNavProps) {
+  const [open, setOpen] = React.useState(false)
+  const pathname = usePathname()
+  const isRTL = lang === "ar"
+
+  const menuLabel = isRTL ? "القائمة" : "Menu"
+  const homeLabel = isRTL ? "الرئيسية" : "Home"
+
+  // Surface the docs tree only while reading docs — the desktop sidebar that
+  // normally carries it is hidden below lg.
+  const showDocs = !!sections && pathname?.includes("/docs")
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button
+          variant="ghost"
+          className={cn(
+            "extend-touch-target h-8 touch-manipulation items-center justify-start gap-2.5 !p-0 hover:bg-transparent focus-visible:bg-transparent focus-visible:ring-0 active:bg-transparent dark:hover:bg-transparent",
+            className
+          )}
+        >
+          {/* Animated hamburger — two bars that rotate into an X */}
+          <div className="relative flex h-8 w-4 items-center justify-center">
+            <div className="relative size-4">
+              <span
+                className={cn(
+                  "bg-foreground absolute start-0 block h-0.5 w-4 transition-all duration-100",
+                  open ? "top-[0.4rem] -rotate-45" : "top-1"
+                )}
+              />
+              <span
+                className={cn(
+                  "bg-foreground absolute start-0 block h-0.5 w-4 transition-all duration-100",
+                  open ? "top-[0.4rem] rotate-45" : "top-2.5"
+                )}
+              />
+            </div>
+            <span className="sr-only">{menuLabel}</span>
+          </div>
+          <span className="flex h-8 items-center text-lg leading-none font-medium">
+            {menuLabel}
+          </span>
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent
+        // Portaled outside the dir="rtl" wrapper, so set direction explicitly.
+        dir={isRTL ? "rtl" : "ltr"}
+        className="bg-background/90 no-scrollbar h-(--radix-popper-available-height) w-(--radix-popper-available-width) overflow-y-auto rounded-none border-none p-0 shadow-none backdrop-blur duration-100"
+        align="start"
+        side="bottom"
+        alignOffset={-16}
+        sideOffset={14}
+      >
+        <div className="flex flex-col gap-8 overflow-auto px-6 py-6">
+          {/* Main menu */}
+          <div className="flex flex-col gap-4">
+            <div className="text-muted-foreground text-sm font-medium">
+              {menuLabel}
+            </div>
+            <div className="flex flex-col gap-3">
+              <MobileLink href="/" lang={lang} onOpenChange={setOpen}>
+                {homeLabel}
+              </MobileLink>
+              {items.map((item) => (
+                <MobileLink
+                  key={item.href}
+                  href={item.href}
+                  lang={lang}
+                  onOpenChange={setOpen}
+                >
+                  {item.label}
+                </MobileLink>
+              ))}
+            </div>
+          </div>
+
+          {/* Full docs tree (only on /docs) */}
+          {showDocs &&
+            sections!.map((entry, i) =>
+              "title" in entry ? (
+                <div key={entry.title} className="flex flex-col gap-4">
+                  <div className="text-muted-foreground text-sm font-medium">
+                    {entry.title}
+                  </div>
+                  <div className="flex flex-col gap-3">
+                    {entry.items.map((item) => (
+                      <MobileLink
+                        key={item.href}
+                        href={item.href}
+                        lang={lang}
+                        onOpenChange={setOpen}
+                      >
+                        {item.label}
+                      </MobileLink>
+                    ))}
+                  </div>
+                </div>
+              ) : (
+                <div key={i} className="flex flex-col gap-3">
+                  <MobileLink href={entry.href} lang={lang} onOpenChange={setOpen}>
+                    {entry.label}
+                  </MobileLink>
+                </div>
+              )
+            )}
+
+          {/* Actions — same controls the desktop header carries on the right */}
+          <div className="flex items-center gap-2 border-t pt-4 **:data-[slot=separator]:!h-4">
+            <GitHubLink />
+            <Separator orientation="vertical" />
+            <LangSwitcher />
+            <ModeSwitcher />
+            <UserButton />
+          </div>
+        </div>
+      </PopoverContent>
+    </Popover>
+  )
+}
+
+function MobileLink({
+  href,
+  onOpenChange,
+  className,
+  children,
+  lang,
+  ...props
+}: LinkProps & {
+  onOpenChange?: (open: boolean) => void
+  children: React.ReactNode
+  className?: string
+  lang?: string
+}) {
+  const router = useRouter()
+  const base = lang ? `/${lang}` : ""
+  const path = href.toString()
+  const fullHref = path === "/" ? base || "/" : `${base}${path}`
+
+  return (
+    <Link
+      href={fullHref}
+      onClick={() => {
+        router.push(fullHref)
+        onOpenChange?.(false)
+      }}
+      className={cn("text-2xl font-medium", className)}
+      {...props}
+    >
+      {children}
+    </Link>
+  )
+}

--- a/src/components/template/site-header.tsx
+++ b/src/components/template/site-header.tsx
@@ -4,7 +4,10 @@ import { ModeSwitcher } from "./mode-switcher"
 import { LangSwitcher } from "./lang-switcher"
 import { GitHubLink } from "./github-link"
 import { UserButton } from "./user-button"
+import { MobileNav } from "./mobile-nav"
+import { siteNav } from "./config"
 import { Separator } from "@/components/ui/separator"
+import { docsNav } from "@/components/docs/docs-config"
 
 interface SiteHeaderProps {
   lang: string
@@ -14,43 +17,40 @@ export function SiteHeader({ lang }: SiteHeaderProps) {
   return (
     <header className="bg-background sticky top-0 z-50 w-full">
       <div className="container-wrapper">
-        <div className="flex h-(--header-height) items-center **:data-[slot=separator]:!h-4">
+        <div className="flex h-(--header-height) items-center gap-2 md:gap-4 **:data-[slot=separator]:!h-4">
           <Link href={`/${lang}`} className="flex items-center gap-1.5 me-6">
             <span className="font-bold">Kun</span>
           </Link>
-          <nav className="flex items-center gap-4 text-sm">
-            <Link
-              href={`/${lang}/docs`}
-              className="transition-colors hover:text-foreground/80 text-foreground/60"
-            >
-              Docs
-            </Link>
-            <Link
-              href={`/${lang}/incantations`}
-              className="transition-colors hover:text-foreground/80 text-foreground/60"
-            >
-              Incantations
-            </Link>
-            <Link
-              href={`/${lang}/team`}
-              className="transition-colors hover:text-foreground/80 text-foreground/60"
-            >
-              Team
-            </Link>
-            <Link
-              href={`/${lang}/context`}
-              className="transition-colors hover:text-foreground/80 text-foreground/60"
-            >
-              Context
-            </Link>
+
+          {/* Desktop nav — collapses into the hamburger below md */}
+          <nav className="hidden items-center gap-4 text-sm md:flex">
+            {siteNav.map((item) => (
+              <Link
+                key={item.href}
+                href={`/${lang}${item.href}`}
+                className="transition-colors hover:text-foreground/80 text-foreground/60"
+              >
+                {item.label}
+              </Link>
+            ))}
           </nav>
-          <div className="ms-auto flex items-center gap-2">
+
+          {/* Desktop controls — move into the hamburger below lg */}
+          <div className="ms-auto hidden items-center gap-2 lg:flex">
             <GitHubLink />
             <Separator orientation="vertical" />
             <LangSwitcher />
             <ModeSwitcher />
             <UserButton />
           </div>
+
+          {/* Mobile hamburger — visible below lg */}
+          <MobileNav
+            className="ms-auto flex lg:hidden"
+            lang={lang}
+            items={siteNav}
+            sections={docsNav}
+          />
         </div>
       </div>
     </header>

--- a/src/components/ui/popover.tsx
+++ b/src/components/ui/popover.tsx
@@ -1,0 +1,48 @@
+"use client"
+
+import * as React from "react"
+import * as PopoverPrimitive from "@radix-ui/react-popover"
+
+import { cn } from "@/lib/utils"
+
+function Popover({
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Root>) {
+  return <PopoverPrimitive.Root data-slot="popover" {...props} />
+}
+
+function PopoverTrigger({
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Trigger>) {
+  return <PopoverPrimitive.Trigger data-slot="popover-trigger" {...props} />
+}
+
+function PopoverContent({
+  className,
+  align = "center",
+  sideOffset = 4,
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Content>) {
+  return (
+    <PopoverPrimitive.Portal>
+      <PopoverPrimitive.Content
+        data-slot="popover-content"
+        align={align}
+        sideOffset={sideOffset}
+        className={cn(
+          "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-72 origin-(--radix-popover-content-transform-origin) rounded-md border p-4 shadow-md outline-hidden",
+          className
+        )}
+        {...props}
+      />
+    </PopoverPrimitive.Portal>
+  )
+}
+
+function PopoverAnchor({
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Anchor>) {
+  return <PopoverPrimitive.Anchor data-slot="popover-anchor" {...props} />
+}
+
+export { Popover, PopoverTrigger, PopoverContent, PopoverAnchor }


### PR DESCRIPTION
## Summary

- The docs header never collapsed and the docs sidebar was `hidden lg:flex`, so **below 1024px the docs nav vanished entirely** — mobile readers could only use prev/next.
- Ports the hogwarts responsive-header pattern: desktop nav + controls collapse into an animated **Popover hamburger** that surfaces the **full docs tree** on mobile.
- Docs *page* and *layout* already matched hogwarts, so this is scoped to the header + mobile nav.

## Changes

- **`ui/popover.tsx`** (new): shadcn Popover wrapper around the already-installed `@radix-ui/react-popover`.
- **`template/mobile-nav.tsx`** (new): animated bars→X hamburger. Full-viewport panel shows main nav + the full docs tree (when on `/docs`) + actions (GitHub/lang/theme/user). Localizes Menu/Home by lang; sets `dir` explicitly because the panel is portaled outside the `dir="rtl"` wrapper.
- **`docs/docs-config.ts`** + **`template/config.ts`** (new): single source of truth for docs nav and site nav, consumed by both the desktop sidebar and the mobile menu. Adds the previously-missing `share-economy` + `onboarding` entries.
- **`docs/docs-sidebar.tsx`**: reads `docsNav` from the shared config (grouped sidebar unchanged).
- **`template/site-header.tsx`**: logo always visible; desktop nav `hidden md:flex`; controls `hidden lg:flex`; hamburger `flex lg:hidden`.

## Test plan

Verified against a local production build (`pnpm build` ✓, all 38 docs pages generate) with Playwright screenshots at 390 / 768 / 1280:

- [x] Desktop ≥1024px: inline nav + controls, **no** hamburger
- [x] Tablet 768–1023px: inline nav + hamburger (carries controls)
- [x] Mobile <768px: logo + hamburger; panel shows the **full docs tree** (Introduction → Engine → Operations → Reference)
- [x] RTL (`/ar`): header mirrors (hamburger left, logo right); panel content right-aligned after the `dir` fix
- [x] `share-economy` + `onboarding` now appear in both the desktop sidebar and the mobile menu

> Note: `/ar/docs/*` 404s (pre-existing — docs `generateStaticParams` hardcodes `lang:"en"` with `dynamicParams=false`); out of scope here. RTL was verified on `/ar`.

Closes #65

🤖 Generated with [Claude Code](https://claude.com/claude-code)