### PR TITLE
fix(report): captcha degrades gracefully when Turnstile unconfigured

### DIFF
--- a/src/lib/report/hard-filters.ts
+++ b/src/lib/report/hard-filters.ts
@@ -74,12 +74,14 @@ export function runHardFilters(
     };
   }
 
-  // HF3 — anonymous needs valid captcha. (When ctx.captchaValid is null, captcha
-  // wasn't required — e.g. authenticated user on a non-anon page.)
-  if (reporter.kind === "anonymous" && ctx.captchaValid !== true) {
+  // HF3 — reject only when captcha was CONFIGURED-but-failed (explicit false).
+  // When captchaValid is null (Turnstile not enforced: authenticated user, or a
+  // deployment with no Turnstile keys) the report proceeds at degraded trust —
+  // a missing env var must never silently eat a legit report.
+  if (reporter.kind === "anonymous" && ctx.captchaValid === false) {
     return {
       code: "HF3_no_captcha",
-      detail: "Anonymous reports require a valid Turnstile token.",
+      detail: "Anonymous report failed Turnstile verification.",
     };
   }
 

--- a/src/lib/report/pipeline.ts
+++ b/src/lib/report/pipeline.ts
@@ -19,7 +19,7 @@ import { hostMatches, runHardFilters } from "./hard-filters";
 import { reportSchema, type ReportInputParsed } from "./schema";
 import { computeScore } from "./score";
 import { classifyWithHaiku } from "./triage";
-import { verifyTurnstile } from "./turnstile";
+import { isTurnstileConfigured, verifyTurnstile } from "./turnstile";
 import { RateLimitError, type ReportAdapter } from "./adapters/adapter";
 import type {
   AITriageResult,
@@ -69,9 +69,11 @@ export async function runReportPipeline(
     throw err;
   }
 
-  // 4. Captcha — required for anonymous, optional otherwise
+  // 4. Captcha — enforced for anonymous ONLY when Turnstile is configured.
+  // Unconfigured → captchaValid stays null (HF3 won't reject) so reports still
+  // land (degraded trust). This stops a missing env var silently eating reports.
   let captchaValid: boolean | null = null;
-  if (reporter.kind === "anonymous") {
+  if (reporter.kind === "anonymous" && isTurnstileConfigured()) {
     captchaValid = await verifyTurnstile(input.captchaToken, opts.ip);
   }
 

--- a/src/lib/report/turnstile.ts
+++ b/src/lib/report/turnstile.ts
@@ -9,11 +9,21 @@
 
 const VERIFY_URL = "https://challenges.cloudflare.com/turnstile/v0/siteverify";
 
+/**
+ * Is Turnstile configured for this deployment? When false, captcha is NOT
+ * enforced — the pipeline leaves captchaValid=null so anonymous reports still
+ * go through (degraded trust, lower score) instead of silently vanishing.
+ * Misconfig must never silently eat a legit report.
+ */
+export function isTurnstileConfigured(): boolean {
+  return Boolean(process.env.TURNSTILE_SECRET_KEY);
+}
+
 export async function verifyTurnstile(token: string | undefined, ip: string): Promise<boolean> {
   const secret = process.env.TURNSTILE_SECRET_KEY;
   if (!secret) {
-    // In development without a Turnstile secret, pass through. Real deployments
-    // must set the env var (otherwise HF3 would reject every anonymous report).
+    // Unconfigured: callers should gate on isTurnstileConfigured() and not
+    // enforce captcha at all. If we still get here, pass in dev, fail in prod.
     if (process.env.NODE_ENV !== "production") return true;
     console.warn("[turnstile] TURNSTILE_SECRET_KEY not set in production");
     return false;


### PR DESCRIPTION
Anonymous reports silently vanished on kun: no Turnstile keys → HF3 rejected every anonymous report → pipeline returned ok:true (anti-spam) → UI said 'submitted' but no issue was created. That's why the clean-machine onboarding report was lost.

**Fix:** captcha is enforced only when Turnstile is *configured*; unconfigured → `captchaValid=null` → HF3 doesn't reject → report lands at degraded trust. A missing env var must never silently eat a legit report. Paired with `ANTHROPIC_API_KEY` now set in kun prod (triage lifts real bugs above the silent-reject threshold).

Verified: `pnpm build` passes.