### PR TITLE
fix(report): trim ANTHROPIC_API_KEY so stray newline can't 401 triage

### DIFF
--- a/src/lib/report/triage.ts
+++ b/src/lib/report/triage.ts
@@ -119,7 +119,7 @@ export async function classifyWithHaiku(
   input: ReportInputParsed,
   ctx: TriageContext
 ): Promise<AITriageResult | null> {
-  const apiKey = process.env.ANTHROPIC_API_KEY;
+  const apiKey = process.env.ANTHROPIC_API_KEY?.trim();
   if (!apiKey) {
     console.warn("[report-triage] ANTHROPIC_API_KEY not set; skipping triage");
     return null;


### PR DESCRIPTION
## Summary
- Defense-in-depth follow-up to #97. Trims `ANTHROPIC_API_KEY` at read time in `triage.ts` so a stray trailing newline can't cause `401 invalid x-api-key` and silently disable AI triage.

## Context (production incident)
While verifying the report fix end-to-end, prod logs surfaced two more broken env vars:
- **`AUTH_SECRET` missing** → `MissingSecret` on every request (auth broken site-wide). Fixed out of band (generated + set in prod).
- **`ANTHROPIC_API_KEY` invalid** → currently a junk value (`\nn\n`); needs a valid key. Triage degrades gracefully (reports still land as `needs-human`).

## Changes
- `src/lib/report/triage.ts`: `.trim()` the Anthropic key.

## Test plan
- [x] `tsc` clean for touched file.
- [x] Report submission verified working end-to-end on prod (issue created + closed).
- [ ] After a valid ANTHROPIC_API_KEY is set: confirm triage classifies (no 401 in logs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)