### PR TITLE
fix(report): floor triage-null reports to needs-human (no silent drop)

### DIFF
--- a/src/lib/report/score.ts
+++ b/src/lib/report/score.ts
@@ -102,9 +102,15 @@ export function computeScore(
     }
   }
 
-  // AI failure cap
-  if (ctx.triage === null && bucket === "verified-report") {
-    bucket = "needs-human";
+  // AI failure handling — when triage is unavailable (no/invalid ANTHROPIC key
+  // or API error) we can't auto-assess, so never silently drop a report that
+  // already cleared the hard filters: cap the top (no auto-fix without AI
+  // confirmation) AND floor the bottom (a human reviews it). Everything that
+  // passed HF lands as needs-human. Mirrors the captcha-degradation principle:
+  // missing infra must never silently eat a legit report.
+  if (ctx.triage === null) {
+    if (bucket === "verified-report") bucket = "needs-human";
+    if (bucket === "silent-reject") bucket = "needs-human";
   }
 
   // Severity escalation


### PR DESCRIPTION
**Second silent-loss path found via your re-test.** Even after the captcha fix (#85), reports still vanished: anonymous reputation is only 4, and with no valid `ANTHROPIC_API_KEY` (all our keys are empty/expired) triage returns null → A=P=0 → score ~4+Q+C → under 30 → silent-reject.

**Fix:** score.ts only *capped* null-triage (verified→needs-human); this adds a *floor* (silent-reject→needs-human). When AI triage is unavailable we can't auto-assess, so any report that cleared the hard filters lands as **needs-human** for human review — never silently dropped. Mirrors the captcha-degradation principle.

Build passes.