### PR TITLE
fix(docs): make onboarding install one-liners copy-able like sprint

### DIFF
--- a/content/docs/onboarding.mdx
+++ b/content/docs/onboarding.mdx
@@ -18,10 +18,17 @@ This is the single source of truth for joining databayt. It covers every OS, eve
 
 Paste in a terminal. The wizard takes over.
 
-| OS | Command |
-|---|---|
-| **macOS / Linux** | `curl -fsSL https://kun.databayt.org/install \| bash` |
-| **Windows** (PowerShell) | `iwr https://kun.databayt.org/install.ps1 \| iex` |
+**macOS / Linux**
+
+```bash
+curl -fsSL https://kun.databayt.org/install | bash
+```
+
+**Windows** (PowerShell)
+
+```powershell
+iwr https://kun.databayt.org/install.ps1 | iex
+```
 
 The bootstrap URL auto-detects your OS and dispatches to the right installer. No need to pick. Re-run anytime — it auto-resumes from where it left off via a state file.
 


### PR DESCRIPTION
## Summary
Acts on #103:
> in https://kun.databayt.org/en/docs/onboarding use copy to clipboard like in https://kun.databayt.org/en/docs/sprint for install lines

The install commands on `/docs/onboarding` were inline \`code\` inside a markdown table, and the MDX renderer only decorates fenced code blocks with the copy button. `/docs/sprint` uses fenced blocks, which is why its commands are copy-able.

## Changes
- `content/docs/onboarding.mdx`: replace the 2-row OS/Command table with a pair of labeled fenced code blocks (`bash` + `powershell`), matching the sprint page's pattern. Copy button now ships on both.

Closes #103

🤖 Generated with [Claude Code](https://claude.com/claude-code)