### PR TITLE
docs: Q3 sprint plan page + refresh epics to match

### DIFF
--- a/content/docs/epics.mdx
+++ b/content/docs/epics.mdx
@@ -1,150 +1,125 @@
 ---
 title: Epics
-description: 57 stories across 12 epics with sprint plan for April-June 2026
+description: "Q3 2026 PMF quarter — six epics across two bets, plus the engine already shipped."
 ---
 
 # Epics & Stories
 
-57 stories across 12 epics, organized by phase. Sprints run April-June 2026.
+The work, organized by epic. For the time-phased view — which sprint, when, with exit gates — see the **[Sprint Plan](/docs/sprint)**. Each epic below is a live GitHub tracking issue; that issue is the source of truth, this page is the map.
 
-## Overview
+> Refreshed for **Q3 2026 (Jun–Aug)**. The previous April–June plan is superseded — see the [Sprint Plan](/docs/sprint) for this quarter's context, team, and cash position.
 
-| Epic | Phase | Stories | Status |
-|------|-------|---------|--------|
-| E1: CLAUDE.md Configuration | 1 | 5 | Done |
-| E2: Agent Fleet | 1 | 6 | Done |
-| E3: Skill Library | 1 | 5 | Done |
-| E4: MCP Ecosystem | 1 | 5 | Done |
-| E5: Hook Automation | 1 | 4 | Done |
-| E6: Rules & Memory | 1 | 4 | Done |
-| E7: Team Configuration | 2 | 5 | Planned |
-| E8: Hogwarts Pilot | 2 | 5 | **In Progress** |
-| E9: Agent Teams & CI/CD | 2 | 4 | Planned |
-| E10: Revenue & Operations | 2 | 5 | Planned |
-| E11: Agent SDK Platform | 3 | 4 | Future |
-| E12: Enterprise & Optimization | 3 | 3 | Future |
+## This quarter (Q3 2026 · Jun–Aug)
 
-## Phase 1: Developer Engine (Done)
+The whole team is pointed at two bets — **PMF via school finance** and a **mobile public launch** — to prove product-market fit with two pilot schools. No monetization this quarter; that is a Q4 decision. Full framing, sprints, and runway live in the [Sprint Plan](/docs/sprint).
 
-### E1: CLAUDE.md Configuration
+| Epic | Bet | Owner | Tracker |
+|------|-----|-------|---------|
+| School Finance Module | 1 | Abdout | [hogwarts#313](https://github.com/databayt/hogwarts/issues/313) |
+| Onboarding Friction Kill | 1 | Abdout / web | [hogwarts#314](https://github.com/databayt/hogwarts/issues/314) |
+| PMF Pilots | both | Mutaz / Ali | [hogwarts#316](https://github.com/databayt/hogwarts/issues/316) |
+| Mobile API Layer | 2 | Abdout + Ibrahim | [hogwarts#315](https://github.com/databayt/hogwarts/issues/315) |
+| Mobile Public Launch | 2 | Ibrahim | [swift-app#3](https://github.com/databayt/swift-app/issues/3) |
+| Q3 master tracker | — | Abdout | [kun#76](https://github.com/databayt/kun/issues/76) |
 
-- [x] User-level CLAUDE.md (stack, mode, preferences)
-- [x] Project-level CLAUDE.md (context, architecture)
-- [x] Repo-level CLAUDE.md (100+ keywords, workflows)
-- [x] Keyword system (dev, build, deploy, saas, test...)
-- [x] Configuration hierarchy validation
+## Bet 1 — PMF via School Finance
 
-### E2: Agent Fleet
+### School Finance Module · [hogwarts#313](https://github.com/databayt/hogwarts/issues/313)
 
-- [x] Stack chain (7): nextjs, react, typescript, tailwind, prisma, shadcn, authjs
-- [x] Design chain (4): orchestration, architecture, pattern, structure
-- [x] UI chain (4): shadcn, atom, template, block
-- [x] DevOps chain (3): build, deploy, test
-- [x] VCS chain (2): git, github
-- [x] Specialized (8): middleware, i18n, semantic, sse, optimize, performance, comment, icon
+Build the school's **own** financial features — fee collection from parents, billing, salaries, payroll. The PMF wedge: the system a school runs its money through is the stickiest seat in the building. (Not Databayt-collects-from-schools billing — that is Q4+.)
 
-### E3: Skill Library
+- [ ] [#255](https://github.com/databayt/hogwarts/issues/255) Finance accounts: readiness & open work
+- [ ] [#263](https://github.com/databayt/hogwarts/issues/263) Payment system: end-to-end audit, gaps, phased roadmap
+- [ ] [#264](https://github.com/databayt/hogwarts/issues/264) Auto-provision fee structures at onboarding
+- [ ] [#269](https://github.com/databayt/hogwarts/issues/269) New fee structure: reuse the announcement approach
+- [ ] [#273](https://github.com/databayt/hogwarts/issues/273) QA: Fee Lifecycle end-to-end walkthrough
+- [ ] Salaries & payroll module v1 — *new, to be filed*
+- [ ] Finance reporting — *new, to be filed*
 
-- [x] Workflow: /dev, /build, /quick, /deploy
-- [x] Creation: /atom, /template, /block, /saas
-- [x] Quality: /test, /security, /performance, /fix
-- [x] Documentation: /docs, /codebase, /repos
-- [x] QA: /handover (5-pass across 2 environments)
+### Onboarding Friction Kill · [hogwarts#314](https://github.com/databayt/hogwarts/issues/314)
 
-### E4: MCP Ecosystem
+Eliminate the onboarding friction the pilot reported first-hand — *make a few users love you*.
 
-- [x] UI & Design: shadcn, figma, tailwind, a11y, storybook
-- [x] Testing: browser (headless), browser-headed
-- [x] DevOps: github, vercel, sentry, gcloud
-- [x] Data: neon, postgres, stripe, keychain
-- [x] Knowledge: ref, context7, linear
+- [ ] [#254](https://github.com/databayt/hogwarts/issues/254) Outlook/Hotmail not receiving OTP emails
+- [ ] [#298](https://github.com/databayt/hogwarts/issues/298) no middle-school option
+- [ ] [#299](https://github.com/databayt/hogwarts/issues/299) teacher count default (200) too high
+- [ ] [#300](https://github.com/databayt/hogwarts/issues/300) student count multiples-of-5 not practical
+- [ ] [#301](https://github.com/databayt/hogwarts/issues/301) / [#306](https://github.com/databayt/hogwarts/issues/306) responsive breakage
+- [ ] [#304](https://github.com/databayt/hogwarts/issues/304) back button slow
+- [ ] [#305](https://github.com/databayt/hogwarts/issues/305) add currency selection
+- [ ] [#307](https://github.com/databayt/hogwarts/issues/307) Next button stuck after fees
 
-### E5: Hook Automation
+### PMF Pilots · [hogwarts#316](https://github.com/databayt/hogwarts/issues/316)
 
-- [x] Auto-format (Prettier on Write/Edit)
-- [x] Port management (kill 3000 before dev)
-- [x] Browser launch (Chrome after dev)
-- [x] Session logging (timestamps)
+Two free pilots (King Fahad — Sudanese — plus a 2nd) actively using finance + mobile, with a documented PMF signal that feeds the Q4 cash decision.
 
-### E6: Rules & Memory
+- [ ] King Fahad re-engagement + JTBD interviews
+- [ ] Source 2nd free pilot (3–5 school pipeline)
+- [ ] 2nd pilot onboarding
+- [ ] Usage tracking on both pilots
+- [ ] PMF write-up + case study → Q4 cash brief
 
-- [x] 8 path-scoped rules (auth, i18n, prisma, tailwind, testing, deployment, multi-repo, org-refs)
-- [x] Preference memory (port, env, pnpm)
-- [x] Component memory (59 atoms, 31 templates, 4 blocks)
-- [x] Repository memory (14 repos)
+## Bet 2 — Mobile Public Launch
 
-## Phase 2: Team Engine (Current)
+### Mobile API Layer · [hogwarts#315](https://github.com/databayt/hogwarts/issues/315)
 
-### E7: Team Configuration
+Backend API layer for the iOS + Android apps. Shares the finance domain with Bet 1 (payments + invoices).
 
-| Story | Owner | Priority |
-|-------|-------|----------|
-| Shared settings.json via git | Abdout | P0 |
-| Role-based installer (engineer/business/content) | Abdout | P0 |
-| Windows setup guide + PowerShell installer | Sedon | P1 |
-| Onboarding documentation for all roles | Samia | P1 |
-| Local override support (.local.json) | Abdout | P0 |
+**P0 — store gates**
 
-### E8: Hogwarts Pilot (King Fahad Schools)
+- [ ] [#274](https://github.com/databayt/hogwarts/issues/274) account export (data portability)
+- [ ] [#275](https://github.com/databayt/hogwarts/issues/275) account delete
+- [ ] [#276](https://github.com/databayt/hogwarts/issues/276) translation cache
+- [ ] [#277](https://github.com/databayt/hogwarts/issues/277) payments (Apple Pay + Stripe)
+- [ ] [#278](https://github.com/databayt/hogwarts/issues/278) invoices
+- [ ] [#279](https://github.com/databayt/hogwarts/issues/279) consent (TOS, Privacy, COPPA, GDPR-K)
 
-| Story | Owner | Priority |
-|-------|-------|----------|
-| Admission block — 5-pass QA clean | Abdout | P0 |
-| Notification system — SMS + in-app for parents | Abdout | P0 |
-| Messaging — school-parent communication | Abdout | P1 |
-| Arabic content + user guide | Samia | P0 |
-| Client onboarding plan + training materials | Ali | P0 |
+**P1 — teacher / admin / guardian**
 
-### E9: Agent Teams & CI/CD
+- [ ] [#281](https://github.com/databayt/hogwarts/issues/281) grade entry
+- [ ] [#282](https://github.com/databayt/hogwarts/issues/282) report cards
+- [ ] [#283](https://github.com/databayt/hogwarts/issues/283) attendance
+- [ ] [#284](https://github.com/databayt/hogwarts/issues/284) admin staff + classes
+- [ ] [#285](https://github.com/databayt/hogwarts/issues/285) online exams
+- [ ] [#286](https://github.com/databayt/hogwarts/issues/286) teacher schedule
+- [ ] [#287](https://github.com/databayt/hogwarts/issues/287) guardian write actions
+- [ ] [#288](https://github.com/databayt/hogwarts/issues/288) universal search
 
-| Story | Owner | Priority |
-|-------|-------|----------|
-| Agent Teams parallel feature build | Abdout | P0 |
-| GitHub Actions PR review (Agent SDK) | Abdout | P0 |
-| Scheduled cloud tasks (health, deps) | Abdout | P1 |
-| Pattern compliance CI check | Abdout | P1 |
+### Mobile Public Launch · [swift-app#3](https://github.com/databayt/swift-app/issues/3)
 
-### E10: Revenue & Operations
+Ship the Hogwarts app to the public App Store (iOS) + Google Play (Android).
 
-| Story | Owner | Priority |
-|-------|-------|----------|
-| Stripe billing integration for Hogwarts | Abdout | P0 |
-| Client outreach templates (Arabic) | Ali | P0 |
-| Financial tracking dashboard (Cowork + Stripe MCP) | Ali | P1 |
-| Arabic marketing content for ed.databayt.org | Samia | P1 |
-| Competitive analysis: school platforms in Sudan | Samia | P2 |
+- [ ] Unblock tooling — JDK, Xcode simulator/SDK, Code Connect
+- [ ] App shell + navigation (Swift + Kotlin)
+- [ ] Atoms → screens (auth, dashboard, attendance, fees)
+- [ ] Consume the Mobile API Layer
+- [ ] Store compliance (privacy, account export/delete, consent)
+- [ ] Submit to both stores + public launch
+- [ ] ⚠️ **Prerequisite:** create `databayt/kotlin-app` — the Android repo does not exist yet
 
-## Phase 3: Company Engine (Future)
+## Already shipped — the engine
 
-### E11: Agent SDK Platform
+The kun engine that lets six people operate like twenty. Operational since Phase 1:
 
-- [ ] CI/CD review agent (auto-review every PR)
-- [ ] Deploy verification agent (post-deploy health)
-- [ ] School onboarding agent (automated tenant setup)
-- [ ] Client report agent (weekly status generation)
+| Capability | Count |
+|---|---|
+| Agents | 40 |
+| Skills | 25 |
+| MCP servers | 18 |
+| Rules | 8 |
+| Hooks | 5 |
+| Keywords | 100+ |
 
-### E12: Enterprise & Optimization
+Detail: [Configuration](/docs/configuration) · [Agents](/docs/agents) · [Architecture](/docs/architecture) · [Keywords](/docs/keywords).
 
-- [ ] SSO/SCIM + audit logging
-- [ ] Prompt caching + batch API (95% cost savings)
-- [ ] Pattern distribution packaging
+## Next — Q4 and beyond
 
-## Sprint Plan (April-June 2026)
+Once PMF is proven this quarter, Q4 opens:
 
-| Sprint | Dates | Focus | Key Deliverables |
-|--------|-------|-------|-----------------|
-| **S1** | Apr 1-14 | Foundation | Installer scripts, role configs, fumadocs site |
-| **S2** | Apr 15-28 | Hogwarts QA | Admission 5-pass, notification system |
-| **S3** | May 1-14 | Team + Revenue | Cowork onboarding (Ali, Samia), Stripe billing |
-| **S4** | May 15-28 | Automation | Agent Teams, CI/CD, scheduled tasks |
-| **S5** | Jun 1-14 | Pilot Launch | King Fahad Schools go-live, monitoring |
+- **The cash decision** — light monetization, a pre-seed raise, a sponsored build, or cut burn (see [Sprint Plan → Cash and runway](/docs/sprint#cash-and-runway)).
+- **Share-economy framework** — the Contribution-Units operational model and the future `databayt/revenue` repo (Samia-owned R&D; see [Share Economy](/docs/share-economy)).
+- **Deferred products** — Mkan soft launch and Souq reactivation, both parked behind Hogwarts this quarter.
 
-### Sprint 1 Detail (Current)
+---
 
-| Task | Owner | Status |
-|------|-------|--------|
-| Refactor docs to Databayt context | Abdout | Done |
-| Update fumadocs MDX site | Abdout | In Progress |
-| Create role-based installer | Abdout | Planned |
-| Update repositories.json (11 → 14 repos) | Abdout | Planned |
-| Windows PowerShell installer | Sedon | Planned |
+For the sprint-by-sprint timeline, exit gates, team long/short vision, and the machine-readiness prerequisites, see the **[Sprint Plan](/docs/sprint)**.

--- a/content/docs/meta.json
+++ b/content/docs/meta.json
@@ -14,6 +14,7 @@
     "---Operations---",
     "captain",
     "team",
+    "sprint",
     "share-economy",
     "onboarding",
     "dispatch",

--- a/content/docs/sprint.mdx
+++ b/content/docs/sprint.mdx
@@ -9,6 +9,18 @@ Spend this quarter's runway to buy **product-market-fit proof**: two Sudanese sc
 
 This is the living plan. Day-to-day work and discussion happen on the GitHub epics linked below; this page is the map.
 
+## Before the sprint — machines ready, one workflow
+
+Every sprint here is executed through the **kun engine**: we build by vibe coding *within architectural constraints* (humans design, AI generates — see [Architecture](/docs/architecture) and [Configuration](/docs/configuration)) and ship through **one unified workflow** (issue → branch → PR → merge). That only works when every machine is provisioned identically — so a ready machine is the entry ticket, not an afterthought.
+
+Before any sprint work begins, each teammate:
+
+1. **Provisions the machine** — [Onboarding](/docs/onboarding) is the single source of truth. One paste does it — `curl -fsSL https://kun.databayt.org/install | bash` (macOS/Linux) or `iwr https://kun.databayt.org/install.ps1 | iex` (Windows): every tool, every repo, the full Claude config.
+2. **Verifies green** — `bash ~/.claude/scripts/health.sh` and `claude doctor` (all checks green = ready). Steps in [Onboarding → Verify everything](/docs/onboarding#verify-everything).
+3. **Reads the workflow** — how we capture and ship work: the [Issue pipeline](/docs/issue), the [keyword vocabulary](/docs/keywords), and the [github-workflow rule](https://github.com/databayt/kun/blob/main/.claude/rules/github-workflow.md) (issue → branch → PR → merge).
+
+This is the **hard gate for Sprint 0**: Ibrahim + Mutaz fully onboarded and green by **May 31** — no feature work starts on an unprovisioned machine.
+
 ## Two bets
 
 | | Bet 1 — PMF via School Finance | Bet 2 — Mobile Public Launch |
@@ -54,7 +66,7 @@ Two-week cadence: Monday plan, Wednesday check, Friday review. Each sprint's **e
 ### Sprint 0 — Kickoff (now → May 31)
 **Goal:** onboard the team, stand up the issue map, clear debris.
 
-- Onboard **Ibrahim + Mutaz** (deadline May 31); run config-health checks on their machines.
+- Onboard **Ibrahim + Mutaz** (deadline May 31) via [Onboarding](/docs/onboarding) — one-paste install, then `health.sh` + `claude doctor` green (see *Before the sprint* above).
 - Create the epics *(done)*; refresh this page + the epics page to v4; log the north-star PMF reframe as a Type-1 decision.
 - **Hygiene:** triage the two security-P0 PRs (marketing#1 unauthenticated upload-auth, souq#1); triage 17 stale dependabot PRs; freeze the dormant repos (souq, shifa, mkan, marketing).
 - **Create `databayt/kotlin-app`** — the Android repo does not exist yet — and push the local code.
@@ -147,8 +159,12 @@ We spend ~$1.6K of runway to buy one asset: proof that two schools love running 
 
 ## How we track and communicate
 
-Every workstream is a GitHub issue, and updates and discussion happen on the issue, not in chat (see [Issues](/docs/issue)). Each epic is a checklist that links its child issues; cross-repo mentions create backlinks automatically. Standups are auto-generated from commits, issues, and deploys — humans intervene on exceptions. The weekly cadence (plan / check / review) reads the epics and posts summaries.
+Every workstream is a GitHub issue, and updates and discussion happen on the issue, not in chat (see [Issues](/docs/issue)). Each epic is a checklist that links its child issues; cross-repo mentions create backlinks automatically. Standups are auto-generated from commits, issues, and deploys — humans intervene on exceptions. The weekly cadence (plan / check / review) reads the epics and posts summaries. Code ships through one path — issue → branch → PR → merge (the [github-workflow rule](https://github.com/databayt/kun/blob/main/.claude/rules/github-workflow.md)).
 
 ## Reference
 
-[Epics](/docs/epics) · [Team](/docs/team) · [Captain](/docs/captain) · [Products](/docs/products) · [Share Economy](/docs/share-economy). Strategy lives in the kun repo `docs/`: [NORTH-STAR](https://github.com/databayt/kun/blob/main/docs/NORTH-STAR.md), [CONSTITUTION](https://github.com/databayt/kun/blob/main/docs/CONSTITUTION.md), [PRINCIPLES](https://github.com/databayt/kun/blob/main/docs/PRINCIPLES.md), [CEO-OS](https://github.com/databayt/kun/blob/main/docs/CEO-OS.md), [AGILE](https://github.com/databayt/kun/blob/main/docs/AGILE.md).
+**Set up & workflow:** [Onboarding](/docs/onboarding) (machine provisioning + install) · [Claude Code](/docs/claude-code) · [Configuration](/docs/configuration) · [Architecture](/docs/architecture) · [Workflows](/docs/workflows) · [Issue pipeline](/docs/issue) · [github-workflow rule](https://github.com/databayt/kun/blob/main/.claude/rules/github-workflow.md)
+
+**Operations:** [Epics](/docs/epics) · [Team](/docs/team) · [Captain](/docs/captain) · [Products](/docs/products) · [Share Economy](/docs/share-economy)
+
+**Strategy** (kun repo `docs/`): [NORTH-STAR](https://github.com/databayt/kun/blob/main/docs/NORTH-STAR.md) · [CONSTITUTION](https://github.com/databayt/kun/blob/main/docs/CONSTITUTION.md) · [PRINCIPLES](https://github.com/databayt/kun/blob/main/docs/PRINCIPLES.md) · [CEO-OS](https://github.com/databayt/kun/blob/main/docs/CEO-OS.md) · [AGILE](https://github.com/databayt/kun/blob/main/docs/AGILE.md)

--- a/content/docs/sprint.mdx
+++ b/content/docs/sprint.mdx
@@ -1,0 +1,154 @@
+---
+title: Sprint Plan
+description: "Q3 2026 (Jun-Aug) — the PMF quarter: two bets, seven sprints, six people."
+---
+
+# Sprint Plan — Q3 2026 (Jun–Aug)
+
+Spend this quarter's runway to buy **product-market-fit proof**: two Sudanese schools running their **fees and payroll** through Hogwarts — on the web **and** a publicly launched mobile app — and defer all monetization to a **Q4 cash decision**.
+
+This is the living plan. Day-to-day work and discussion happen on the GitHub epics linked below; this page is the map.
+
+## Two bets
+
+| | Bet 1 — PMF via School Finance | Bet 2 — Mobile Public Launch |
+|---|---|---|
+| **Goal** | King Fahad + a 2nd free pilot run fees + payroll through Hogwarts and rely on it | iOS + Android live on the App Store + Google Play |
+| **Owner** | Abdout (engineering) · Mutaz/Ali (pilots) | Ibrahim (engineering) · Abdout (architecture) |
+| **Shared spine** | Mobile payments + invoices are the same finance domain — build the data layer once, expose to web and mobile | |
+| **Success** | 2 pilots actively using finance features; documented PMF signal | Public store presence; pilot staff and parents using the app |
+| **Not doing** | SaaS billing / Databayt collecting from schools (deferred to Q4+) | Web-only fallback — this is a full public launch |
+
+> **Why finance, even unpaid?** The system a school runs its money through is the stickiest seat in the building. The eventual business is monetizing the money-flow, not the software. Finance features now are the PMF wedge.
+
+## Epics — the living checklists
+
+All work rolls up to these GitHub tracking issues:
+
+| Epic | Bet | Tracks |
+|---|---|---|
+| [kun#76 — Q3 master tracker](https://github.com/databayt/kun/issues/76) | both | everything below + sprints + cash |
+| [hogwarts#313 — School Finance Module](https://github.com/databayt/hogwarts/issues/313) | 1 | fees, billing, salaries, payroll |
+| [hogwarts#314 — Onboarding Friction Kill](https://github.com/databayt/hogwarts/issues/314) | 1 | pilot field-feedback bugs |
+| [hogwarts#315 — Mobile API Layer](https://github.com/databayt/hogwarts/issues/315) | 2 | 6 P0 + 8 P1 endpoints |
+| [hogwarts#316 — PMF Pilots](https://github.com/databayt/hogwarts/issues/316) | both | King Fahad + 2nd pilot |
+| [swift-app#3 — Mobile Public Launch](https://github.com/databayt/swift-app/issues/3) | 2 | tooling → screens → stores |
+
+## Team — long and short vision
+
+Short = this quarter. Long = the 1–3 year trajectory.
+
+| Person | Role | Short (Q3) | Long |
+|---|---|---|---|
+| **Abdout** | Founder · CEO · Tech Lead | Finance-module architecture + billing/payroll spine; pair Ibrahim onto web; run the captain cadence; make the Q4 cash call | Shift from engineer-of-everything to CEO/allocator; end the bus factor; Databayt as the Arabic-first financial OS for schools |
+| **Ibrahim** | Engineer (mobile-strong) | Own Bet 2 end-to-end: tooling, the Swift + Kotlin apps, the mobile APIs with Abdout, public launch; contribute to Hogwarts web | Mobile + senior full-stack lead; the second load-bearing engineer; owner of the cross-platform surface |
+| **Mutaz** | Business lead (part-time) | Supervise Ali; run the pilot motion; design customer development; shape the Q4 monetization model | Head of business/commercial — go-to-market, monetization, edu-market expansion |
+| **Ali** | Sales + QA | QA the finance + mobile work; run pilot relationships; conduct customer-dev interviews; log everything on issues | Structured sales/customer-success operator; turns pilots into paying customers; future sales lead |
+| **Samia** | R&D · content · voiceover | Research the pattern behind each feature (catalog pattern, payroll best practices) ahead of build; sales content + voiceover | R&D lead + keeper of the share-economy / Contribution-Units model; the voice and content engine; the accessibility conscience |
+| **Sedon** | Facilitator · Ops (15h/wk) | Keep the business team unblocked (Mon/Wed/Fri); Saudi banking groundwork (MADA/STC Pay) for the future market; pilot logistics | Operations/facilitation lead, especially Saudi market entry |
+
+## The sprints
+
+Two-week cadence: Monday plan, Wednesday check, Friday review. Each sprint's **exit gate** follows the Definition of Done — `tsc --noEmit` and `pnpm build` pass, Arabic + English, RTL, responsive at 375 / 768 / 1440, a browser screenshot, deployed.
+
+### Sprint 0 — Kickoff (now → May 31)
+**Goal:** onboard the team, stand up the issue map, clear debris.
+
+- Onboard **Ibrahim + Mutaz** (deadline May 31); run config-health checks on their machines.
+- Create the epics *(done)*; refresh this page + the epics page to v4; log the north-star PMF reframe as a Type-1 decision.
+- **Hygiene:** triage the two security-P0 PRs (marketing#1 unauthenticated upload-auth, souq#1); triage 17 stale dependabot PRs; freeze the dormant repos (souq, shifa, mkan, marketing).
+- **Create `databayt/kotlin-app`** — the Android repo does not exist yet — and push the local code.
+- Samia kicks off pattern R&D.
+
+**Exit gate:** six people onboarded and working; epics live; debris cleared.
+
+### Sprint 5 — Foundations (Jun 1–14)
+**Goal:** remove onboarding friction; lay the finance and mobile foundations.
+
+- **Bet 1:** kill the onboarding bugs ([#298–307](https://github.com/databayt/hogwarts/issues/314), [#254](https://github.com/databayt/hogwarts/issues/254)); finance-module **architecture** (Abdout); harden fee structures ([#263](https://github.com/databayt/hogwarts/issues/263) / [#264](https://github.com/databayt/hogwarts/issues/264) / [#269](https://github.com/databayt/hogwarts/issues/269) / [#273](https://github.com/databayt/hogwarts/issues/273)).
+- **Bet 2:** **unblock mobile tooling** (JDK, Xcode simulator/SDK, Code Connect); scaffold the iOS + Android app shells; first P0 APIs ([#276](https://github.com/databayt/hogwarts/issues/276) translate, [#279](https://github.com/databayt/hogwarts/issues/279) consent).
+- **Pilots:** King Fahad re-engagement + JTBD interviews (Mutaz/Ali).
+
+**Exit gate:** onboarding walkthrough clean; finance schema migrated and types compile; both app shells run.
+
+### Sprint 6 — Core build (Jun 15–28)
+**Goal:** build the net-new finance pieces and the payment APIs.
+
+- **Bet 1:** **payroll / salaries module v1** (net-new); polished fee-collection flows.
+- **Bet 2:** P0 APIs — [#277](https://github.com/databayt/hogwarts/issues/277) payments, [#278](https://github.com/databayt/hogwarts/issues/278) invoices, [#274](https://github.com/databayt/hogwarts/issues/274) / [#275](https://github.com/databayt/hogwarts/issues/275) account export + delete; atoms become core screens (auth, dashboard).
+- **Pilots:** source the 2nd free pilot (build a 3–5 school pipeline).
+
+**Exit gate:** payroll v1 demoable; four of six P0 APIs done; core screens navigable.
+
+### Sprint 7 — Integrate (Jun 29 – Jul 12)
+*Q2 ends Jun 30 — record the PMF reframe at the OKR checkpoint.*
+
+**Goal:** complete the P0 surface; connect mobile to finance.
+
+- **Bet 1:** payroll v1 complete + finance reporting; pay down tech debt (the `ApplicationSession.userId` foreign-key migration).
+- **Bet 2:** all **6 P0 APIs done**; the mobile fee-payment flow (a parent pays via the app); begin P1 APIs ([#281–288](https://github.com/databayt/hogwarts/issues/315)).
+- **Pilots:** 2nd pilot identified; onboarding started.
+
+**Exit gate:** six of six P0 APIs; a parent can pay a fee through the app on a test tenant.
+
+### Sprint 8 — Feature-complete (Jul 13–26)
+**Goal:** both surfaces feature-complete.
+
+- **Bet 1:** finance module **feature-complete on web** (fees + billing + salaries + payroll).
+- **Bet 2:** P1 APIs (attendance, grades, report cards, schedules, exams, admin, search); screens assembled; app feature-complete.
+- **Pilots:** both pilots actively running finance features.
+
+**Exit gate:** a feature-complete demo of web finance + the mobile app on a real tenant.
+
+### Sprint 9 — Harden + store submit (Jul 27 – Aug 9)
+**Goal:** production-harden and enter store review.
+
+- **Bet 1:** QA sweep, edge cases, Arabic/RTL, a security sweep.
+- **Bet 2:** store compliance (privacy, account delete [#275](https://github.com/databayt/hogwarts/issues/275), consent [#279](https://github.com/databayt/hogwarts/issues/279)), screenshots, listings; **submit to the App Store + Google Play**.
+- **Pilots:** gather the PMF signal (usage, satisfaction); Samia drafts the case study.
+
+**Exit gate:** apps submitted to both stores; security sweep clean; PMF metrics instrumented.
+
+### Sprint 10 — Launch + PMF proof (Aug 10–23)
+**Goal:** public launch; document the PMF asset; prepare the Q4 cash decision.
+
+- **Bet 2:** respond to store review and **launch publicly** (iOS + Android).
+- **Bet 1:** production-ready finance; both pilots live.
+- **PMF:** document the proof (2 pilots on finance + mobile); prepare the **Q4 cash-decision brief** (Mutaz + Abdout).
+- Quarter review + retrospective.
+
+**Exit gate:** public store listings live; the PMF write-up and Q4 cash brief published.
+
+## Cash and runway
+
+This quarter is **deliberately cash-flow-negative** — pure PMF, no monetization.
+
+| | Today (May 22) | End of August |
+|---|---|---|
+| Revenue / MRR | $0 | $0 (intentional) |
+| Capital | ~$4.2K | ~$2.5K |
+| Runway | ~8 months | ~5 months (at the burn-cut trigger) |
+| North star | 1 pilot, 0 paying | 2 active pilots, PMF proven |
+
+We spend ~$1.6K of runway to buy one asset: proof that two schools love running their money through Databayt. Hold burn at $500/mo (prompt caching, Haiku for exploration, the Batch API, Oracle's free tier for messaging).
+
+**Q4 cash-decision menu** (to brief in Sprint 10): light monetization of the finance module (a thin transaction fee, or a founding-partner rate); a pre-seed/seed raise on the PMF story; a sponsored build (Mudaraba); or cut burn. **If the PMF signal is weak by Sprint 9, escalate the cash decision early.**
+
+## Risks and watch-outs
+
+| Risk | Mitigation |
+|---|---|
+| Public mobile launch by August is aggressive (store review is unpredictable) | Submit by early Sprint 9; keep TestFlight / Play internal track as the fallback "done" |
+| Single-engineer bus factor | Land Ibrahim's onboarding by May 31; pair on web; spec every feature so agents can execute |
+| Payroll is net-new and may carry Sudan tax nuance | Samia R&D de-risks ahead of build; scope v1 to the pilot's real needs |
+| Mutaz is part-time, so Ali can re-overload | Mutaz delegates and supervises rather than stacking work on Ali |
+| Runway pressure is unaddressed by design | An explicit Q4 decision point; the early-escalation rule if PMF is weak by Sprint 9 |
+| Accessibility | All issues and docs properly structured for a screen reader; voice for sync |
+
+## How we track and communicate
+
+Every workstream is a GitHub issue, and updates and discussion happen on the issue, not in chat (see [Issues](/docs/issue)). Each epic is a checklist that links its child issues; cross-repo mentions create backlinks automatically. Standups are auto-generated from commits, issues, and deploys — humans intervene on exceptions. The weekly cadence (plan / check / review) reads the epics and posts summaries.
+
+## Reference
+
+[Epics](/docs/epics) · [Team](/docs/team) · [Captain](/docs/captain) · [Products](/docs/products) · [Share Economy](/docs/share-economy). Strategy lives in the kun repo `docs/`: [NORTH-STAR](https://github.com/databayt/kun/blob/main/docs/NORTH-STAR.md), [CONSTITUTION](https://github.com/databayt/kun/blob/main/docs/CONSTITUTION.md), [PRINCIPLES](https://github.com/databayt/kun/blob/main/docs/PRINCIPLES.md), [CEO-OS](https://github.com/databayt/kun/blob/main/docs/CEO-OS.md), [AGILE](https://github.com/databayt/kun/blob/main/docs/AGILE.md).


### PR DESCRIPTION
## Summary
- Adds `/en/docs/sprint` — the full Q3 (Jun–Aug) sprint plan as a docs page
- Registers it in the docs nav (`meta.json`, Operations section)

## Changes
- `content/docs/sprint.mdx`: new page — two bets (PMF finance + mobile launch), 7 sprints (S0 + S5–S10) with exit gates, team long/short vision, cash + runway, risks, issue-driven tracking
- `content/docs/meta.json`: add `sprint` to the nav

## Context
Part of Sprint 0 (master tracker databayt/kun#76). Supersedes the stale April–June plan in `epics.mdx` (to be refreshed to v4 separately).

## Test plan
- [ ] `pnpm dev` → visit `/en/docs/sprint`, confirm it renders and appears in the nav
- [ ] Links resolve (epics, issues)

Refs databayt/kun#76

🤖 Generated with [Claude Code](https://claude.com/claude-code)