### PR TITLE
fix(installer): ensure git before clone on macOS, surface real error

### DIFF
--- a/.claude/scripts/installer.sh
+++ b/.claude/scripts/installer.sh
@@ -79,11 +79,28 @@ end try
 EOF
 }
 
-# ── Bootstrap: clone kun if not present ─────────────────────────
+# ── Bootstrap: ensure git, then clone kun ───────────────────────
+# git is needed to clone the repo that installs git, so the wrapper
+# must provide it first. On macOS, git ships with the Xcode Command
+# Line Tools; detect them prompt-free via `xcode-select -p` (same as
+# the backend, onboarding-mac.sh). Without this, the clone below fails
+# with a misleading "check network" alert on a fresh Mac.
+if ! xcode-select -p >/dev/null 2>&1; then
+    notify "Installing developer tools" "Xcode Command Line Tools (includes git)"
+    xcode-select --install >/dev/null 2>&1 || true
+    ask_choice "macOS is installing the Command Line Tools (this provides git).\n\nClick Install in the system dialog and wait for it to finish, then click Done here." "Done" "Skip" >/dev/null
+fi
+if ! command -v git >/dev/null 2>&1 || ! git --version >/dev/null 2>&1; then
+    osascript -e 'display alert "Setup needs git" message "git (Xcode Command Line Tools) is required but is not ready yet.\n\nFinish the Command Line Tools install, then re-run:\n\ncurl -fsSL https://kun.databayt.org/install | bash"' 2>/dev/null
+    exit 1
+fi
+
+# ── Clone kun if not present ────────────────────────────────────
 if [[ ! -d "$HOME/kun" ]]; then
     notify "Cloning kun repo..." "Setting up"
-    if ! git clone https://github.com/databayt/kun.git "$HOME/kun" >/dev/null 2>&1; then
-        osascript -e 'display alert "Setup failed" message "Could not clone databayt/kun. Check your network and try again."' 2>/dev/null
+    if ! clone_err=$(git clone https://github.com/databayt/kun.git "$HOME/kun" 2>&1); then
+        echo "$clone_err" >&2
+        osascript -e 'display alert "Setup failed" message "Could not clone databayt/kun. See the Terminal window for the exact git error.\n\nIf github.com is blocked on your network (proxy/VPN/firewall), that is the likely cause — the raw CDN can stay reachable while github.com is blocked."' 2>/dev/null
         exit 1
     fi
 fi


### PR DESCRIPTION
## Summary
- macOS parity for #90. The macOS wrapper cloned `databayt/kun` before git was guaranteed, and `>/dev/null 2>&1` masked the real failure behind a "check your network" alert.
- On a fresh Mac, git ships with Xcode Command Line Tools (installed by the backend, which runs *after* this clone) — so the clone failed on a brand-new machine even though connectivity was fine.

## Changes
- `.claude/scripts/installer.sh`: detect Command Line Tools prompt-free via `xcode-select -p` (same as `onboarding-mac.sh`); if absent, trigger `xcode-select --install`, guide the user through it with the existing dialog pattern, then verify `git --version` works.
- On clone failure, print git's **real** stderr to the Terminal and show an honest alert pointing there + flagging the github.com-blocked case — instead of injecting arbitrary stderr into an AppleScript string or always blaming the network.

## Test plan
- [x] `/bin/bash --version` → 3.2.57; `/bin/bash -n installer.sh` passes (script targets stock bash)
- [x] Verified the `if ! var=$(…)` negated-assignment construct behaves on bash 3.2
- [ ] Fresh Mac without CLT: guided through install, then clone succeeds (no false "check network")
- [ ] Genuine clone failure prints git's real error to the Terminal

Closes #91

🤖 Generated with [Claude Code](https://claude.com/claude-code)