### PR TITLE
feat(docs): hide logo on mobile, hamburger takes its place

### DIFF
--- a/src/components/template/site-header.tsx
+++ b/src/components/template/site-header.tsx
@@ -18,7 +18,8 @@ export function SiteHeader({ lang }: SiteHeaderProps) {
     <header className="bg-background sticky top-0 z-50 w-full">
       <div className="container-wrapper">
         <div className="flex h-(--header-height) items-center gap-2 md:gap-4 **:data-[slot=separator]:!h-4">
-          <Link href={`/${lang}`} className="flex items-center gap-1.5 me-6">
+          {/* Logo — hidden on mobile; the hamburger takes its place */}
+          <Link href={`/${lang}`} className="me-6 hidden items-center gap-1.5 md:flex">
             <span className="font-bold">Kun</span>
           </Link>
 
@@ -44,9 +45,9 @@ export function SiteHeader({ lang }: SiteHeaderProps) {
             <UserButton />
           </div>
 
-          {/* Mobile hamburger — visible below lg */}
+          {/* Mobile hamburger — at the start on mobile (logo's place), pushed right from md */}
           <MobileNav
-            className="ms-auto flex lg:hidden"
+            className="flex md:ms-auto lg:hidden"
             lang={lang}
             items={siteNav}
             sections={docsNav}


### PR DESCRIPTION
## Summary

Follow-up to #66. On phones the header showed both the **Kun** logo and a right-aligned hamburger. Hide the logo on mobile and let the hamburger sit at the **start** (the logo's old spot).

## Behavior by breakpoint

- **Mobile (<768px):** logo hidden; just `☰ Menu` at the start.
- **Tablet (768–1023px):** logo + nav on the left, hamburger pushed right (unchanged).
- **Desktop (≥1024px):** logo + nav + controls, no hamburger (unchanged).

Two Tailwind tweaks in `site-header.tsx`: logo `flex` → `hidden md:flex`; hamburger `ms-auto flex` → `flex md:ms-auto`.

## Test plan

Verified locally (dev build) with browser screenshots at 390 / 820 / 1280:

- [x] Mobile: only `☰ Menu` at the start, no "Kun"
- [x] Tablet: logo back, hamburger right
- [x] Desktop: logo + nav + controls, no hamburger
- [x] Hamburger panel still opens with the full docs tree

🤖 Generated with [Claude Code](https://claude.com/claude-code)