### PR TITLE
fix(onboarding): auto-open device page and copy code to clipboard during gh auth

### DIFF
--- a/.claude/scripts/onboarding-linux.sh
+++ b/.claude/scripts/onboarding-linux.sh
@@ -58,6 +58,32 @@ ERRORS=0
 pass() { echo -e "  ${G}✓${NC} $1"; }
 fail() { echo -e "  ${R}✗${NC} $1"; ERRORS=$((ERRORS + 1)); }
 info() { echo -e "  ${D}·${NC} $1"; }
+
+# Open a URL in the user's default browser; best-effort, returns silently.
+# Covers desktop Linux (xdg-open), Wayland (wlview), Debian (sensible-browser),
+# and WSL (wslview) so the install one-liner works on every Linux flavor.
+open_url() {
+    local url="$1"
+    if command -v xdg-open >/dev/null 2>&1; then
+        xdg-open "$url" >/dev/null 2>&1 &
+    elif command -v wslview >/dev/null 2>&1; then
+        wslview "$url" >/dev/null 2>&1 &
+    elif command -v sensible-browser >/dev/null 2>&1; then
+        sensible-browser "$url" >/dev/null 2>&1 &
+    fi
+}
+
+# Copy text to the system clipboard; returns 0 if any backend worked.
+# Wayland first (modern default), then X11, then WSL's clip.exe.
+copy_clipboard() {
+    local text="$1"
+    if command -v wl-copy >/dev/null 2>&1 && printf '%s' "$text" | wl-copy >/dev/null 2>&1; then return 0; fi
+    if command -v xclip   >/dev/null 2>&1 && printf '%s' "$text" | xclip -selection clipboard >/dev/null 2>&1; then return 0; fi
+    if command -v xsel    >/dev/null 2>&1 && printf '%s' "$text" | xsel --clipboard --input >/dev/null 2>&1; then return 0; fi
+    if command -v clip.exe >/dev/null 2>&1 && printf '%s' "$text" | clip.exe >/dev/null 2>&1; then return 0; fi
+    return 1
+}
+
 step() {
     echo ""
     echo -e "${BD}[$1/8]${NC} ${B}$2${NC}"
@@ -299,8 +325,34 @@ fi
 # to auth via web". Drive it from /dev/tty, with a token-paste fallback.
 if ! gh auth status >/dev/null 2>&1; then
     if [ -e /dev/tty ]; then
-        info "Logging into GitHub — you'll get a one-time code to enter at https://github.com/login/device (any browser, even your phone)."
-        gh auth login -p ssh -w </dev/tty >/dev/tty 2>&1 || true
+        info "Connect your device to GitHub — opening the device page in your browser. If you don't have a GitHub account yet, sign up from that page (free)."
+        # Pre-open the device-flow URL so the user doesn't have to copy it
+        # from gh's output. The one-time code from gh is auto-copied to the
+        # clipboard below — user just pastes when the page asks for it.
+        open_url "https://github.com/login/device"
+
+        # Run gh interactively while tee'ing its output to a temp file. A
+        # background watcher pulls the XXXX-XXXX device code out of the file
+        # as soon as gh prints it and copies it to the clipboard.
+        ghout=$(mktemp)
+        (
+            while sleep 0.3; do
+                [ -s "$ghout" ] || continue
+                code=$(grep -oE '[A-Z0-9]{4}-[A-Z0-9]{4}' "$ghout" 2>/dev/null | head -1)
+                if [ -n "$code" ]; then
+                    if copy_clipboard "$code"; then
+                        printf '\n  %b✓%b One-time code %s copied to clipboard — paste it on the page.\n\n' "${G}" "${NC}" "$code" >/dev/tty
+                    fi
+                    exit 0
+                fi
+            done
+        ) &
+        watcher_pid=$!
+        gh auth login -p ssh -w </dev/tty 2>&1 | tee "$ghout" >/dev/tty || true
+        kill "$watcher_pid" 2>/dev/null
+        wait "$watcher_pid" 2>/dev/null
+        rm -f "$ghout"
+
         if ! gh auth status >/dev/null 2>&1; then
             {
                 echo ""

--- a/.claude/scripts/onboarding-mac.sh
+++ b/.claude/scripts/onboarding-mac.sh
@@ -62,6 +62,11 @@ D='\033[2m' BD='\033[1m' NC='\033[0m'
 pass() { echo -e "  ${G}✓${NC} $1"; }
 fail() { echo -e "  ${R}✗${NC} $1"; ERRORS=$((ERRORS + 1)); }
 info() { echo -e "  ${D}·${NC} $1"; }
+
+# Open a URL in the default browser; macOS has 'open' on every system.
+open_url() { open "$1" >/dev/null 2>&1 & }
+# Copy text to the macOS clipboard.
+copy_clipboard() { printf '%s' "$1" | pbcopy >/dev/null 2>&1; }
 step() {
     echo ""
     echo -e "${BD}[$1/8]${NC} ${B}$2${NC}"
@@ -262,8 +267,29 @@ fi
 
 # GitHub auth
 if ! gh auth status &>/dev/null 2>&1; then
-    info "Logging into GitHub (browser will open)..."
-    gh auth login -p ssh -w
+    info "Connect your device to GitHub — opening the device page in your browser. If you don't have a GitHub account yet, sign up from that page (free)."
+    open_url "https://github.com/login/device"
+
+    # Auto-copy the one-time XXXX-XXXX device code to the clipboard as soon
+    # as gh prints it, so the user only needs to paste on the device page.
+    ghout=$(mktemp)
+    (
+        while sleep 0.3; do
+            [ -s "$ghout" ] || continue
+            code=$(grep -oE '[A-Z0-9]{4}-[A-Z0-9]{4}' "$ghout" 2>/dev/null | head -1)
+            if [ -n "$code" ]; then
+                if copy_clipboard "$code"; then
+                    printf '\n  %b✓%b One-time code %s copied to clipboard — paste it on the page.\n\n' "${G}" "${NC}" "$code"
+                fi
+                exit 0
+            fi
+        done
+    ) &
+    watcher_pid=$!
+    gh auth login -p ssh -w 2>&1 | tee "$ghout"
+    kill "$watcher_pid" 2>/dev/null
+    wait "$watcher_pid" 2>/dev/null
+    rm -f "$ghout"
     pass "GitHub authenticated"
 else
     GH_USER=$(gh api user --jq '.login' 2>/dev/null || echo "unknown")

--- a/.claude/scripts/onboarding-windows.ps1
+++ b/.claude/scripts/onboarding-windows.ps1
@@ -62,6 +62,16 @@ $KUN_DIR = "$HOME_DIR\kun"
 function Pass($msg) { Write-Host "  + $msg" -ForegroundColor Green }
 function Fail($msg) { Write-Host "  x $msg" -ForegroundColor Red; $script:ERRORS++ }
 function Info($msg) { Write-Host "  . $msg" -ForegroundColor DarkGray }
+
+# Open a URL in the user's default browser; silent on failure.
+function Open-Url($url) {
+    try { Start-Process $url -ErrorAction Stop | Out-Null } catch { }
+}
+# Copy text to the Windows clipboard.
+function Copy-Clipboard($text) {
+    try { Set-Clipboard -Value $text -ErrorAction Stop; return $true } catch { return $false }
+}
+
 function Step($num, $msg) {
     Write-Host ""
     Write-Host "[$num/8] $msg" -ForegroundColor Cyan
@@ -224,8 +234,32 @@ if (-not (Test-Path $sshKey)) {
 # GitHub auth
 $ghAuth = gh auth status 2>&1
 if ($LASTEXITCODE -ne 0) {
-    Info "Logging into GitHub (browser will open)..."
-    gh auth login -p ssh -w
+    Info "Connect your device to GitHub — opening the device page in your browser. If you don't have a GitHub account yet, sign up from that page (free)."
+    Open-Url "https://github.com/login/device"
+
+    # Capture gh's output via Tee-Object so a background watcher can pluck the
+    # XXXX-XXXX one-time code and copy it to the clipboard — saves the user
+    # from copying it by hand into the device page.
+    $ghOut = [System.IO.Path]::GetTempFileName()
+    $watcher = Start-Job -ScriptBlock {
+        param($path)
+        while ($true) {
+            Start-Sleep -Milliseconds 300
+            if (Test-Path $path) {
+                $content = Get-Content $path -Raw -ErrorAction SilentlyContinue
+                if ($content -and ($content -match '([A-Z0-9]{4}-[A-Z0-9]{4})')) {
+                    try { Set-Clipboard -Value $matches[1] -ErrorAction Stop } catch { }
+                    break
+                }
+            }
+        }
+    } -ArgumentList $ghOut
+
+    gh auth login -p ssh -w 2>&1 | Tee-Object -FilePath $ghOut
+    Stop-Job $watcher -ErrorAction SilentlyContinue
+    Remove-Job $watcher -ErrorAction SilentlyContinue
+    Remove-Item $ghOut -ErrorAction SilentlyContinue
+
     Pass "GitHub authenticated"
 } else {
     $ghUser = gh api user --jq '.login' 2>$null


### PR DESCRIPTION
## Summary
Acts on the user feedback in #102 about onboarding step 3 (GitHub — SSH key, authentication, git config):

> can you auto open browser, and what if i don't have github account, shouldn't create/login to github be part of the process

## Changes
Across all three installers (`onboarding-linux.sh`, `onboarding-mac.sh`, `onboarding-windows.ps1`):

1. **Pre-open the device page**. Before `gh auth login` prints the URL/code, the script now opens `https://github.com/login/device` in the user's default browser (`xdg-open`/`wslview`/`sensible-browser` on Linux, `open` on macOS, `Start-Process` on Windows). The device page itself handles both sign-in and "Create an account", which addresses the "what if I don't have a GitHub account" concern without an extra prompt — that page is the entry point either way.
2. **Reword the prompt** from *"Logging into GitHub (browser will open)…"* to *"Connect your device to GitHub … If you don't have a GitHub account yet, sign up from that page (free)."* The new phrasing tells users without an account what to do.
3. **Auto-copy the one-time code to the clipboard**. `gh`'s output is tee'd to a temp file; a background watcher extracts the `XXXX-XXXX` code as soon as it appears and copies it to the system clipboard (`wl-copy`/`xclip`/`xsel`/`clip.exe` on Linux, `pbcopy` on macOS, `Set-Clipboard` on Windows). The user pastes on the device page instead of typing.
4. The Linux headless/PAT fallback path is preserved unchanged.

## Test plan
- [x] `bash -n` clean on both shell scripts.
- [ ] Linux desktop (Ubuntu/Firefox — the reporter's environment): browser opens, code is in clipboard.
- [ ] macOS: same.
- [ ] Windows 11 PowerShell: same.
- [ ] Linux headless (no DISPLAY): falls through to existing PAT-paste path unchanged.

Closes #102

🤖 Generated with [Claude Code](https://claude.com/claude-code)