### PR TITLE
docs: universalize remaining role tables (skills, mcp)

### DIFF
--- a/content/docs/mcp.mdx
+++ b/content/docs/mcp.mdx
@@ -52,14 +52,9 @@ description: 18 MCP servers connecting Claude Code to external services
 
 ## Role-Specific Configs
 
-Not every team member needs all 18 servers. Each role gets a tailored MCP config:
+**Every machine gets the full `mcp.json` (all 18 servers).** Config is universal — any machine can run any task. Access is scoped by **secrets, not config**: a server whose API key isn't in your `~/.claude/.env` simply doesn't connect, and which keys you hold is set by the **Gist** you're handed.
 
-| Role | Config File | Server Count |
-|------|------------|--------------|
-| **engineer** | mcp.json | All 18 |
-| **business** | mcp-business.json | 8 (github, slack, linear, stripe, notion, browser, context7, memory-bank) |
-| **content** | mcp-content.json | 8 (github, slack, notion, browser, figma, context7, memory-bank, ref) |
-| **ops** | mcp-ops.json | 9 (github, slack, vercel, sentry, neon, stripe, browser, posthog, memory-bank) |
+> The legacy role-scoped `mcp-business.json` / `mcp-content.json` / `mcp-ops.json` are used only by the deprecated `install.sh`. Canonical installer is `setup.sh` (full fleet for everyone).
 
 ## Configuration
 

--- a/content/docs/skills.mdx
+++ b/content/docs/skills.mdx
@@ -68,14 +68,9 @@ description: 25 reusable skills with keyword triggers
 | /costs | `costs` | API spend breakdown and optimization |
 | /incident | `incident [severity]` | P0/P1/P2 incident response workflow |
 
-## Role Availability
+## Availability — Universal
 
-| Role | Available Skills |
-|------|-----------------|
-| **engineer** | All 25 |
-| **business** | Core + business (proposal, pricing, weekly, docs, repos) |
-| **content** | Core + content (translate, content-calendar, docs, repos) |
-| **ops** | Core + ops (monitor, costs, incident, docs, repos) |
+**Every machine gets all 25 skills.** Config is universal — the machine, not the person, is the unit of capability, so any machine can run any skill. Role is a label + secrets-trust tier, not a skill gate (a skill that calls a service whose key you don't hold simply can't complete that call).
 
 ## How Skills Work
 


### PR DESCRIPTION
Two role-scoped tables missed in #67's universal-config pass — `skills.mdx` Role Availability and a second MCP role table in `mcp.mdx`. Both reframed to universal config + secrets-trust tier. Closes #68