### PR TITLE
fix(installer): ensure git before clone on Windows, fix failure detection

### DIFF
--- a/.claude/scripts/installer.ps1
+++ b/.claude/scripts/installer.ps1
@@ -131,12 +131,33 @@ function Notify($title, $body) {
 }
 Add-Type -AssemblyName Microsoft.VisualBasic   # for InputBox
 
-# ── Bootstrap: clone kun if missing ─────────────────────────────
+# ── Bootstrap: ensure git, then clone kun ───────────────────────
+# git is needed to clone the repo that installs git, so the wrapper
+# must provide it first. The backend (onboarding-windows.ps1) re-checks
+# and no-ops if git is already present. Windows ships no git by default —
+# without this, the clone below fails with a misleading "check network".
+if (-not (Get-Command git -EA SilentlyContinue)) {
+    if (Get-Command winget -EA SilentlyContinue) {
+        Notify "Installing" "git (prerequisite for clone)"
+        winget install --id Git.Git -e --accept-source-agreements --accept-package-agreements --silent
+        # Refresh PATH so git resolves in this session (same as backend)
+        $env:Path = [System.Environment]::GetEnvironmentVariable("Path", "Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path", "User")
+    }
+}
+if (-not (Get-Command git -EA SilentlyContinue)) {
+    [System.Windows.MessageBox]::Show("git is required but could not be installed automatically.`n`nInstall Git for Windows (https://git-scm.com/download/win), then re-run:`n`niwr https://kun.databayt.org/install.ps1 | iex", "Setup needs git", "OK", "Error") | Out-Null
+    exit 1
+}
+
+# ── Clone kun if missing ────────────────────────────────────────
 if (-not (Test-Path "$env:USERPROFILE\kun")) {
     Notify "Cloning" "kun repo"
-    git clone https://github.com/databayt/kun.git "$env:USERPROFILE\kun" 2>&1 | Out-Null
-    if (-not $?) {
-        [System.Windows.MessageBox]::Show("Could not clone databayt/kun. Check network.", "Setup failed", "OK", "Error") | Out-Null
+    # Capture output and gate on $LASTEXITCODE — after a pipeline, $? reflects
+    # the last element (e.g. Out-Null), not the native command's exit code.
+    $cloneOut = git clone https://github.com/databayt/kun.git "$env:USERPROFILE\kun" 2>&1
+    if ($LASTEXITCODE -ne 0) {
+        [Console]::Error.WriteLine(($cloneOut -join "`n"))
+        [System.Windows.MessageBox]::Show("Could not clone databayt/kun. See the terminal window for the exact git error.`n`nIf github.com is blocked on your network (proxy/VPN/firewall), that is the likely cause — the raw CDN can stay reachable while github.com is blocked.", "Setup failed", "OK", "Error") | Out-Null
         exit 1
     }
 }


### PR DESCRIPTION
## Summary
- Windows parity for #90/#92. The wrapper (`installer.ps1`, the live target of `iwr https://kun.databayt.org/install.ps1 | iex`) cloned `databayt/kun` before git existed — and Windows ships no git, so a fresh box failed at the clone with a "Check network" dialog.
- Two extra defects compounded it: `2>&1 | Out-Null` discarded git's error, and `if (-not $?)` checked the pipeline's last element (`Out-Null`), not git's exit code — so a genuine clone failure could slip past and surface later as a misleading "Backend missing".

## Changes
- `.claude/scripts/installer.ps1`: before cloning, ensure git via `winget install --id Git.Git` and refresh `$env:Path` from the registry (verbatim from `onboarding-windows.ps1`); if git still isn't available (e.g. no winget), show an actionable dialog (git-scm.com + the re-run command) and exit.
- Gate the clone on `$LASTEXITCODE -ne 0` (the correct idiom for native commands), capture git's output, and write the real error to the terminal on failure — with a github.com-blocked hint.

## Test plan
- [x] Edited region brace/paren balanced (5 open / 5 close); every construct mirrors working in-repo code (backend PATH refresh, `$LASTEXITCODE`, `MessageBox::Show`, `[Console]::Error.WriteLine`)
- [ ] ⚠️ No `pwsh` on the authoring machine, so this was **not** run through a PowerShell parser — worth a quick `pwsh -NoProfile -File installer.ps1 -NoGui` smoke test on a Windows box before relying on it
- [ ] Fresh Windows without git: winget installs git, clone succeeds (no false "check network")
- [ ] No winget: actionable "install Git for Windows, then re-run" dialog
- [ ] Real clone failure detected via `$LASTEXITCODE`, git's actual error reaches the terminal

## Scope note
`.claude/scripts/install.ps1` is the post-clone config installer (run from an existing `~/kun`), not the bootstrap path — out of scope.

Closes #94

🤖 Generated with [Claude Code](https://claude.com/claude-code)