### PR TITLE
docs: add Onboarding Field Notes (simple run log)

### DIFF
--- a/content/docs/onboarding-notes.mdx
+++ b/content/docs/onboarding-notes.mdx
@@ -1,0 +1,34 @@
+---
+title: Onboarding — Field Notes
+description: What we observed running onboarding on real machines
+---
+
+# Onboarding — Field Notes
+
+Ran the onboarding on a real machine? **Add a note below.** What worked, what broke, what was confusing, what you'd change. No format police — just append a dated block so the next person (and the next fix) has the context.
+
+Edit this file directly: the **Edit on GitHub** link on this page, or `content/docs/onboarding-notes.mdx` in the repo.
+
+---
+
+## Template (copy this)
+
+```
+## YYYY-MM-DD — <name> — <OS> / <role>
+
+- **Worked:**
+- **Broke / confusing:**
+- **Changed or want changed:**
+```
+
+---
+
+## Notes
+
+Newest on top.
+
+### 2026-05-22 — (example) — macOS / engineer
+
+- **Worked:** one-liner ran clean; repos + config landed.
+- **Broke / confusing:** —
+- **Changed or want changed:** (delete this example once there are real notes)

--- a/content/docs/onboarding.mdx
+++ b/content/docs/onboarding.mdx
@@ -8,7 +8,9 @@ description: Fresh machine to fully working dev environment in one paste
 > One paste. ~20 minutes mostly silent. ≤3 clicks at the end.
 > A fresh Mac, Windows, or Linux laptop becomes a fully provisioned databayt environment — every tool installed, every repo cloned, every Claude surface working.
 
-This is the single source of truth for joining databayt. It covers every OS, every Claude surface, every dotfile, every external account. If something here doesn't match what you see on your machine, that's a bug — file an issue.
+This is the single source of truth for joining databayt. It covers every OS, every Claude surface, every dotfile, every external account.
+
+> **Ran this on a real machine?** Jot what you saw in [Field Notes](/docs/onboarding-notes) — what worked, what broke, what to change. That's how this page gets better each run.
 
 ---
 
@@ -584,6 +586,7 @@ This page is the front door. Once your machine is provisioned, branch out from h
 - [Team](/docs/team) — the 6 humans + roles
 
 **Contribute**
+- [Field Notes](/docs/onboarding-notes) — jot what you observed running this on a real machine
 - [Repositories](/docs/repositories) — full org map
 - [Contributing](https://github.com/databayt/kun/blob/main/.claude/rules/github-workflow.md) — issue → branch → PR → merge
 


### PR DESCRIPTION
Dead-simple field-notes log for real-machine onboarding runs — append a dated block, no processing. Linked from onboarding.mdx. Closes the 'how do we give feedback' ask without any pipeline. Closes the issue above.