### PR TITLE
docs: make onboarding.mdx the entry hub + refresh index

### DIFF
--- a/content/docs/index.mdx
+++ b/content/docs/index.mdx
@@ -9,9 +9,11 @@ description: Kun (كن) — The Databayt Engine
 
 ## What is Kun?
 
-Kun is not a server. Not a platform. It is the brain that coordinates **14 repositories**, **4 team members**, and every tool in the stack — from git commit to Stripe checkout to team standup.
+Kun is not a server. Not a platform. It is the brain that coordinates **14 repositories**, **6 team members**, and every tool in the stack — from git commit to Stripe checkout to team standup.
 
 **One word, and it happens.**
+
+> **New here? Start with [Onboarding](/docs/onboarding).** One paste takes a fresh Mac, Windows, or Linux machine to a fully provisioned databayt workstation — then it links you to everything else.
 
 ## The Company
 
@@ -25,8 +27,8 @@ Kun is not a server. Not a platform. It is the brain that coordinates **14 repos
 
 | Component | Count | Purpose |
 |-----------|-------|---------|
-| **Agents** | 28 | Specialized AI across 6 chains |
-| **Skills** | 17 | One-command workflows |
+| **Agents** | 40 | Specialized AI across 7 chains |
+| **Skills** | 25 | One-command workflows |
 | **MCP Servers** | 18 | External tool integrations |
 | **Rules** | 8 | Auto-activating guardrails |
 | **Hooks** | 5 | Guaranteed automation |
@@ -45,10 +47,12 @@ Kun is not a server. Not a platform. It is the brain that coordinates **14 repos
 
 | Name | Role |
 |------|------|
-| **Abdout** | Builder |
+| **Abdout** | Founder & Tech Lead |
+| **Ibrahim** | Senior Fullstack Engineer |
 | **Ali** | QA Engineer + Sales |
-| **Samia** | R&D & Kun Caretaker |
-| **Sedon** | Executor |
+| **Mutaz** | Product Engineer (business) |
+| **Samia** | R&D |
+| **Sedon** | Facilitator |
 
 ## The Products
 
@@ -72,7 +76,7 @@ Establish real-world solutions. **$500/month burn**: Claude Code ($200) + servic
 
 ### Phase 1: Developer Engine (Done)
 
-28 agents, 17 skills, 18 MCP servers, 8 rules, 5 hooks, 100+ keywords — all operational.
+40 agents, 25 skills, 18 MCP servers, 8 rules, 5 hooks, 100+ keywords — all operational.
 
 ### Phase 2: Team Engine (Current)
 

--- a/content/docs/onboarding.mdx
+++ b/content/docs/onboarding.mdx
@@ -561,18 +561,31 @@ For anything else, file an issue at https://github.com/databayt/kun/issues.
 
 ---
 
-## Reference
+## Where to go next
 
-- [Claude Code — install detail and config](/docs/claude-code)
-- [Cowork ↔ Code bridge](/docs/cowork)
-- [Apps — Claude in Slack, Figma, Asana](/docs/apps)
-- [Captain — decisions and delegation](/docs/captain)
-- [Connectors — MCP catalog](/docs/connectors)
-- [Secrets — Gist-based provisioning](/docs/secrets)
-- [Self-hosting — Tailscale / tmux / Docker (optional)](/docs/self-hosting)
-- [Dispatch — Apple Notes bridge](/docs/dispatch)
-- [Repositories — full org map](/docs/repositories)
-- [Keywords — full vocabulary](/docs/keywords)
-- [OpenCode](https://opencode.ai)
-- [Anthropic Directory](https://claude.ai/directory)
-- [Contributing — github-workflow rule](https://github.com/databayt/kun/blob/main/.claude/rules/github-workflow.md)
+This page is the front door. Once your machine is provisioned, branch out from here:
+
+**Set up & verify**
+- [Claude Code](/docs/claude-code) — CLI install detail + config (incl. OpenCode)
+- [MCP](/docs/mcp) — the server fleet + `/mcp-doctor` browser recovery
+- [Secrets](/docs/secrets) — Gist-based provisioning (which keys your machine holds)
+- [Self-hosting](/docs/self-hosting) — Tailscale / tmux / Docker (optional)
+
+**Daily use**
+- [Keywords](/docs/keywords) — the full vocabulary, one word → a workflow
+- [Captain](/docs/captain) — decisions, delegation, the weekly rhythm
+- [Cowork ↔ Code](/docs/cowork) — same brain, two modes
+- [Dispatch](/docs/dispatch) — Apple Notes bridge for async updates
+
+**Understand the engine**
+- [Configuration](/docs/configuration) — universal-config blueprint
+- [Architecture](/docs/architecture) — the 5 layers
+- [Agents](/docs/agents) — the 40-agent fleet
+- [Team](/docs/team) — the 6 humans + roles
+
+**Contribute**
+- [Repositories](/docs/repositories) — full org map
+- [Contributing](https://github.com/databayt/kun/blob/main/.claude/rules/github-workflow.md) — issue → branch → PR → merge
+
+**External**
+- [OpenCode](https://opencode.ai) · [Apps — Claude in Slack/Figma/Asana](/docs/apps) · [Connectors — MCP catalog](/docs/connectors) · [Anthropic Directory](https://claude.ai/directory)


### PR DESCRIPTION
Make `onboarding.mdx` the canonical entry — grouped **Where to go next** hub routing to every other doc — and add a **Start here → /docs/onboarding** pointer on the docs home (plus refresh stale 28→40 agents / 17→25 skills / 4→6 team). Closes #70