### PR TITLE
fix(routing): /docs/<slug> 404 — locale redirect

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -6,6 +6,18 @@ const nextConfig: NextConfig = {
     ignoreBuildErrors: true,
   },
   reactStrictMode: false,
+  // Locale-less docs URLs (e.g. shared links like /docs/onboarding) redirect
+  // to the default locale. The docs render under /[lang]/docs/[[...slug]], so
+  // without this a bare /docs/<slug> 404s.
+  async redirects() {
+    return [
+      {
+        source: "/docs/:path*",
+        destination: "/en/docs/:path*",
+        permanent: false,
+      },
+    ];
+  },
 };
 
 const withMDX = createMDX();


### PR DESCRIPTION
Locale-less docs sub-paths (e.g. `/docs/onboarding`, used in the pinned announcement #77) 404'd. Add `/docs/:path*` → `/en/docs/:path*` redirect. Closes the issue above.