### PR TITLE
fix(report): trim env values so stray newline in GITHUB_REPO can't break submissions

### DIFF
--- a/src/lib/report/adapter.ts
+++ b/src/lib/report/adapter.ts
@@ -26,8 +26,10 @@ import {
 } from "./adapters/adapter";
 import type { PipelineEvent, ReporterContext, ReportInput } from "./types";
 
-const REPO = process.env.GITHUB_REPO || "databayt/kun";
-const SALT = process.env.REPORT_IP_SALT || "kun-default-salt";
+// Trim env values — a stray trailing newline in GITHUB_REPO (e.g. "databayt/kun\n")
+// builds a malformed GitHub URL and silently breaks every report submission.
+const REPO = (process.env.GITHUB_REPO || "databayt/kun").trim();
+const SALT = (process.env.REPORT_IP_SALT || "kun-default-salt").trim();
 
 export const kunReportAdapter: ReportAdapter = {
   repo: REPO,

--- a/src/lib/report/pipeline.ts
+++ b/src/lib/report/pipeline.ts
@@ -37,7 +37,7 @@ export async function runReportPipeline(
   adapter: ReportAdapter,
   opts: { ip: string } = { ip: "0.0.0.0" }
 ): Promise<PipelineResult> {
-  const token = process.env.GITHUB_PERSONAL_ACCESS_TOKEN;
+  const token = process.env.GITHUB_PERSONAL_ACCESS_TOKEN?.trim();
   if (!token) {
     console.error("[report-pipeline] GITHUB_PERSONAL_ACCESS_TOKEN not configured");
     return { ok: false, error: "config" };


### PR DESCRIPTION
## Summary
- "Report an issue" submissions on kun.databayt.org failed with **"something went wrong, try again"** for every user.
- Root cause: the production `GITHUB_REPO` env var was set to `"databayt/kun\n"` (trailing newline, set 51 days ago). The adapter passed it verbatim into the GitHub issue URL, so `createIssue` POSTed to `/repos/databayt/kun%0A/issues`, threw, and the pipeline returned `error: "internal"` → the dialog showed its generic error.
- The pipeline's symmetric-success design masked this — almost every other path returns `ok:true`, so a *consistent* error pointed straight at the two `ok:false` branches (missing token / `createIssue` throw).

## Changes
- `src/lib/report/adapter.ts`: `.trim()` `GITHUB_REPO` and `REPORT_IP_SALT` at read time.
- `src/lib/report/pipeline.ts`: `.trim()` `GITHUB_PERSONAL_ACCESS_TOKEN` at read time.
- Production `GITHUB_REPO` env var corrected (newline removed) out of band.

## Test plan
- [x] Verified token + `databayt/kun` repo access locally (full push/issues perms, 200).
- [x] Confirmed `databayt/kun\n` produces a malformed/404 GitHub URL.
- [x] `tsc` clean for touched files (pre-existing unrelated `.next/types` layout errors remain).
- [ ] After deploy: submit a report from kun.databayt.org/en/docs/onboarding and confirm success.

🤖 Generated with [Claude Code](https://claude.com/claude-code)