### PR TITLE
feat(config): universal config — every machine is a full autonomous worker

### DIFF
--- a/.claude/scripts/health.ps1
+++ b/.claude/scripts/health.ps1
@@ -50,17 +50,18 @@ if ($ruleCount -gt 0) { Check pass "rules/" "$ruleCount files" } else { Check wa
 if (Test-Path "$CLAUDE_DIR\memory") { Check pass "memory/" "exists" } else { Check warn "memory/" "missing" }
 
 # ── MCP count ────────────────────────────────────────────────────
+# Universal — every machine gets the full fleet; scoped secrets, not config
 if (Test-Path "$CLAUDE_DIR\mcp.json") {
     $mcpCount = (Select-String -Path "$CLAUDE_DIR\mcp.json" -Pattern '"description"' -EA SilentlyContinue).Count
-    $expected = switch ($ROLE) { "engineer" { 20 } "business" { 6 } "content" { 6 } "ops" { 7 } default { 1 } }
+    $expected = 18
     if ($mcpCount -ge $expected) { Check pass "MCP servers" "$mcpCount (expected >=$expected)" }
     else { Check warn "MCP servers" "$mcpCount (expected >=$expected)" }
 }
 
-# ── Commands scope ───────────────────────────────────────────────
-$expectedCmds = switch ($ROLE) { "engineer" { 20 } "business" { 6 } "content" { 6 } "ops" { 7 } default { 1 } }
-if ($cmdCount -ge $expectedCmds) { Check pass "commands scope" "$cmdCount (expected >=$expectedCmds)" }
-else { Check warn "commands scope" "$cmdCount (expected >=$expectedCmds)" }
+# ── Commands (universal — full skill set on every machine) ───────
+$expectedCmds = 20
+if ($cmdCount -ge $expectedCmds) { Check pass "commands" "$cmdCount (expected >=$expectedCmds)" }
+else { Check warn "commands" "$cmdCount (expected >=$expectedCmds)" }
 
 # ── CLI ──────────────────────────────────────────────────────────
 $claude = Get-Command claude -EA SilentlyContinue

--- a/.claude/scripts/health.sh
+++ b/.claude/scripts/health.sh
@@ -67,30 +67,20 @@ RULE_COUNT=$(ls "$CLAUDE_DIR/rules/"*.md 2>/dev/null | wc -l | tr -d ' ')
 [ "$RULE_COUNT" -gt 0 ] && check pass "rules/" "$RULE_COUNT files" || check warn "rules/" "empty"
 [ -d "$CLAUDE_DIR/memory" ] && check pass "memory/" "exists" || check warn "memory/" "missing"
 
-# ── MCP server count ────────────────────────────────────────────
+# ── MCP server count (universal — every machine gets the full fleet) ──
+# Secrets are scoped, not config: a server without a key just doesn't
+# connect, so the full mcp.json is expected on every machine.
 if [ -f "$CLAUDE_DIR/mcp.json" ]; then
     MCP_COUNT=$(grep -c '"description"' "$CLAUDE_DIR/mcp.json" 2>/dev/null || echo 0)
-    case "$ROLE" in
-        engineer) EXPECTED=20; ;; # ~25 servers
-        business) EXPECTED=6; ;;
-        content)  EXPECTED=6; ;;
-        ops)      EXPECTED=7; ;;
-        *)        EXPECTED=1; ;;
-    esac
+    EXPECTED=18
     [ "$MCP_COUNT" -ge "$EXPECTED" ] && check pass "MCP servers" "$MCP_COUNT (expected ≥$EXPECTED)" || \
         check warn "MCP servers" "$MCP_COUNT (expected ≥$EXPECTED)"
 fi
 
-# ── Expected commands per role ───────────────────────────────────
-case "$ROLE" in
-    engineer) EXPECTED_CMDS=20; ;;
-    business) EXPECTED_CMDS=6; ;;
-    content)  EXPECTED_CMDS=6; ;;
-    ops)      EXPECTED_CMDS=7; ;;
-    *)        EXPECTED_CMDS=1; ;;
-esac
-[ "$CMD_COUNT" -ge "$EXPECTED_CMDS" ] && check pass "commands scope" "$CMD_COUNT (expected ≥$EXPECTED_CMDS)" || \
-    check warn "commands scope" "$CMD_COUNT (expected ≥$EXPECTED_CMDS)"
+# ── Expected commands (universal — full skill set on every machine) ──
+EXPECTED_CMDS=20
+[ "$CMD_COUNT" -ge "$EXPECTED_CMDS" ] && check pass "commands" "$CMD_COUNT (expected ≥$EXPECTED_CMDS)" || \
+    check warn "commands" "$CMD_COUNT (expected ≥$EXPECTED_CMDS)"
 
 # ── Permissions ──────────────────────────────────────────────────
 if [ -f "$CLAUDE_DIR/settings.json" ]; then

--- a/.claude/scripts/installer-linux.sh
+++ b/.claude/scripts/installer-linux.sh
@@ -221,6 +221,14 @@ if [[ -z "$WITH_TAILSCALE" ]]; then
     state_set withTailscale "$WITH_TAILSCALE"
 fi
 
+# Hogwarts local dev — opt-in (heavy: pnpm + DB seed + build, ~10 min)
+HOGWARTS_DEV=$(state_get hogwartsDev)
+if [[ -z "$HOGWARTS_DEV" ]]; then
+    HD_ANS=$(ask_yesno "Set up hogwarts local dev now? (pnpm + DB seed + build, ~10 min — skip if this machine won't run hogwarts locally)")
+    [[ "$HD_ANS" == "Yes" ]] && HOGWARTS_DEV="1" || HOGWARTS_DEV="0"
+    state_set hogwartsDev "$HOGWARTS_DEV"
+fi
+
 # =============================================================================
 # ACT 2 — Silent batch
 # =============================================================================
@@ -231,6 +239,7 @@ BACKEND_ARGS=("$ROLE")
 BACKEND_ARGS+=("--quiet" "--name" "$GIT_NAME_ARG" "--email" "$GIT_EMAIL_ARG")
 [[ -n "$REPOS_DIR" && "$REPOS_DIR" != "$HOME" ]] && BACKEND_ARGS+=("--repos-dir" "$REPOS_DIR")
 [[ "$WITH_TAILSCALE" == "1" ]] && BACKEND_ARGS+=("--with-tailscale")
+[[ "$HOGWARTS_DEV" == "1" ]] && BACKEND_ARGS+=("--hogwarts-dev")
 
 echo ""
 echo "════════════════════════════════════════════════════"

--- a/.claude/scripts/installer.ps1
+++ b/.claude/scripts/installer.ps1
@@ -250,6 +250,14 @@ if (-not $withTailscale) {
     Set-State withTailscale $withTailscale
 }
 
+# Hogwarts local dev — opt-in (heavy: pnpm + DB seed + build, ~10 min)
+$hogwartsDev = Get-State hogwartsDev
+if (-not $hogwartsDev) {
+    $ans = Ask-YesNo "Set up hogwarts local dev now? (pnpm + DB seed + build, ~10 min — skip if this machine won't run hogwarts locally)"
+    if ($ans -eq "Yes") { $hogwartsDev = "1" } else { $hogwartsDev = "0" }
+    Set-State hogwartsDev $hogwartsDev
+}
+
 # =============================================================================
 # ACT 2 - Silent batch
 # =============================================================================
@@ -259,6 +267,7 @@ $backendArgs = @("-Role", $role, "-Quiet", "-GitName", $gitName, "-GitEmail", $g
 if ($gistId) { $backendArgs += @("-GistId", $gistId) }
 if ($reposDir -and $reposDir -ne $env:USERPROFILE) { $backendArgs += @("-ReposDir", $reposDir) }
 if ($withTailscale -eq "1") { $backendArgs += @("-WithTailscale") }
+if ($hogwartsDev -eq "1") { $backendArgs += @("-HogwartsDev") }
 
 Write-Host ""
 Write-Host "════════════════════════════════════════════════════" -ForegroundColor Cyan

--- a/.claude/scripts/installer.sh
+++ b/.claude/scripts/installer.sh
@@ -202,6 +202,14 @@ if [[ -z "$WITH_TAILSCALE" ]]; then
     state_set withTailscale "$WITH_TAILSCALE"
 fi
 
+# Hogwarts local dev — opt-in (heavy: pnpm + DB seed + build, ~10 min)
+HOGWARTS_DEV=$(state_get hogwartsDev)
+if [[ -z "$HOGWARTS_DEV" ]]; then
+    HD_ANS=$(ask_choice "Set up hogwarts local dev now? (pnpm + DB seed + build, ~10 min)\n\nSkip if this machine won't run hogwarts locally — you can add it later." "Yes" "No")
+    [[ "$HD_ANS" == "Yes" ]] && HOGWARTS_DEV="1" || HOGWARTS_DEV="0"
+    state_set hogwartsDev "$HOGWARTS_DEV"
+fi
+
 # =============================================================================
 # ACT 2 — Silent batch (in terminal; notifications on phase transitions)
 # =============================================================================
@@ -212,6 +220,7 @@ BACKEND_ARGS=("$ROLE")
 BACKEND_ARGS+=("--quiet" "--name" "$GIT_NAME_ARG" "--email" "$GIT_EMAIL_ARG")
 [[ -n "$REPOS_DIR" && "$REPOS_DIR" != "$HOME" ]] && BACKEND_ARGS+=("--repos-dir" "$REPOS_DIR")
 [[ "$WITH_TAILSCALE" == "1" ]] && BACKEND_ARGS+=("--with-tailscale")
+[[ "$HOGWARTS_DEV" == "1" ]] && BACKEND_ARGS+=("--hogwarts-dev")
 
 echo ""
 echo "════════════════════════════════════════════════════"

--- a/.claude/scripts/onboarding-linux.sh
+++ b/.claude/scripts/onboarding-linux.sh
@@ -30,7 +30,7 @@ set -e
 
 # ── Args ────────────────────────────────────────────────────────
 ROLE="" GIST_ID="" QUIET=0 GIT_NAME_ARG="" GIT_EMAIL_ARG=""
-WITH_TAILSCALE=0 ALL_REPOS=1 REPOS_DIR="$HOME"
+WITH_TAILSCALE=0 ALL_REPOS=1 REPOS_DIR="$HOME" HOGWARTS_DEV=0
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --quiet)            QUIET=1; shift ;;
@@ -39,6 +39,7 @@ while [[ $# -gt 0 ]]; do
         --repos-dir)        REPOS_DIR="$2"; shift 2 ;;
         --with-tailscale)   WITH_TAILSCALE=1; shift ;;
         --essentials-only)  ALL_REPOS=0; shift ;;
+        --hogwarts-dev)     HOGWARTS_DEV=1; shift ;;
         --*)                echo "Unknown flag: $1" >&2; exit 1 ;;
         *)
             if [[ -z "$ROLE" ]]; then ROLE="$1"
@@ -77,6 +78,7 @@ if [[ -z "$ROLE" ]]; then
     echo "  --email <email>    Pre-supply git email"
     echo "  --essentials-only  Skip optional org repos"
     echo "  --repos-dir <dir>  Where to save databayt repos (default: \$HOME)"
+    echo "  --hogwarts-dev     Set up hogwarts local dev (pnpm + DB seed + build)"
     echo "  --with-tailscale   Install Tailscale + 'up --ssh'"
     echo ""
     echo "One-liner:"
@@ -213,28 +215,27 @@ step "2" "Applications — VS Code, WebStorm, Chrome"
 HAS_SNAP=0
 command -v snap >/dev/null 2>&1 && HAS_SNAP=1
 
-if [[ "$ROLE" == "engineer" ]]; then
-    # VS Code
-    if ! command -v code >/dev/null 2>&1; then
-        if [[ "$HAS_SNAP" == "1" ]]; then
-            sudo snap install code --classic >/dev/null 2>&1 && pass "VS Code (snap)" || info "VS Code snap install failed — install manually"
-        else
-            info "snap not available — install VS Code manually from https://code.visualstudio.com/"
-        fi
+# IDEs on every machine — full workstation regardless of role
+# VS Code
+if ! command -v code >/dev/null 2>&1; then
+    if [[ "$HAS_SNAP" == "1" ]]; then
+        sudo snap install code --classic >/dev/null 2>&1 && pass "VS Code (snap)" || info "VS Code snap install failed — install manually"
     else
-        pass "VS Code"
+        info "snap not available — install VS Code manually from https://code.visualstudio.com/"
     fi
+else
+    pass "VS Code"
+fi
 
-    # WebStorm
-    if ! command -v webstorm >/dev/null 2>&1 && [[ ! -d "/snap/webstorm" ]]; then
-        if [[ "$HAS_SNAP" == "1" ]]; then
-            sudo snap install webstorm --classic >/dev/null 2>&1 && pass "WebStorm (snap)" || info "WebStorm snap install failed — install manually from jetbrains.com"
-        else
-            info "snap not available — install WebStorm manually from https://www.jetbrains.com/webstorm/"
-        fi
+# WebStorm
+if ! command -v webstorm >/dev/null 2>&1 && [[ ! -d "/snap/webstorm" ]]; then
+    if [[ "$HAS_SNAP" == "1" ]]; then
+        sudo snap install webstorm --classic >/dev/null 2>&1 && pass "WebStorm (snap)" || info "WebStorm snap install failed — install manually from jetbrains.com"
     else
-        pass "WebStorm"
+        info "snap not available — install WebStorm manually from https://www.jetbrains.com/webstorm/"
     fi
+else
+    pass "WebStorm"
 fi
 
 # Chrome — only via snap or manual install (no official package in most distros)
@@ -335,15 +336,14 @@ symlink_home() {
         ln -sf "$REPOS_DIR/$repo" "$HOME/$repo" && info "~/$repo → $REPOS_DIR/$repo"
 }
 
+# Every machine clones the full org — any machine can be any task.
 clone_repo "kun"; symlink_home "kun"
-if [[ "$ROLE" == "engineer" ]]; then
-    clone_repo "hogwarts"; symlink_home "hogwarts"
-    clone_repo "codebase"; symlink_home "codebase"
-    if [[ "$ALL_REPOS" == "1" ]]; then
-        for repo in shadcn radix souq mkan shifa swift-app distributed-computer marketing; do
-            clone_repo "$repo"; symlink_home "$repo"
-        done
-    fi
+clone_repo "hogwarts"; symlink_home "hogwarts"
+clone_repo "codebase"; symlink_home "codebase"
+if [[ "$ALL_REPOS" == "1" ]]; then
+    for repo in shadcn radix souq mkan shifa swift-app distributed-computer marketing; do
+        clone_repo "$repo"; symlink_home "$repo"
+    done
 fi
 
 # =============================================================================
@@ -459,7 +459,8 @@ step "7" "Hogwarts — dependencies, database, seed"
 
 HOGWARTS_DIR="$REPOS_DIR/hogwarts"
 
-if [[ "$ROLE" == "engineer" && -d "$HOGWARTS_DIR" ]]; then
+# Heavy local-dev setup is opt-in (--hogwarts-dev), not role-gated
+if [[ "$HOGWARTS_DEV" == "1" && -d "$HOGWARTS_DIR" ]]; then
     cd "$HOGWARTS_DIR"
 
     if [[ ! -f ".env" ]]; then
@@ -500,12 +501,10 @@ if [[ "$ROLE" == "engineer" && -d "$HOGWARTS_DIR" ]]; then
     fi
 
     cd "$HOME"
+elif [[ "$HOGWARTS_DEV" == "1" ]]; then
+    info "Hogwarts not cloned — skipped"
 else
-    if [[ "$ROLE" == "engineer" ]]; then
-        info "Hogwarts not cloned — skipped"
-    else
-        info "Hogwarts skipped (role: $ROLE)"
-    fi
+    info "Hogwarts local dev skipped (pass --hogwarts-dev to set it up)"
 fi
 
 # =============================================================================
@@ -525,10 +524,8 @@ command -v opencode >/dev/null 2>&1 && pass "opencode" || info "opencode (option
 gh auth status >/dev/null 2>&1      && pass "GitHub auth" || fail "GitHub auth"
 
 [[ -d "$REPOS_DIR/kun" ]]                && pass "kun repo"    || fail "kun"
-if [[ "$ROLE" == "engineer" ]]; then
-    [[ -d "$REPOS_DIR/hogwarts" ]]       && pass "hogwarts"     || fail "hogwarts"
-    [[ -d "$REPOS_DIR/codebase" ]]       && pass "codebase"     || fail "codebase"
-fi
+[[ -d "$REPOS_DIR/hogwarts" ]]           && pass "hogwarts"     || fail "hogwarts"
+[[ -d "$REPOS_DIR/codebase" ]]           && pass "codebase"     || fail "codebase"
 
 [[ -f "$HOME/.claude/CLAUDE.md" ]]   && pass "Kun CLAUDE.md"  || fail "Kun CLAUDE.md"
 [[ -f "$HOME/.claude/settings.json" ]] && pass "settings.json" || fail "settings.json"
@@ -584,7 +581,7 @@ echo "  • CLI: 'claude' / 'c' / 'opencode' / 'o'"
 echo "  • Browser: https://claude.ai/code (same projects as CLI)"
 echo "  • IDE: install Claude plugin from VS Code/WebStorm Marketplace"
 
-if [[ "$ROLE" == "engineer" ]]; then
+if [[ "$HOGWARTS_DEV" == "1" ]]; then
     echo ""
     echo -e "${BD}Run hogwarts:${NC}"
     echo "  cd ~/hogwarts && pnpm dev"

--- a/.claude/scripts/onboarding-mac.sh
+++ b/.claude/scripts/onboarding-mac.sh
@@ -28,7 +28,7 @@ set -e
 
 # Parse args — positional <role> [gist_id] plus optional flags
 ROLE="" GIST_ID="" QUIET=0 GIT_NAME_ARG="" GIT_EMAIL_ARG=""
-WITH_TAILSCALE=0 ALL_REPOS=1 REPOS_DIR="$HOME"
+WITH_TAILSCALE=0 ALL_REPOS=1 REPOS_DIR="$HOME" HOGWARTS_DEV=0
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --quiet)            QUIET=1; shift ;;
@@ -37,6 +37,7 @@ while [[ $# -gt 0 ]]; do
         --repos-dir)        REPOS_DIR="$2"; shift 2 ;;
         --with-tailscale)   WITH_TAILSCALE=1; shift ;;
         --essentials-only)  ALL_REPOS=0; shift ;;
+        --hogwarts-dev)     HOGWARTS_DEV=1; shift ;;
         --*)                echo "Unknown flag: $1" >&2; exit 1 ;;
         *)
             if [[ -z "$ROLE" ]]; then ROLE="$1"
@@ -86,6 +87,7 @@ if [[ -z "$ROLE" ]]; then
     echo "  --email <email>    Pre-supply git email (skips prompt)"
     echo "  --essentials-only  Clone only kun/hogwarts/codebase (default: all org repos)"
     echo "  --repos-dir <dir>  Where to save databayt org repos (default: \$HOME)"
+    echo "  --hogwarts-dev     Set up hogwarts local dev (pnpm + DB seed + build)"
     echo "  --with-tailscale   Install Tailscale + 'tailscale up --ssh' for remote/mobile"
     echo ""
     echo "One-liner:"
@@ -184,24 +186,23 @@ fi
 # =============================================================================
 step "2" "Applications"
 
-if [[ "$ROLE" == "engineer" ]]; then
-    # WebStorm
-    if [[ ! -d "/Applications/WebStorm.app" ]]; then
-        info "Installing WebStorm..."
-        brew install --cask webstorm
-        pass "WebStorm installed"
-    else
-        pass "WebStorm"
-    fi
+# IDEs on every machine — full workstation regardless of role
+# WebStorm
+if [[ ! -d "/Applications/WebStorm.app" ]]; then
+    info "Installing WebStorm..."
+    brew install --cask webstorm
+    pass "WebStorm installed"
+else
+    pass "WebStorm"
+fi
 
-    # VS Code
-    if [[ ! -d "/Applications/Visual Studio Code.app" ]]; then
-        info "Installing VS Code..."
-        brew install --cask visual-studio-code
-        pass "VS Code installed"
-    else
-        pass "VS Code"
-    fi
+# VS Code
+if [[ ! -d "/Applications/Visual Studio Code.app" ]]; then
+    info "Installing VS Code..."
+    brew install --cask visual-studio-code
+    pass "VS Code installed"
+else
+    pass "VS Code"
 fi
 
 # Chrome
@@ -307,18 +308,16 @@ symlink_home() {
         ln -sf "$REPOS_DIR/$repo" "$HOME/$repo" && info "~/$repo → $REPOS_DIR/$repo"
 }
 
+# Every machine clones the full org — any machine can be any task.
 clone_repo "kun"; symlink_home "kun"
+clone_repo "hogwarts"; symlink_home "hogwarts"
+clone_repo "codebase"; symlink_home "codebase"
 
-if [[ "$ROLE" == "engineer" ]]; then
-    clone_repo "hogwarts"; symlink_home "hogwarts"
-    clone_repo "codebase"; symlink_home "codebase"
-
-    if [[ "$ALL_REPOS" == "1" ]]; then
-        info "Cloning remaining databayt org repos..."
-        for repo in shadcn radix souq mkan shifa swift-app distributed-computer marketing; do
-            clone_repo "$repo"; symlink_home "$repo"
-        done
-    fi
+if [[ "$ALL_REPOS" == "1" ]]; then
+    info "Cloning remaining databayt org repos..."
+    for repo in shadcn radix souq mkan shifa swift-app distributed-computer marketing; do
+        clone_repo "$repo"; symlink_home "$repo"
+    done
 fi
 
 # =============================================================================
@@ -470,7 +469,8 @@ step "7" "Hogwarts — dependencies, database, seed"
 
 HOGWARTS_DIR="$REPOS_DIR/hogwarts"
 
-if [[ "$ROLE" == "engineer" && -d "$HOGWARTS_DIR" ]]; then
+# Heavy local-dev setup is opt-in (--hogwarts-dev), not role-gated
+if [[ "$HOGWARTS_DEV" == "1" && -d "$HOGWARTS_DIR" ]]; then
     cd "$HOGWARTS_DIR"
 
     # .env
@@ -516,12 +516,10 @@ if [[ "$ROLE" == "engineer" && -d "$HOGWARTS_DIR" ]]; then
     fi
 
     cd "$HOME"
+elif [[ "$HOGWARTS_DEV" == "1" ]]; then
+    info "Hogwarts not cloned — skipped"
 else
-    if [[ "$ROLE" == "engineer" ]]; then
-        info "Hogwarts not cloned — skipped"
-    else
-        info "Hogwarts skipped (role: $ROLE)"
-    fi
+    info "Hogwarts local dev skipped (pass --hogwarts-dev to set it up)"
 fi
 
 # =============================================================================
@@ -548,10 +546,11 @@ gh auth status &>/dev/null 2>&1   && pass "GitHub auth" || fail "GitHub auth"
 [[ -d "/Applications/Google Chrome.app" ]] && pass "Chrome"         || info "Chrome"
 [[ -d "/Applications/Claude.app" ]]        && pass "Claude Desktop" || info "Claude Desktop"
 
-if [[ "$ROLE" == "engineer" ]]; then
-    [[ -d "/Applications/WebStorm.app" ]]  && pass "WebStorm"       || info "WebStorm"
-    [[ -d "$HOME/hogwarts" ]]              && pass "hogwarts repo"   || fail "hogwarts"
-    [[ -d "$HOME/codebase" ]]              && pass "codebase repo"   || fail "codebase"
+# Repos + IDEs are universal now
+[[ -d "/Applications/WebStorm.app" ]]  && pass "WebStorm"       || info "WebStorm"
+[[ -d "$HOME/hogwarts" ]]              && pass "hogwarts repo"   || fail "hogwarts"
+[[ -d "$HOME/codebase" ]]              && pass "codebase repo"   || fail "codebase"
+if [[ "$HOGWARTS_DEV" == "1" ]]; then
     [[ -f "$HOME/hogwarts/.env" ]]         && pass "hogwarts .env"   || info "hogwarts .env (need gist)"
     [[ -d "$HOME/hogwarts/node_modules" ]] && pass "hogwarts deps"   || info "hogwarts deps"
 fi
@@ -606,11 +605,11 @@ if [[ -z "$GIST_ID" ]]; then
     echo "  5. Load secrets when you have the gist ID:"
     echo "     bash ~/kun/.claude/scripts/secrets.sh <GIST_ID>"
 fi
-if [[ "$ROLE" == "engineer" ]]; then
-    echo ""
-    echo -e "${BD}IDE plugins (manual install from Marketplace):${NC}"
-    echo "  • WebStorm: Settings → Plugins → search 'Claude Code' → Install"
-    echo "  • VS Code: Extensions → search 'Claude Code' → Install"
+echo ""
+echo -e "${BD}IDE plugins (manual install from Marketplace):${NC}"
+echo "  • WebStorm: Settings → Plugins → search 'Claude Code' → Install"
+echo "  • VS Code: Extensions → search 'Claude Code' → Install"
+if [[ "$HOGWARTS_DEV" == "1" ]]; then
     echo ""
     echo -e "${BD}Run hogwarts:${NC}"
     echo "  cd ~/hogwarts && pnpm dev"

--- a/.claude/scripts/onboarding-windows.ps1
+++ b/.claude/scripts/onboarding-windows.ps1
@@ -27,6 +27,7 @@ param(
     [string]$GitEmail,
     [switch]$EssentialsOnly,    # default: clone all org repos
     [switch]$WithTailscale,      # optional: enable Tailscale SSH
+    [switch]$HogwartsDev,        # optional: set up hogwarts local dev
     [string]$ReposDir = $env:USERPROFILE
 )
 
@@ -142,27 +143,26 @@ if (-not $hasPnpm) {
 # =============================================================================
 Step "2" "Applications"
 
-if ($Role -eq "engineer") {
-    # WebStorm
-    $wsPath = "${env:ProgramFiles}\JetBrains\WebStorm*"
-    $wsLocal = "$HOME_DIR\AppData\Local\JetBrains\Toolbox\apps\WebStorm"
-    if (-not (Test-Path $wsPath) -and -not (Test-Path $wsLocal)) {
-        Info "Installing WebStorm..."
-        winget install --id JetBrains.WebStorm -e --accept-source-agreements --accept-package-agreements 2>$null
-        if ($?) { Pass "WebStorm installed" } else { Info "WebStorm — install manually from jetbrains.com" }
-    } else {
-        Pass "WebStorm"
-    }
+# IDEs on every machine — full workstation regardless of role
+# WebStorm
+$wsPath = "${env:ProgramFiles}\JetBrains\WebStorm*"
+$wsLocal = "$HOME_DIR\AppData\Local\JetBrains\Toolbox\apps\WebStorm"
+if (-not (Test-Path $wsPath) -and -not (Test-Path $wsLocal)) {
+    Info "Installing WebStorm..."
+    winget install --id JetBrains.WebStorm -e --accept-source-agreements --accept-package-agreements 2>$null
+    if ($?) { Pass "WebStorm installed" } else { Info "WebStorm — install manually from jetbrains.com" }
+} else {
+    Pass "WebStorm"
+}
 
-    # VS Code
-    $hasCode = Get-Command code -EA SilentlyContinue
-    if (-not $hasCode) {
-        Info "Installing VS Code..."
-        winget install --id Microsoft.VisualStudioCode -e --accept-source-agreements --accept-package-agreements
-        Pass "VS Code installed"
-    } else {
-        Pass "VS Code"
-    }
+# VS Code
+$hasCode = Get-Command code -EA SilentlyContinue
+if (-not $hasCode) {
+    Info "Installing VS Code..."
+    winget install --id Microsoft.VisualStudioCode -e --accept-source-agreements --accept-package-agreements
+    Pass "VS Code installed"
+} else {
+    Pass "VS Code"
 }
 
 # Chrome
@@ -271,16 +271,15 @@ function Symlink-Home($repo) {
     }
 }
 
+# Every machine clones the full org — any machine can be any task.
 Clone-Repo "kun"; Symlink-Home "kun"
-if ($Role -eq "engineer") {
-    Clone-Repo "hogwarts"; Symlink-Home "hogwarts"
-    Clone-Repo "codebase"; Symlink-Home "codebase"
+Clone-Repo "hogwarts"; Symlink-Home "hogwarts"
+Clone-Repo "codebase"; Symlink-Home "codebase"
 
-    if (-not $EssentialsOnly) {
-        Info "Cloning remaining databayt org repos..."
-        foreach ($repo in @("shadcn", "radix", "souq", "mkan", "shifa", "swift-app", "distributed-computer", "marketing")) {
-            Clone-Repo $repo; Symlink-Home $repo
-        }
+if (-not $EssentialsOnly) {
+    Info "Cloning remaining databayt org repos..."
+    foreach ($repo in @("shadcn", "radix", "souq", "mkan", "shifa", "swift-app", "distributed-computer", "marketing")) {
+        Clone-Repo $repo; Symlink-Home $repo
     }
 }
 
@@ -447,7 +446,8 @@ Step "7" "Hogwarts — dependencies, database, seed"
 
 $HOGWARTS_DIR = "$ReposDir\hogwarts"
 
-if ($Role -eq "engineer" -and (Test-Path $HOGWARTS_DIR)) {
+# Heavy local-dev setup is opt-in (-HogwartsDev), not role-gated
+if ($HogwartsDev -and (Test-Path $HOGWARTS_DIR)) {
     Push-Location $HOGWARTS_DIR
 
     # .env
@@ -491,10 +491,10 @@ if ($Role -eq "engineer" -and (Test-Path $HOGWARTS_DIR)) {
     if ($LASTEXITCODE -eq 0) { Pass "Build passes" } else { Info "Build issues — run 'pnpm build'" }
 
     Pop-Location
-} elseif ($Role -eq "engineer") {
+} elseif ($HogwartsDev) {
     Info "Hogwarts not cloned — skipped"
 } else {
-    Info "Hogwarts skipped (role: $Role)"
+    Info "Hogwarts local dev skipped (pass -HogwartsDev to set it up)"
 }
 
 # =============================================================================
@@ -517,11 +517,11 @@ if (Test-Path "$HOME_DIR\.ssh\id_ed25519")   { Pass "SSH key" }    else { Fail "
 $ghCheck = gh auth status 2>&1
 if ($LASTEXITCODE -eq 0) { Pass "GitHub auth" } else { Fail "GitHub auth" }
 
-# Repos
+# Repos (universal)
 if (Test-Path "$KUN_DIR")                    { Pass "kun repo" }     else { Fail "kun" }
-if ($Role -eq "engineer") {
-    if (Test-Path "$HOGWARTS_DIR")            { Pass "hogwarts repo" } else { Fail "hogwarts" }
-    if (Test-Path "$HOME_DIR\codebase")       { Pass "codebase repo" } else { Fail "codebase" }
+if (Test-Path "$HOGWARTS_DIR")               { Pass "hogwarts repo" } else { Fail "hogwarts" }
+if (Test-Path "$ReposDir\codebase")          { Pass "codebase repo" } else { Fail "codebase" }
+if ($HogwartsDev) {
     if (Test-Path "$HOGWARTS_DIR\.env")       { Pass "hogwarts .env" } else { Info "hogwarts .env (need gist)" }
     if (Test-Path "$HOGWARTS_DIR\node_modules") { Pass "hogwarts deps" } else { Info "hogwarts deps" }
 }
@@ -575,11 +575,11 @@ if (-not $GistId) {
     Write-Host "  5. Load secrets when you have the gist ID:"
     Write-Host "     & ~\kun\.claude\scripts\secrets.ps1 -GistId <ID>"
 }
-if ($Role -eq "engineer") {
-    Write-Host ""
-    Write-Host "IDE plugins (manual install from Marketplace):" -ForegroundColor Cyan
-    Write-Host "  - WebStorm: Settings -> Plugins -> search 'Claude Code' -> Install"
-    Write-Host "  - VS Code:  Extensions -> search 'Claude Code' -> Install"
+Write-Host ""
+Write-Host "IDE plugins (manual install from Marketplace):" -ForegroundColor Cyan
+Write-Host "  - WebStorm: Settings -> Plugins -> search 'Claude Code' -> Install"
+Write-Host "  - VS Code:  Extensions -> search 'Claude Code' -> Install"
+if ($HogwartsDev) {
     Write-Host ""
     Write-Host "Run hogwarts:" -ForegroundColor Cyan
     Write-Host "  cd ~\hogwarts; pnpm dev"

--- a/.claude/scripts/setup.ps1
+++ b/.claude/scripts/setup.ps1
@@ -74,69 +74,32 @@ Info "scripts"
 
 Write-Host ""
 
-# ── Scoped config ───────────────────────────────────────────────
-Write-Host "Scoped config ($Role)" -ForegroundColor Cyan
+# ── Full config (universal — every machine is a full autonomous worker) ──
+# Role no longer scopes capability; it's only a label + secrets-trust tier.
+# Secrets stay scoped via which Gist you're handed — MCP servers without a
+# key simply don't connect, so a full mcp.json is safe everywhere.
+Write-Host "Full config" -ForegroundColor Cyan
 
-$commonCmds = @("docs", "repos", "screenshot", "codebase")
-switch ($Role) {
-    "engineer" {
-        Get-ChildItem "$KUN_DIR\.claude\commands\*.md" -EA SilentlyContinue | ForEach-Object {
-            Copy-Item $_.FullName "$CLAUDE_DIR\commands\" -Force
-        }
-    }
-    "business" {
-        ($commonCmds + @("proposal", "pricing", "weekly")) | ForEach-Object {
-            $src = "$KUN_DIR\.claude\commands\$_.md"
-            if (Test-Path $src) { Copy-Item $src "$CLAUDE_DIR\commands\" -Force }
-        }
-    }
-    "content" {
-        ($commonCmds + @("translate", "content-calendar", "weekly")) | ForEach-Object {
-            $src = "$KUN_DIR\.claude\commands\$_.md"
-            if (Test-Path $src) { Copy-Item $src "$CLAUDE_DIR\commands\" -Force }
-        }
-    }
-    "ops" {
-        ($commonCmds + @("monitor", "costs", "incident", "weekly")) | ForEach-Object {
-            $src = "$KUN_DIR\.claude\commands\$_.md"
-            if (Test-Path $src) { Copy-Item $src "$CLAUDE_DIR\commands\" -Force }
-        }
-    }
+# All commands/skills
+Get-ChildItem "$KUN_DIR\.claude\commands\*.md" -EA SilentlyContinue | ForEach-Object {
+    Copy-Item $_.FullName "$CLAUDE_DIR\commands\" -Force
 }
 $cmdCount = (Get-ChildItem "$CLAUDE_DIR\commands\*.md" -EA SilentlyContinue).Count
 Info "commands ($cmdCount)"
 
-# Agent index
-$roleIndex = if ($Role -eq "engineer") { "$KUN_DIR\.claude\agents\_index.md" } else { "$KUN_DIR\.claude\agents\_index-$Role.md" }
-if (Test-Path $roleIndex) {
-    Copy-Item $roleIndex "$CLAUDE_DIR\agents\_index.md" -Force
+# Full agent index
+if (Test-Path "$KUN_DIR\.claude\agents\_index.md") {
+    Copy-Item "$KUN_DIR\.claude\agents\_index.md" "$CLAUDE_DIR\agents\_index.md" -Force
     Info "agent index (_index.md)"
 }
 
-# Settings
-if ($Role -eq "engineer") {
-    Copy-Item "$KUN_DIR\.claude\settings-windows.json" "$CLAUDE_DIR\settings.json" -Force
-    Info "settings (full + hooks)"
-} else {
-    @'
-{
-  "env": {
-    "DEV_PORT": "3000"
-  }
-}
-'@ | Set-Content "$CLAUDE_DIR\settings.json"
-    Info "settings (minimal)"
-}
+# Full settings + hooks
+Copy-Item "$KUN_DIR\.claude\settings-windows.json" "$CLAUDE_DIR\settings.json" -Force
+Info "settings (full + hooks)"
 
-# MCP
-$mcpFile = switch ($Role) {
-    "engineer" { "$KUN_DIR\.claude\mcp.json" }
-    "business" { "$KUN_DIR\.claude\mcp-business.json" }
-    "content"  { "$KUN_DIR\.claude\mcp-content.json" }
-    "ops"      { "$KUN_DIR\.claude\mcp-ops.json" }
-}
-if (Test-Path $mcpFile) {
-    Copy-Item $mcpFile "$CLAUDE_DIR\mcp.json" -Force
+# Full MCP fleet
+if (Test-Path "$KUN_DIR\.claude\mcp.json") {
+    Copy-Item "$KUN_DIR\.claude\mcp.json" "$CLAUDE_DIR\mcp.json" -Force
     $mcpCount = (Select-String -Path "$CLAUDE_DIR\mcp.json" -Pattern '"description"' -EA SilentlyContinue).Count
     Info "MCP servers ($mcpCount)"
 }

--- a/.claude/scripts/setup.sh
+++ b/.claude/scripts/setup.sh
@@ -75,88 +75,49 @@ info "scripts"
 
 echo ""
 
-# ── Scoped config (role-specific) ───────────────────────────────
-echo -e "${B}Scoped config ($ROLE)${NC}"
+# ── Full config (universal — every machine is a full autonomous worker) ──
+# Role no longer scopes capability; it's only a label + secrets-trust tier.
+# Secrets stay scoped via which Gist you're handed — MCP servers without a
+# key simply don't connect, so a full mcp.json is safe everywhere.
+echo -e "${B}Full config${NC}"
 
-# Commands/skills per role
-COMMON_CMDS="docs repos screenshot codebase"
-case "$ROLE" in
-    engineer)
-        cp "$KUN_DIR/.claude/commands/"*.md "$CLAUDE_DIR/commands/" 2>/dev/null || true
-        ;;
-    business)
-        for cmd in $COMMON_CMDS proposal pricing weekly; do
-            cp "$KUN_DIR/.claude/commands/$cmd.md" "$CLAUDE_DIR/commands/" 2>/dev/null || true
-        done
-        ;;
-    content)
-        for cmd in $COMMON_CMDS translate content-calendar weekly; do
-            cp "$KUN_DIR/.claude/commands/$cmd.md" "$CLAUDE_DIR/commands/" 2>/dev/null || true
-        done
-        ;;
-    ops)
-        for cmd in $COMMON_CMDS monitor costs incident weekly; do
-            cp "$KUN_DIR/.claude/commands/$cmd.md" "$CLAUDE_DIR/commands/" 2>/dev/null || true
-        done
-        ;;
-esac
+# All commands/skills
+cp "$KUN_DIR/.claude/commands/"*.md "$CLAUDE_DIR/commands/" 2>/dev/null || true
 CMD_COUNT=$(ls "$CLAUDE_DIR/commands/"*.md 2>/dev/null | wc -l | tr -d ' ')
 info "commands ($CMD_COUNT)"
 
-# Agent index per role
-ROLE_INDEX="$KUN_DIR/.claude/agents/_index-${ROLE}.md"
-if [[ "$ROLE" == "engineer" ]]; then
-    ROLE_INDEX="$KUN_DIR/.claude/agents/_index.md"
-fi
-if [ -f "$ROLE_INDEX" ]; then
-    cp "$ROLE_INDEX" "$CLAUDE_DIR/agents/_index.md"
+# Full agent index
+if [ -f "$KUN_DIR/.claude/agents/_index.md" ]; then
+    cp "$KUN_DIR/.claude/agents/_index.md" "$CLAUDE_DIR/agents/_index.md"
     info "agent index (_index.md)"
 fi
 
-# Settings per role
-if [[ "$ROLE" == "engineer" ]]; then
-    if [[ "$(uname)" == "Darwin" ]]; then
-        cp "$KUN_DIR/.claude/settings.json" "$CLAUDE_DIR/settings.json"
-    else
-        cp "$KUN_DIR/.claude/settings-windows.json" "$CLAUDE_DIR/settings.json"
-    fi
-    info "settings (full + hooks)"
+# Full settings + hooks
+if [[ "$(uname)" == "Darwin" ]]; then
+    cp "$KUN_DIR/.claude/settings.json" "$CLAUDE_DIR/settings.json"
 else
-    cat > "$CLAUDE_DIR/settings.json" << 'SETTINGS'
-{
-  "env": {
-    "DEV_PORT": "3000"
-  }
-}
-SETTINGS
-    info "settings (minimal)"
+    cp "$KUN_DIR/.claude/settings-windows.json" "$CLAUDE_DIR/settings.json" 2>/dev/null || \
+        cp "$KUN_DIR/.claude/settings.json" "$CLAUDE_DIR/settings.json"
 fi
 chmod 600 "$CLAUDE_DIR/settings.json" 2>/dev/null || true
+info "settings (full + hooks)"
 
-# MCP per role
-case "$ROLE" in
-    engineer)  MCP_SRC="$KUN_DIR/.claude/mcp.json" ;;
-    business)  MCP_SRC="$KUN_DIR/.claude/mcp-business.json" ;;
-    content)   MCP_SRC="$KUN_DIR/.claude/mcp-content.json" ;;
-    ops)       MCP_SRC="$KUN_DIR/.claude/mcp-ops.json" ;;
-esac
-if [ -f "$MCP_SRC" ]; then
-    cp "$MCP_SRC" "$CLAUDE_DIR/mcp.json"
+# Full MCP fleet
+if [ -f "$KUN_DIR/.claude/mcp.json" ]; then
+    cp "$KUN_DIR/.claude/mcp.json" "$CLAUDE_DIR/mcp.json"
     chmod 600 "$CLAUDE_DIR/mcp.json" 2>/dev/null || true
     MCP_COUNT=$(grep -c '"description"' "$CLAUDE_DIR/mcp.json" 2>/dev/null || echo 0)
     info "MCP servers ($MCP_COUNT)"
 fi
 
-# Codebase clone (engineer only)
-if [[ "$ROLE" == "engineer" ]]; then
-    CODEBASE_DIR="$HOME/codebase"
-    if [ ! -d "$CODEBASE_DIR" ]; then
-        echo ""
-        echo -e "${Y}Cloning codebase...${NC}"
-        git clone git@github.com:databayt/codebase.git "$CODEBASE_DIR" 2>/dev/null || \
-        git clone https://github.com/databayt/codebase.git "$CODEBASE_DIR" 2>/dev/null || \
-        info "clone failed — run manually: git clone git@github.com:databayt/codebase.git ~/codebase"
-    fi
+# Codebase clone (every machine)
+CODEBASE_DIR="$HOME/codebase"
+if [ ! -d "$CODEBASE_DIR" ]; then
+    echo ""
+    echo -e "${Y}Cloning codebase...${NC}"
+    git clone git@github.com:databayt/codebase.git "$CODEBASE_DIR" 2>/dev/null || \
+    git clone https://github.com/databayt/codebase.git "$CODEBASE_DIR" 2>/dev/null || \
+    info "clone failed — run manually: git clone git@github.com:databayt/codebase.git ~/codebase"
 fi
 
 # Claude CLI (install if missing)

--- a/content/docs/configuration.mdx
+++ b/content/docs/configuration.mdx
@@ -288,14 +288,11 @@ Operational configuration: 100+ keyword-to-action mappings, MCP trigger table, s
 | context7 | Up-to-date library docs |
 | linear | Issue tracking |
 
-### Role-Specific MCP Configs
+### MCP Config — Universal
 
-| Role | Config File | Servers |
-|------|------------|---------|
-| **engineer** | mcp.json | All 18 servers |
-| **business** | mcp-business.json | github, slack, linear, stripe, notion, browser, context7, memory-bank |
-| **content** | mcp-content.json | github, slack, notion, browser, figma, context7, memory-bank, ref |
-| **ops** | mcp-ops.json | github, slack, vercel, sentry, neon, stripe, browser, posthog, memory-bank |
+Every machine gets the **full `mcp.json`** (all 18 servers). The machine, not the person, is the unit of capability — any machine can run any task. Access is controlled by **secrets, not config**: a server whose API key isn't in your `~/.claude/.env` simply doesn't connect (harmless), and which keys you hold is scoped by the **Gist** you're handed.
+
+> The legacy role-scoped `mcp-business.json` / `mcp-content.json` / `mcp-ops.json` are used only by the deprecated `install.sh`. The canonical installer is `setup.sh`, which installs the full `mcp.json` for everyone.
 
 ## Rules Engine (8 rules)
 
@@ -348,12 +345,14 @@ cd ~/kun; .\.claude\scripts\install.ps1
 
 ### Roles
 
-| Role | Skills | MCP | Hooks | Primary Human |
-|------|--------|-----|-------|---------------|
-| **engineer** | All 25 | All 18 | All 5 | Abdout, Ibrahim |
-| **business** | 11 (core + business) | 8 (mcp-business.json) | Prettier only | Ali, Mutaz |
-| **content** | 11 (core + content) | 8 (mcp-content.json) | Prettier only | Samia |
-| **ops** | 11 (core + ops) | 9 (mcp-ops.json) | All 5 | Sedon |
+Every machine gets the **full config** — all 25 skills, all 18 MCP servers, all 5 hooks. Role is a label + secrets-trust tier, not a capability gate (the machine is the unit of capability — any machine can run any task). Which API keys a machine holds is scoped by the **Gist** that person is handed.
+
+| Role | Config | Primary Human |
+|------|--------|---------------|
+| **engineer** | full (all skills, MCP, hooks) | Abdout, Ibrahim |
+| **business** | full | Ali, Mutaz |
+| **content** | full | Samia |
+| **ops** | full | Sedon |
 
 ### What the Installer Does
 

--- a/content/docs/mcp.mdx
+++ b/content/docs/mcp.mdx
@@ -81,18 +81,14 @@ MCP servers are configured in `~/.claude/mcp.json`:
 
 ## Installation
 
+Every machine gets the full MCP fleet (all 18 servers) — access is scoped by secrets (the Gist you're handed), not by config. One command, role is just a label:
+
 ```bash
-# Engineer (all 18 servers)
-cd ~/kun && bash .claude/scripts/install.sh
+# macOS/Linux
+cd ~/kun && bash .claude/scripts/setup.sh engineer
 
-# Business role (8 servers)
-cd ~/kun && bash .claude/scripts/install.sh business
-
-# Content role (8 servers)
-cd ~/kun && bash .claude/scripts/install.sh content
-
-# Ops role (9 servers)
-cd ~/kun && bash .claude/scripts/install.sh ops
+# Windows (PowerShell)
+cd ~/kun; .\.claude\scripts\setup.ps1 -Role engineer
 ```
 
 ## Troubleshooting — Browser / Playwright MCP

--- a/content/docs/onboarding.mdx
+++ b/content/docs/onboarding.mdx
@@ -51,10 +51,10 @@ Provisioning lands in six layers. Run these to confirm each — all green means 
 |---|---|---|
 | **Tools** | `for t in git node pnpm gh claude opencode; do command -v $t; done` | a path prints for each |
 | **Auth** | `gh auth status && ssh -T git@github.com` | "Logged in"; "successfully authenticated" |
-| **Code** | `ls ~/kun ~/hogwarts ~/codebase` *(engineer)* | directories exist |
+| **Code** | `ls ~/kun ~/hogwarts ~/codebase` | directories exist (all org repos on every machine) |
 | **Config** | `bash ~/.claude/scripts/health.sh` | `✅ healthy` (0 errors) |
 | **Surfaces** | `claude doctor` | all checks green |
-| **Product** *(engineer)* | `cd ~/hogwarts && pnpm dev` → open `localhost:3000` | login works (`admin@kingfahad.edu` / `1234`) |
+| **Product** *(if `--hogwarts-dev`)* | `cd ~/hogwarts && pnpm dev` → open `localhost:3000` | login works (`admin@kingfahad.edu` / `1234`) |
 
 `bash ~/.claude/scripts/health.sh` is the authoritative config gate but only audits `~/.claude/` — pair it with the other rows for a complete check.
 
@@ -67,27 +67,31 @@ Want a different result? Edit the source, then re-run the bootstrap (idempotent)
 | Which repos clone | Phase 4 repo list in `onboarding-{mac,linux}.sh` / `foreach` in `onboarding-windows.ps1`; or pass `--essentials-only` for just kun/hogwarts/codebase |
 | Where repos land | `--repos-dir <path>` (Mac/Linux) / `-ReposDir <path>` (Windows), or the wizard's "where to save repos" prompt |
 | Which tools install | Phase 1–2 of the `onboarding-*` backend for your OS |
-| MCP servers per role | role `case` in `setup.sh` / `setup.ps1` + the `mcp-<role>.json` files |
-| Skills / commands per role | role `case` in `setup.sh` (`COMMON_CMDS` + per-role list) |
-| Agents available | all are copied — add/remove files in `.claude/agents/` |
-| Secrets / env | `secrets.sh <GIST_ID>` + the contents of the private Gist |
+| MCP servers (universal) | edit `.claude/mcp.json` — every machine gets the full fleet |
+| Skills / commands (universal) | add/remove files in `.claude/commands/` — copied in full to every machine |
+| Agents (universal) | add/remove files in `.claude/agents/` |
+| Which keys a machine holds | scoped by the **Gist** you hand someone (`secrets.sh <GIST_ID>`), not by config |
+| hogwarts local dev | `--hogwarts-dev` / `-HogwartsDev` (default off) |
 | Tailscale on/off | `--with-tailscale` / `-WithTailscale` (default off) |
-| Role | re-run the wizard, or pass a different role arg to the backend |
 
 All installer scripts live in `~/kun/.claude/scripts/`. Print any backend's flags with no args (e.g. `bash ~/kun/.claude/scripts/onboarding-mac.sh`).
 
-### What each profile gets
+### Every machine is a full autonomous worker
 
-"Fully provisioned" is relative to your **role × OS × plan** — a missing surface may be correct for you, not a bug:
+**Config is universal — the machine, not the person, is the unit of capability.** Every machine gets all agents, all skills, the full MCP fleet, all hooks, and the entire org's repos. Any machine can run any task. Your **role** is just a label + a *secrets-trust tier* — it does not limit what your computer can do.
 
-| | engineer | business | content | ops |
-|---|:-:|:-:|:-:|:-:|
-| Repos | all org | kun | kun | kun |
-| MCP servers | ~18 | ~6 | ~6 | ~7 |
-| hogwarts local dev | ✓ | — | — | — |
-| Claude Desktop | Mac/Win | Mac/Win | Mac/Win | Mac/Win |
+| What | Every machine |
+|---|---|
+| Agents / skills / hooks | full set |
+| MCP servers | full fleet (~18) |
+| Repos | all of the databayt org |
+| IDEs (WebStorm + VS Code) | installed |
+| hogwarts local dev | opt-in (`--hogwarts-dev` / wizard prompt) — not role-gated |
 
-- **Linux**: Claude Desktop doesn't exist on Linux — your surfaces are the CLI, `claude.ai/code` in the browser, and the IDE plugins. A Linux box with those is complete; don't expect the Chat/Cowork/Code tabs.
+What still varies (and why):
+
+- **Secrets** — scoped, not by config but by which **Gist** you're handed. A machine only holds the keys it's trusted with; an MCP server without its key simply doesn't connect (harmless). Full config everywhere, contained blast radius.
+- **Linux**: Claude Desktop doesn't exist on Linux — surfaces are the CLI, `claude.ai/code` in the browser, and the IDE plugins. A Linux box with those is complete; don't expect the Chat/Cowork/Code tabs.
 - **No Pro/Max**: Desktop tabs are unavailable — the intended path is OpenCode + an `ANTHROPIC_API_KEY`.
 
 ---
@@ -117,11 +121,12 @@ The wizard auto-detects what it can and only asks for what it can't:
 | Welcome / start | always shown |
 | GitHub account? | always asked (opens `github.com/join` if "No") |
 | Anthropic account? | always asked (opens `claude.ai/login` if "No") |
-| Role: engineer / business / content / ops | inferred from `~/.claude/mcp.json` if exists |
+| Role (label + secrets-trust tier — does *not* limit config) | inferred from `~/.claude/mcp.json` if exists |
 | Full name, email (for git commits) | inferred from `git config --global` if set |
 | Secrets Gist ID | asked once, then persisted |
 | Pro/Max subscription? (affects Desktop tabs) | asked once |
 | Where to save databayt repos? | asked once: `Home root` / `~/databayt/` / `Custom...` |
+| Set up hogwarts local dev? (heavy, opt-in) | asked once |
 | Tailscale SSH? (remote control) | asked once |
 
 All answers persist in a state file. Re-runs skip questions already answered.
@@ -133,12 +138,12 @@ Eight phases run in the background. You can minimize the terminal and do other w
 | Phase | What |
 |---|---|
 | 1 | System Foundation — build tools, git, Node 22 LTS, pnpm, gh CLI |
-| 2 | Applications — WebStorm, VS Code, Chrome (engineer role) |
+| 2 | Applications — WebStorm, VS Code, Chrome (every machine) |
 | 3 | GitHub — SSH key, `gh auth login --web`, key uploaded |
-| 4 | Clone Repositories — kun + (engineer: hogwarts, codebase, all org repos) |
+| 4 | Clone Repositories — the full databayt org (every machine) |
 | 5 | Claude — Code CLI, Desktop (Mac/Win), OpenCode, Desktop MCP symlink, AGENTS.md, `c` + `o` functions in shell |
-| 6 | Kun Engine — `setup.sh <role>` populates `~/.claude/`, `secrets.sh` pulls `.env` |
-| 7 | Hogwarts — pnpm install, prisma generate + push + seed, build verify (engineer only) |
+| 6 | Kun Engine — `setup.sh` installs the full config (agents, skills, MCP, hooks); `secrets.sh` pulls `.env` |
+| 7 | Hogwarts — pnpm install, prisma generate + push + seed, build verify (only with `--hogwarts-dev`) |
 | 8 | Health Check — every tool / repo / config verified |
 | 9 (opt) | Tailscale — install + `up --ssh` if you opted in |
 
@@ -152,7 +157,7 @@ What's left needs a human at the keyboard. Auto-polling OAuth means the only **m
 |---|---|---|
 | Sign in to Claude Desktop | 1 (open + sign in) | not Pro/Max, or Linux |
 | Toggle computer-use in Desktop Settings | 1 | not Pro/Max, or Linux |
-| Install Claude Code plugin in WebStorm | 1 (if not auto) | not engineer role |
+| Install Claude Code plugin in WebStorm | 1 (if not auto) | — (WebStorm is on every machine) |
 | VS Code Claude extension | **0** | auto-installed via `code --install-extension` |
 | GitHub OAuth | **0** | `gh auth login --web` polls until done |
 | Anthropic CLI OAuth | **0** | `claude` first-run polls until done |
@@ -186,25 +191,13 @@ If something's missing the wizard skips that step and lists it under "things to 
 
 ## Which repos you get
 
-The wizard clones every active databayt org repo to your chosen directory (`~/`, `~/databayt/`, or custom). Engineer role gets everything; other roles get just `kun`.
+**Every machine clones the full databayt org** to your chosen directory (`~/`, `~/databayt/`, or custom) — any machine can touch any repo:
 
-| Repo | Engineer | Business | Content | Ops |
-|---|:-:|:-:|:-:|:-:|
-| **kun** — the engine config | ✓ | ✓ | ✓ | ✓ |
-| **hogwarts** — multi-tenant LMS (flagship) | ✓ | | | |
-| **codebase** — patterns, agents, blocks | ✓ | | | |
-| **shadcn** — UI component library | ✓ | | | |
-| **radix** — UI primitives | ✓ | | | |
-| **souq** — e-commerce marketplace | ✓ | | | |
-| **mkan** — rentals + booking | ✓ | | | |
-| **shifa** — medical platform | ✓ | | | |
-| **swift-app** — iOS/Swift mobile | ✓ | | | |
-| **distributed-computer** — infra | ✓ | | | |
-| **marketing** — landing pages | ✓ | | | |
+`kun` (engine config), `hogwarts` (multi-tenant LMS), `codebase` (patterns, agents, blocks), `shadcn` (UI library), `radix` (UI primitives), `souq` (e-commerce), `mkan` (rentals), `shifa` (medical), `swift-app` (iOS/Swift), `distributed-computer` (infra), `marketing` (landing pages).
 
 When you pick a custom directory, the wizard symlinks `~/kun`, `~/hogwarts`, etc. back to it so all existing tooling that hard-codes `~/kun` keeps working.
 
-To skip the optional repos: pass `--essentials-only` (Mac/Linux) or `-EssentialsOnly` (Windows) — keeps just kun, hogwarts, codebase.
+To clone only the essentials (kun, hogwarts, codebase): pass `--essentials-only` (Mac/Linux) or `-EssentialsOnly` (Windows).
 
 ---
 

--- a/content/docs/team.mdx
+++ b/content/docs/team.mdx
@@ -27,31 +27,22 @@ Research on Claude/Anthropic products, sharing economy models, revenue distribut
 ### Sedon — Facilitator
 Facilitates the business team (Ali + Mutaz) — clears blockers, runs the ops cadence. Saudi operations: bank account, physical presence, payments.
 
-## Role-Specific MCP Configs
+## Config — Universal
 
-| Role | Config File | Servers |
-|------|------------|---------|
-| **engineer** | mcp.json | github, vercel, neon, stripe, sentry, figma, shadcn, browser, + 10 more |
-| **business** | mcp-business.json | github, slack, linear, stripe, notion, browser, context7, memory-bank |
-| **content** | mcp-content.json | github, slack, notion, browser, figma, context7, memory-bank, ref |
-| **ops** | mcp-ops.json | github, slack, vercel, sentry, neon, stripe, browser, posthog, memory-bank |
+Every machine gets the **full config**: all agents, all 25 skills, the full MCP fleet (18 servers), all hooks. The machine — not the person — is the unit of capability, so any machine can run any task. Role is a label + a *secrets-trust tier*; it does not limit what the computer can do.
+
+What still varies: **which API keys a machine holds**, scoped by the Gist that person is handed. An MCP server without its key just doesn't connect (harmless).
 
 ## Setup
 
-One command per role — installs or updates config + runs health check:
+One command — installs or updates the full config + runs a health check. The role arg is just a label:
 
 ```bash
 # macOS/Linux
 cd ~/kun && bash .claude/scripts/setup.sh engineer
-cd ~/kun && bash .claude/scripts/setup.sh business
-cd ~/kun && bash .claude/scripts/setup.sh content
-cd ~/kun && bash .claude/scripts/setup.sh ops
 
 # Windows (PowerShell)
 cd ~/kun; .\.claude\scripts\setup.ps1 -Role engineer
-cd ~/kun; .\.claude\scripts\setup.ps1 -Role business
-cd ~/kun; .\.claude\scripts\setup.ps1 -Role content
-cd ~/kun; .\.claude\scripts\setup.ps1 -Role ops
 ```
 
 Re-run anytime to update config after pulling latest from git.


### PR DESCRIPTION
## Summary

Shift from role-scoped to **universal config**: the machine, not the person, is the unit of capability. Every machine gets the full config + all repos so any machine — engineer or not — can run any autonomous task. Role becomes a label + a *secrets-trust tier*, not a capability gate.

## Decisions (confirmed)

- **Universal config** — all agents, all 25 skills, full `mcp.json` (18 servers), all hooks, full settings on every machine
- **Scoped secrets** — no code change: which keys a machine holds is set by the **Gist** it's handed; an MCP server without its key just doesn't connect (harmless)
- **All repos universal** — every machine clones the full org
- **Hogwarts local dev opt-in** — `--hogwarts-dev` / `-HogwartsDev` flag (was role-gated)
- **IDEs universal** — WebStorm + VS Code on every machine (last role-gate on capability removed)

## Changes

**Scripts**
- `setup.sh` / `setup.ps1` — removed per-role branching; always install full config
- `onboarding-{mac,linux}.sh` + `onboarding-windows.ps1` — full-org clone for everyone; IDEs universal; hogwarts dev behind `--hogwarts-dev`; Phase 7/8/footer ungated
- `health.sh` / `health.ps1` — universal expected counts
- `installer.{sh,ps1,-linux.sh}` — added "set up hogwarts local dev?" prompt; role kept as label

**Docs**
- `onboarding.mdx` — "Every machine is a full autonomous worker", full-org repos, updated wizard/verify/modify tables
- `configuration.mdx`, `team.mdx`, `mcp.mdx` — universal-config doctrine; role = label + secrets tier

## Notes / follow-up

- Legacy `install.sh` / `install.ps1` + `mcp-{business,content,ops}.json` left as a **deprecated** path (`setup.sh` is canonical). Follow-up ticket to remove them together.
- **Open question for review**: I made **IDEs universal** (every machine installs WebStorm + VS Code) since that was the last role-gate on the machine. If you'd rather keep IDEs opt-in for non-dev folks, easy to revert that hunk.

## Test plan

- [x] `bash -n` + `shellcheck -S error` clean on all changed scripts
- [x] `pnpm build` renders the 4 MDX files
- [ ] Vercel build green
- [ ] `setup.sh <any-role>` installs identical full config (verify on a real machine)
- [ ] hogwarts dev only runs with `--hogwarts-dev`

Closes #64

🤖 Generated with [Claude Code](https://claude.com/claude-code)