### PR TITLE
fix(installer): ensure git before clone on Linux, surface real error

### DIFF
--- a/.claude/scripts/installer-linux.sh
+++ b/.claude/scripts/installer-linux.sh
@@ -113,13 +113,36 @@ open_url() {
     fi
 }
 
-# ── Bootstrap: clone kun if not present ─────────────────────────
+# ── Bootstrap: ensure git, then clone kun ───────────────────────
+# git is needed to clone the repo that installs git, so the wrapper
+# must provide it first. The backend (onboarding-linux.sh) re-checks
+# and no-ops if git is already present. Fresh Linux images ship curl
+# but often not git — without this, the clone below fails with a
+# misleading "check network" message.
+if ! command -v git >/dev/null 2>&1; then
+    notify "Installing" "git (prerequisite for clone)"
+    if   command -v apt-get >/dev/null 2>&1; then sudo apt-get update -y >/dev/null 2>&1 && sudo DEBIAN_FRONTEND=noninteractive apt-get install -y git >/dev/null 2>&1
+    elif command -v dnf     >/dev/null 2>&1; then sudo dnf install -y git >/dev/null 2>&1
+    elif command -v pacman  >/dev/null 2>&1; then sudo pacman -S --noconfirm --needed git >/dev/null 2>&1
+    elif command -v zypper  >/dev/null 2>&1; then sudo zypper install -y git >/dev/null 2>&1
+    fi
+fi
+if ! command -v git >/dev/null 2>&1; then
+    echo "git is required but could not be installed automatically." >&2
+    echo "Install git, then re-run:  curl -fsSL https://kun.databayt.org/install | bash" >&2
+    exit 1
+fi
+
+# ── Clone kun if not present ────────────────────────────────────
 if [[ ! -d "$HOME/kun" ]]; then
     notify "Cloning" "kun repo"
-    git clone https://github.com/databayt/kun.git "$HOME/kun" >/dev/null 2>&1 || {
-        echo "Could not clone databayt/kun. Check network and try again." >&2
+    if ! clone_err=$(git clone https://github.com/databayt/kun.git "$HOME/kun" 2>&1); then
+        echo "Could not clone databayt/kun:" >&2
+        echo "$clone_err" >&2
+        echo "If github.com is blocked on your network (proxy/VPN/firewall), that's the likely cause —" >&2
+        echo "raw.githubusercontent.com can stay reachable while github.com is blocked." >&2
         exit 1
-    }
+    fi
 fi
 
 BACKEND="$HOME/kun/.claude/scripts/onboarding-linux.sh"


### PR DESCRIPTION
## Summary
- Fresh Linux onboarding (`curl -fsSL https://kun.databayt.org/install | bash`) failed with "Could not clone databayt/kun. Check network and try again." even when the network was fine.
- Cause: the wrapper cloned the repo **before** git was installed (the backend installs git, but runs later), and `>/dev/null 2>&1` hid git's real `command not found` error behind a network red herring.

## Changes
- `.claude/scripts/installer-linux.sh`: ensure `git` exists before the clone — install it via the detected package manager (apt/dnf/pacman/zypper) if missing; the backend still re-checks and no-ops if already present.
- On clone failure, print git's **actual** stderr plus a hint that github.com may be blocked while `raw.githubusercontent.com` stays reachable (proxy/VPN/firewall), instead of unconditionally blaming the network.

## Test plan
- [x] `bash -n .claude/scripts/installer-linux.sh` passes
- [ ] Fresh Linux box without git: clone step succeeds (git auto-installed) instead of false "check network"
- [ ] Box where git can't be installed (no sudo): actionable "install git, then re-run" message, not a network red herring
- [ ] Genuine clone failure surfaces git's real error

## Notes
macOS `installer.sh` has the same muffled-clone pattern but git is effectively always present there (Xcode CLT). Out of scope for this PR — flag if you want a parity pass.

Closes #89

🤖 Generated with [Claude Code](https://claude.com/claude-code)