### PR TITLE
refactor(onboarding): collapse wizard to 2 questions + 1 click, add test suite

### DIFF
--- a/.claude/scripts/installer-linux.sh
+++ b/.claude/scripts/installer-linux.sh
@@ -2,8 +2,9 @@
 # =============================================================================
 # Quiet Wizard — Linux Installer
 # =============================================================================
-# Three-act guided installer for Linux. Detects zenity → kdialog → TUI fallback.
-# Wraps onboarding-linux.sh with native dialogs and deep-link action buttons.
+# 2 dialogs (identity, hogwarts) → silent batch with 1 unavoidable click
+# (GitHub Authorize on the auto-opened device-flow page) → done panel.
+# Detects zenity → kdialog → TUI fallback.
 #
 # Bootstrap:
 #   curl -fsSL https://kun.databayt.org/install | bash
@@ -12,9 +13,8 @@
 #
 # State file: ${XDG_CONFIG_HOME:-~/.config}/databayt/installer-state.json
 #
-# NOTE: Claude Desktop is NOT available on Linux. Wrapper skips desktop
-# sign-in and computer-use toggle steps. Linux users use CLI + browser +
-# IDE plugins.
+# NOTE: Claude Desktop is NOT available on Linux. Linux users use CLI +
+# browser + IDE plugins.
 # =============================================================================
 
 set -e
@@ -69,7 +69,7 @@ ask_yesno() {
     esac
 }
 ask_choice() {
-    # ask_choice <prompt> <opt1> <opt2> [opt3] — TUI uses numbered menu
+    # 2-3 button choice
     local prompt="$1" opt1="$2" opt2="$3" opt3="${4:-}"
     case "$GUI" in
         zenity)
@@ -92,11 +92,30 @@ ask_choice() {
             ;;
     esac
 }
-ask_role() {
+ask_identity() {
+    # Identity card: ask name + email + role in ONE dialog when GUI supports it.
+    # Returns "name|email|role" or empty on cancel.
+    local default_name="$1" default_email="$2" default_role="${3:-engineer}"
     case "$GUI" in
-        zenity)  zenity --list --title="Databayt Setup" --text="Pick your role:" --column=Role engineer business content ops 2>/dev/null || echo "" ;;
-        kdialog) kdialog --title "Databayt Setup" --menu "Pick your role:" engineer engineer business business content content ops ops 2>/dev/null || echo "" ;;
-        *)       ask_choice "Pick your role:" engineer business content ops ;;
+        zenity)
+            zenity --forms --title="Databayt Setup" \
+                --text="Identity card — confirm your git identity and role." \
+                --add-entry="Full name (for git commits)" \
+                --add-entry="Email (for git commits)" \
+                --add-combo="Role" --combo-values="engineer|business|content|ops" \
+                2>/dev/null || echo ""
+            ;;
+        kdialog|*)
+            # kdialog / TUI: chain three prompts but treat as one logical step
+            local n="$default_name" e="$default_email" r="$default_role"
+            [[ -z "$n" ]] && n=$(ask_text "Identity 1/3 — full name (for git commits):")
+            [[ -z "$n" ]] && { echo ""; return; }
+            [[ -z "$e" ]] && e=$(ask_text "Identity 2/3 — email (for git commits):")
+            [[ -z "$e" ]] && { echo ""; return; }
+            [[ -z "$r" ]] && r=$(ask_choice "Identity 3/3 — role:" "engineer" "business" "content")
+            [[ -z "$r" ]] && r="engineer"
+            echo "$n|$e|$r"
+            ;;
     esac
 }
 notify() {
@@ -114,11 +133,6 @@ open_url() {
 }
 
 # ── Bootstrap: ensure git, then clone kun ───────────────────────
-# git is needed to clone the repo that installs git, so the wrapper
-# must provide it first. The backend (onboarding-linux.sh) re-checks
-# and no-ops if git is already present. Fresh Linux images ship curl
-# but often not git — without this, the clone below fails with a
-# misleading "check network" message.
 if ! command -v git >/dev/null 2>&1; then
     notify "Installing" "git (prerequisite for clone)"
     if   command -v apt-get >/dev/null 2>&1; then sudo apt-get update -y >/dev/null 2>&1 && sudo DEBIAN_FRONTEND=noninteractive apt-get install -y git >/dev/null 2>&1
@@ -152,124 +166,72 @@ if [[ ! -f "$BACKEND" ]]; then
 fi
 
 # =============================================================================
-# ACT 1 — Pre-flight
+# ACT 1 — Two dialogs (or fewer, after autofill)
 # =============================================================================
-WELCOME=$(ask_choice "Welcome — this sets up a fresh Linux box for databayt.\n\nAbout 15-20 minutes (mostly silent downloads).\n\nReady?" "Start" "Cancel")
-[[ "$WELCOME" != "Start" ]] && { notify "Cancelled" "Run again anytime"; exit 0; }
+# Consent implied by `curl … | bash`. Ctrl+C aborts.
+echo ""
+echo "════════════════════════════════════════════════════"
+echo " Databayt Setup — ~15-20 min · 2 dialogs · 1 click"
+echo "════════════════════════════════════════════════════"
+echo " Press Ctrl+C any time to abort. State auto-saves."
+echo "════════════════════════════════════════════════════"
+echo ""
 
 ROLE=$(state_get role)
-GIST_ID=$(state_get gistId)
 GIT_NAME_ARG=$(state_get gitName)
 GIT_EMAIL_ARG=$(state_get gitEmail)
-WITH_TAILSCALE=$(state_get withTailscale)
-REPOS_DIR=$(state_get reposDir)
-HAS_GITHUB=$(state_get hasGithub)
-HAS_ANTHROPIC=$(state_get hasAnthropic)
-
-# Account guidance
-if [[ -z "$HAS_GITHUB" ]]; then
-    ANS=$(ask_choice "Do you have a GitHub account?" "Yes, I have one" "No, create one" "Skip")
-    if [[ "$ANS" == "No, create one" ]]; then
-        open_url "https://github.com/join"
-        ask_choice "GitHub sign-up opened. Done when you've created the account." "Done" "Skip" >/dev/null
-    fi
-    state_set hasGithub "1"
-fi
-if [[ -z "$HAS_ANTHROPIC" ]]; then
-    ANS=$(ask_choice "Do you have an Anthropic account?\n(For Claude Code CLI + claude.ai/code in browser.)" "Yes, I have one" "No, create one" "Skip")
-    if [[ "$ANS" == "No, create one" ]]; then
-        open_url "https://claude.ai/login"
-        ask_choice "Anthropic sign-in opened. Done when you've created the account." "Done" "Skip" >/dev/null
-    fi
-    state_set hasAnthropic "1"
-fi
-
-# Repos dir
-if [[ -z "$REPOS_DIR" ]]; then
-    CHOICE=$(ask_choice "Where do you want databayt org repos saved?\n(Default: home root)" "Home root (~/)" "~/databayt/" "Custom...")
-    case "$CHOICE" in
-        "Home root (~/)") REPOS_DIR="$HOME" ;;
-        "~/databayt/")    REPOS_DIR="$HOME/databayt"; mkdir -p "$REPOS_DIR" ;;
-        "Custom...")
-            CUSTOM=$(ask_text "Enter absolute path:" "$HOME/projects/databayt")
-            [[ -z "$CUSTOM" ]] && CUSTOM="$HOME"
-            REPOS_DIR="$CUSTOM"; mkdir -p "$REPOS_DIR" ;;
-        *) REPOS_DIR="$HOME" ;;
-    esac
-    state_set reposDir "$REPOS_DIR"
-fi
-
-# Role: auto-detect from existing mcp.json
-if [[ -z "$ROLE" ]]; then
-    if [[ -f "$HOME/.claude/mcp.json" ]]; then
-        if grep -q '"shadcn"' "$HOME/.claude/mcp.json" 2>/dev/null; then ROLE="engineer"
-        elif grep -q '"linear"' "$HOME/.claude/mcp.json" 2>/dev/null; then ROLE="business"
-        elif grep -q '"figma"' "$HOME/.claude/mcp.json" 2>/dev/null; then ROLE="content"
-        elif grep -q '"posthog"' "$HOME/.claude/mcp.json" 2>/dev/null; then ROLE="ops"
-        fi
-    fi
-    if [[ -z "$ROLE" ]]; then
-        ROLE=$(ask_role)
-        [[ -z "$ROLE" ]] && { notify "Cancelled" "No role"; exit 0; }
-    fi
-    state_set role "$ROLE"
-fi
-
-# Git identity
-if [[ -z "$GIT_NAME_ARG" ]]; then
-    EXISTING_NAME=$(git config --global user.name 2>/dev/null || echo "")
-    if [[ -n "$EXISTING_NAME" ]]; then
-        GIT_NAME_ARG="$EXISTING_NAME"
-        GIT_EMAIL_ARG=$(git config --global user.email 2>/dev/null || echo "")
-    else
-        GIT_NAME_ARG=$(ask_text "Your full name (for git commits):")
-        [[ -z "$GIT_NAME_ARG" ]] && { notify "Cancelled" "No name"; exit 0; }
-        GIT_EMAIL_ARG=$(ask_text "Your email (for git commits):")
-        [[ -z "$GIT_EMAIL_ARG" ]] && { notify "Cancelled" "No email"; exit 0; }
-    fi
-    state_set gitName "$GIT_NAME_ARG"
-    state_set gitEmail "$GIT_EMAIL_ARG"
-fi
-
-# Gist ID
-if [[ -z "$GIST_ID" ]]; then
-    GIST_ID=$(ask_text "Secrets Gist ID (or blank to skip):")
-    state_set gistId "$GIST_ID"
-fi
-
-# Tailscale
-if [[ -z "$WITH_TAILSCALE" ]]; then
-    TS_ANS=$(ask_yesno "Enable Tailscale SSH? (Remote control from iPhone/laptop.)")
-    [[ "$TS_ANS" == "Yes" ]] && WITH_TAILSCALE="1" || WITH_TAILSCALE="0"
-    state_set withTailscale "$WITH_TAILSCALE"
-fi
-
-# Hogwarts local dev — opt-in (heavy: pnpm + DB seed + build, ~10 min)
 HOGWARTS_DEV=$(state_get hogwartsDev)
-if [[ -z "$HOGWARTS_DEV" ]]; then
+
+# Autofill from git config + mcp.json
+[[ -z "$GIT_NAME_ARG"  ]] && GIT_NAME_ARG=$(git config --global user.name  2>/dev/null || echo "")
+[[ -z "$GIT_EMAIL_ARG" ]] && GIT_EMAIL_ARG=$(git config --global user.email 2>/dev/null || echo "")
+if [[ -z "$ROLE" && -f "$HOME/.claude/mcp.json" ]]; then
+    if   grep -q '"shadcn"'  "$HOME/.claude/mcp.json" 2>/dev/null; then ROLE="engineer"
+    elif grep -q '"linear"'  "$HOME/.claude/mcp.json" 2>/dev/null; then ROLE="business"
+    elif grep -q '"figma"'   "$HOME/.claude/mcp.json" 2>/dev/null; then ROLE="content"
+    elif grep -q '"posthog"' "$HOME/.claude/mcp.json" 2>/dev/null; then ROLE="ops"
+    fi
+fi
+
+# Identity card — single dialog (zenity --forms) or chained (kdialog/TUI)
+if [[ -z "$GIT_NAME_ARG" || -z "$GIT_EMAIL_ARG" || -z "$ROLE" ]]; then
+    IDENTITY=$(ask_identity "$GIT_NAME_ARG" "$GIT_EMAIL_ARG" "$ROLE")
+    if [[ -n "$IDENTITY" ]]; then
+        IFS='|' read -r N E R <<< "$IDENTITY"
+        [[ -n "$N" ]] && GIT_NAME_ARG="$N"
+        [[ -n "$E" ]] && GIT_EMAIL_ARG="$E"
+        [[ -n "$R" ]] && ROLE="$R"
+    fi
+    [[ -z "$GIT_NAME_ARG"  ]] && { notify "Cancelled" "No name";  exit 0; }
+    [[ -z "$GIT_EMAIL_ARG" ]] && { notify "Cancelled" "No email"; exit 0; }
+    [[ -z "$ROLE"          ]] && ROLE="engineer"
+fi
+state_set gitName  "$GIT_NAME_ARG"
+state_set gitEmail "$GIT_EMAIL_ARG"
+state_set role     "$ROLE"
+
+# Hogwarts local dev — engineer-only
+if [[ "$ROLE" == "engineer" && -z "$HOGWARTS_DEV" ]]; then
     HD_ANS=$(ask_yesno "Set up hogwarts local dev now? (pnpm + DB seed + build, ~10 min — skip if this machine won't run hogwarts locally)")
     [[ "$HD_ANS" == "Yes" ]] && HOGWARTS_DEV="1" || HOGWARTS_DEV="0"
     state_set hogwartsDev "$HOGWARTS_DEV"
 fi
 
 # =============================================================================
-# ACT 2 — Silent batch
+# ACT 2 — Silent batch (1 unavoidable Authorize click during Phase 3)
 # =============================================================================
-notify "Installing" "~15-20 min in terminal"
+notify "Installing" "1 GitHub Authorize click around minute 2"
 
 BACKEND_ARGS=("$ROLE")
-[[ -n "$GIST_ID" ]] && BACKEND_ARGS+=("$GIST_ID")
 BACKEND_ARGS+=("--quiet" "--name" "$GIT_NAME_ARG" "--email" "$GIT_EMAIL_ARG")
-[[ -n "$REPOS_DIR" && "$REPOS_DIR" != "$HOME" ]] && BACKEND_ARGS+=("--repos-dir" "$REPOS_DIR")
-[[ "$WITH_TAILSCALE" == "1" ]] && BACKEND_ARGS+=("--with-tailscale")
 [[ "$HOGWARTS_DEV" == "1" ]] && BACKEND_ARGS+=("--hogwarts-dev")
 
 echo ""
 echo "════════════════════════════════════════════════════"
-echo " Databayt Setup — Silent Install in Progress"
+echo " Installing — minimize the terminal and walk away"
+echo " (one Authorize click in the browser ~2 min in)"
 echo "════════════════════════════════════════════════════"
 echo " Role: $ROLE"
-echo " You can minimize this terminal and do other work."
 echo "════════════════════════════════════════════════════"
 echo ""
 
@@ -294,11 +256,11 @@ fi
 state_set silentBatch "done"
 
 # =============================================================================
-# ACT 3 — Manual finishing (no Claude Desktop on Linux)
+# ACT 3 — Done. No dialogs; auto-install what we can; list the rest.
 # =============================================================================
-notify "Almost done" "Final clicks"
+notify "Almost done" "Wrapping up"
 
-# 3a. VS Code Claude extension — auto-install
+# Silent: VS Code Claude extension
 if command -v code >/dev/null 2>&1 && [[ "$(state_get vsCodeExt)" != "1" ]]; then
     if code --list-extensions 2>/dev/null | grep -q "anthropic.claude-code"; then
         state_set vsCodeExt "1"
@@ -307,43 +269,29 @@ if command -v code >/dev/null 2>&1 && [[ "$(state_get vsCodeExt)" != "1" ]]; the
     fi
 fi
 
-# 3b. WebStorm Claude plugin (engineer)
-if [[ "$ROLE" == "engineer" ]] && command -v webstorm >/dev/null 2>&1 || [[ -d "/snap/webstorm" ]]; then
-    if [[ "$(state_get webstormPlugin)" != "1" ]]; then
-        ANS=$(ask_choice "(Optional) Install Claude Code plugin in WebStorm:\n\n1. Click [Open WebStorm]\n2. Settings → Plugins → Marketplace → 'Claude Code' → Install\n3. Click [Done]" "Open WebStorm" "Done" "Skip")
-        case "$ANS" in
-            "Open WebStorm")
-                if command -v webstorm >/dev/null 2>&1; then webstorm & else snap run webstorm & fi
-                ANS=$(ask_choice "Plugin installed?" "Done" "Skip")
-                ;;
-        esac
-        [[ "$ANS" == "Done" ]] && state_set webstormPlugin "1"
-    fi
-fi
-
-# 3c. Final verify
-notify "Verifying" "Health check"
+# Health check
 HEALTH_STATUS="(health.sh not found)"
 if [[ -f "$HOME/.claude/scripts/health.sh" ]]; then
     HEALTH_STATUS=$(bash "$HOME/.claude/scripts/health.sh" 2>&1 | head -1 || true)
 fi
 
-FINAL_MSG="Setup complete! Role: $ROLE\n\n"
-FINAL_MSG+="Config health: $HEALTH_STATUS\n\n"
-FINAL_MSG+="Tools: git, node, pnpm, gh, claude\n"
-FINAL_MSG+="Repos: ~/kun"
-[[ "$ROLE" == "engineer" ]] && FINAL_MSG+=", ~/hogwarts, ~/codebase, +org repos"
-FINAL_MSG+="\nConfig: ~/.claude/ (agents, skills, MCP)\n\n"
-FINAL_MSG+="Linux note: no Claude Desktop. Use:\n"
+# Final panel: one-shot summary + optional follow-ups
+FINAL_MSG="Setup complete · Role: $ROLE\n"
+FINAL_MSG+="Config: $HEALTH_STATUS\n\n"
+FINAL_MSG+="Linux note: no Claude Desktop — use:\n"
 FINAL_MSG+="  • CLI: 'claude' / 'c'\n"
 FINAL_MSG+="  • Browser: https://claude.ai/code\n"
 FINAL_MSG+="  • IDE: VS Code + WebStorm Claude plugins\n\n"
-FINAL_MSG+="Mobile: install Claude on iPhone/Android with the same account."
+FINAL_MSG+="Optional follow-ups (do later, in any order):\n"
+( command -v webstorm >/dev/null 2>&1 || [[ -d "/snap/webstorm" ]] ) && [[ "$ROLE" == "engineer" ]] && \
+    FINAL_MSG+="  • WebStorm plugin: Settings → Plugins → 'Claude Code'\n"
+FINAL_MSG+="  • Secrets from Gist: bash ~/kun/.claude/scripts/secrets.sh <GIST_ID>\n"
+FINAL_MSG+="  • Mobile / remote: install Claude on iOS/Android, or open claude.ai/code in any browser\n\n"
+FINAL_MSG+="Docs: https://kun.databayt.org/docs/onboarding"
 
-ask_choice "$FINAL_MSG" "Done" "View Docs" >/dev/null
-
-if [[ "$(ask_yesno "Open onboarding docs in browser?")" == "Yes" ]]; then
-    open_url "https://github.com/databayt/kun/blob/main/content/docs/onboarding.mdx"
+RESULT=$(ask_choice "$FINAL_MSG" "Done" "Open Docs")
+if [[ "$RESULT" == "Open Docs" ]]; then
+    open_url "https://kun.databayt.org/docs/onboarding"
 fi
 
 state_set lastStep "done"

--- a/.claude/scripts/installer.ps1
+++ b/.claude/scripts/installer.ps1
@@ -1,8 +1,8 @@
 # =============================================================================
 # Quiet Wizard - Windows Installer
 # =============================================================================
-# Three-act guided installer for Windows. Uses WPF dialogs (PresentationFramework
-# ships with .NET on Win10/11). Wraps onboarding-windows.ps1 -Quiet.
+# 2 dialogs (identity, hogwarts) -> silent batch with 1 unavoidable click
+# (GitHub Authorize on auto-opened device-flow page) -> done panel.
 #
 # Bootstrap:
 #   iwr https://kun.databayt.org/install.ps1 | iex
@@ -20,6 +20,7 @@ $ErrorActionPreference = "Continue"
 
 Add-Type -AssemblyName PresentationFramework
 Add-Type -AssemblyName System.Windows.Forms
+Add-Type -AssemblyName Microsoft.VisualBasic
 
 # ── State file ──────────────────────────────────────────────────
 $stateDir = "$env:APPDATA\Databayt"
@@ -37,7 +38,6 @@ function Set-State($key, $value) {
     $d = if (Test-Path $stateFile) {
         try { Get-Content $stateFile -Raw | ConvertFrom-Json } catch { @{} }
     } else { @{} }
-    # PSCustomObject -> Hashtable so we can add properties
     $h = @{}
     if ($d) { $d.PSObject.Properties | ForEach-Object { $h[$_.Name] = $_.Value } }
     $h[$key] = $value
@@ -61,7 +61,6 @@ function Ask-Text($prompt, $default = "") {
         $a = Read-Host
         if ([string]::IsNullOrEmpty($a)) { return $default } else { return $a }
     }
-    # WinForms InputBox - simplest reliable text input on Win10+
     return [Microsoft.VisualBasic.Interaction]::InputBox($prompt, "Databayt Setup", $default)
 }
 function Ask-Choice($prompt, $opt1, $opt2, $opt3 = $null) {
@@ -74,17 +73,16 @@ function Ask-Choice($prompt, $opt1, $opt2, $opt3 = $null) {
         $n = Read-Host
         switch ($n) { "1" { return $opt1 } "2" { return $opt2 } "3" { return $opt3 } default { return "" } }
     }
-    # WPF custom dialog for 2-3 button choice
     $window = New-Object System.Windows.Window
     $window.Title = "Databayt Setup"
-    $window.Width = 480; $window.Height = 220
+    $window.Width = 520; $window.SizeToContent = "Height"
     $window.WindowStartupLocation = "CenterScreen"; $window.ResizeMode = "NoResize"
     $stack = New-Object System.Windows.Controls.StackPanel; $stack.Margin = "20"
     $tb = New-Object System.Windows.Controls.TextBlock
     $tb.Text = $prompt; $tb.TextWrapping = "Wrap"; $tb.Margin = "0,0,0,20"; $tb.FontSize = 13
     $stack.Children.Add($tb) | Out-Null
     $row = New-Object System.Windows.Controls.StackPanel; $row.Orientation = "Horizontal"; $row.HorizontalAlignment = "Right"
-    $result = ""
+    $script:result = ""
     $buttons = @($opt1, $opt2); if ($opt3) { $buttons += $opt3 }
     foreach ($b in $buttons) {
         $btn = New-Object System.Windows.Controls.Button
@@ -97,31 +95,67 @@ function Ask-Choice($prompt, $opt1, $opt2, $opt3 = $null) {
     $window.ShowDialog() | Out-Null
     return $script:result
 }
-function Ask-Role() {
-    if ($NoGui) { return Ask-Choice "Pick your role:" "engineer" "business" "content" }
-    $roles = @("engineer", "business", "content", "ops")
+function Ask-Identity($defaultName, $defaultEmail, $defaultRole) {
+    # Single WPF window: name + email + role. Returns [name, email, role] or @() on cancel.
+    if ($NoGui) {
+        $n = Ask-Text "Identity 1/3 - full name (for git commits):" $defaultName
+        if (-not $n) { return @() }
+        $e = Ask-Text "Identity 2/3 - email (for git commits):" $defaultEmail
+        if (-not $e) { return @() }
+        $r = Ask-Choice "Identity 3/3 - role:" "engineer" "business" "content"
+        if (-not $r) { $r = if ($defaultRole) { $defaultRole } else { "engineer" } }
+        return @($n, $e, $r)
+    }
     $window = New-Object System.Windows.Window
-    $window.Title = "Databayt Setup"; $window.Width = 360; $window.Height = 280
+    $window.Title = "Databayt Setup - Identity"
+    $window.Width = 460; $window.SizeToContent = "Height"
     $window.WindowStartupLocation = "CenterScreen"; $window.ResizeMode = "NoResize"
     $stack = New-Object System.Windows.Controls.StackPanel; $stack.Margin = "20"
-    $lbl = New-Object System.Windows.Controls.TextBlock; $lbl.Text = "Pick your role:"; $lbl.Margin = "0,0,0,10"; $lbl.FontSize = 13
-    $stack.Children.Add($lbl) | Out-Null
-    $list = New-Object System.Windows.Controls.ListBox
-    foreach ($r in $roles) { $list.Items.Add($r) | Out-Null }
-    $list.SelectedIndex = 0; $list.Height = 120
-    $stack.Children.Add($list) | Out-Null
-    $btn = New-Object System.Windows.Controls.Button
-    $btn.Content = "OK"; $btn.Width = 80; $btn.Margin = "0,15,0,0"; $btn.HorizontalAlignment = "Right"
-    $script:result = ""
-    $btn.Add_Click({ $script:result = $list.SelectedItem; $window.Close() })
-    $stack.Children.Add($btn) | Out-Null
+
+    $heading = New-Object System.Windows.Controls.TextBlock
+    $heading.Text = "Identity card - confirm your git identity and role."
+    $heading.Margin = "0,0,0,15"; $heading.FontSize = 13; $heading.TextWrapping = "Wrap"
+    $stack.Children.Add($heading) | Out-Null
+
+    $lblName = New-Object System.Windows.Controls.TextBlock; $lblName.Text = "Full name"; $lblName.Margin = "0,0,0,4"
+    $stack.Children.Add($lblName) | Out-Null
+    $txtName = New-Object System.Windows.Controls.TextBox; $txtName.Text = $defaultName; $txtName.Margin = "0,0,0,12"; $txtName.Padding = "5"
+    $stack.Children.Add($txtName) | Out-Null
+
+    $lblEmail = New-Object System.Windows.Controls.TextBlock; $lblEmail.Text = "Email"; $lblEmail.Margin = "0,0,0,4"
+    $stack.Children.Add($lblEmail) | Out-Null
+    $txtEmail = New-Object System.Windows.Controls.TextBox; $txtEmail.Text = $defaultEmail; $txtEmail.Margin = "0,0,0,12"; $txtEmail.Padding = "5"
+    $stack.Children.Add($txtEmail) | Out-Null
+
+    $lblRole = New-Object System.Windows.Controls.TextBlock; $lblRole.Text = "Role"; $lblRole.Margin = "0,0,0,4"
+    $stack.Children.Add($lblRole) | Out-Null
+    $cmbRole = New-Object System.Windows.Controls.ComboBox; $cmbRole.Margin = "0,0,0,18"; $cmbRole.Padding = "5"
+    foreach ($r in @("engineer", "business", "content", "ops")) { $cmbRole.Items.Add($r) | Out-Null }
+    $cmbRole.SelectedItem = if ($defaultRole) { $defaultRole } else { "engineer" }
+    $stack.Children.Add($cmbRole) | Out-Null
+
+    $row = New-Object System.Windows.Controls.StackPanel
+    $row.Orientation = "Horizontal"; $row.HorizontalAlignment = "Right"
+    $script:identityResult = @()
+    $btnCancel = New-Object System.Windows.Controls.Button
+    $btnCancel.Content = "Cancel"; $btnCancel.Width = 90; $btnCancel.Margin = "0,0,10,0"; $btnCancel.Padding = "5"
+    $btnCancel.Add_Click({ $script:identityResult = @(); $window.Close() })
+    $btnOk = New-Object System.Windows.Controls.Button
+    $btnOk.Content = "Continue"; $btnOk.Width = 90; $btnOk.Padding = "5"; $btnOk.IsDefault = $true
+    $btnOk.Add_Click({
+        $script:identityResult = @($txtName.Text.Trim(), $txtEmail.Text.Trim(), $cmbRole.SelectedItem.ToString())
+        $window.Close()
+    })
+    $row.Children.Add($btnCancel) | Out-Null
+    $row.Children.Add($btnOk) | Out-Null
+    $stack.Children.Add($row) | Out-Null
+
     $window.Content = $stack
     $window.ShowDialog() | Out-Null
-    return $script:result
+    return $script:identityResult
 }
 function Notify($title, $body) {
     if ($NoGui) { Write-Host "[$title] $body" -ForegroundColor Cyan; return }
-    # BalloonTip via NotifyIcon — fire and forget
     $bal = New-Object System.Windows.Forms.NotifyIcon
     $bal.Icon = [System.Drawing.SystemIcons]::Information
     $bal.BalloonTipTitle = $title; $bal.BalloonTipText = $body
@@ -129,18 +163,12 @@ function Notify($title, $body) {
     Start-Sleep -Milliseconds 100
     $bal.Dispose()
 }
-Add-Type -AssemblyName Microsoft.VisualBasic   # for InputBox
 
 # ── Bootstrap: ensure git, then clone kun ───────────────────────
-# git is needed to clone the repo that installs git, so the wrapper
-# must provide it first. The backend (onboarding-windows.ps1) re-checks
-# and no-ops if git is already present. Windows ships no git by default —
-# without this, the clone below fails with a misleading "check network".
 if (-not (Get-Command git -EA SilentlyContinue)) {
     if (Get-Command winget -EA SilentlyContinue) {
         Notify "Installing" "git (prerequisite for clone)"
         winget install --id Git.Git -e --accept-source-agreements --accept-package-agreements --silent
-        # Refresh PATH so git resolves in this session (same as backend)
         $env:Path = [System.Environment]::GetEnvironmentVariable("Path", "Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path", "User")
     }
 }
@@ -149,15 +177,12 @@ if (-not (Get-Command git -EA SilentlyContinue)) {
     exit 1
 }
 
-# ── Clone kun if missing ────────────────────────────────────────
 if (-not (Test-Path "$env:USERPROFILE\kun")) {
     Notify "Cloning" "kun repo"
-    # Capture output and gate on $LASTEXITCODE — after a pipeline, $? reflects
-    # the last element (e.g. Out-Null), not the native command's exit code.
     $cloneOut = git clone https://github.com/databayt/kun.git "$env:USERPROFILE\kun" 2>&1
     if ($LASTEXITCODE -ne 0) {
         [Console]::Error.WriteLine(($cloneOut -join "`n"))
-        [System.Windows.MessageBox]::Show("Could not clone databayt/kun. See the terminal window for the exact git error.`n`nIf github.com is blocked on your network (proxy/VPN/firewall), that is the likely cause — the raw CDN can stay reachable while github.com is blocked.", "Setup failed", "OK", "Error") | Out-Null
+        [System.Windows.MessageBox]::Show("Could not clone databayt/kun. See the terminal window for the exact git error.`n`nIf github.com is blocked on your network (proxy/VPN/firewall), that is the likely cause - the raw CDN can stay reachable while github.com is blocked.", "Setup failed", "OK", "Error") | Out-Null
         exit 1
     }
 }
@@ -169,144 +194,80 @@ if (-not (Test-Path $Backend)) {
 }
 
 # =============================================================================
-# ACT 1 - Pre-flight
+# ACT 1 - Two dialogs (or fewer, after autofill)
 # =============================================================================
-$welcome = Ask-Choice "Welcome - this sets up a fresh Windows laptop for databayt.`n`nAbout 20 minutes (mostly silent downloads).`n`nReady?" "Start" "Cancel"
-if ($welcome -ne "Start") { Notify "Cancelled" "Run again anytime"; exit 0 }
+Write-Host ""
+Write-Host "════════════════════════════════════════════════════" -ForegroundColor Cyan
+Write-Host " Databayt Setup - ~20 min · 2 dialogs · 1 click"
+Write-Host "════════════════════════════════════════════════════"
+Write-Host " Press Ctrl+C any time to abort. State auto-saves."
+Write-Host "════════════════════════════════════════════════════"
+Write-Host ""
 
 $role = Get-State role
-$gistId = Get-State gistId
 $gitName = Get-State gitName
 $gitEmail = Get-State gitEmail
-$withTailscale = Get-State withTailscale
-$proMax = Get-State proMax
-$reposDir = Get-State reposDir
-$hasGithub = Get-State hasGithub
-$hasAnthropic = Get-State hasAnthropic
+$hogwartsDev = Get-State hogwartsDev
 
-# Account guidance
-if (-not $hasGithub) {
-    $ans = Ask-Choice "Do you have a GitHub account?" "Yes, I have one" "No, create one" "Skip"
-    if ($ans -eq "No, create one") {
-        Start-Process "https://github.com/join"
-        Ask-Choice "GitHub sign-up opened in browser. Done when you've created the account." "Done" "Skip" | Out-Null
-    }
-    Set-State hasGithub "1"
-}
-if (-not $hasAnthropic) {
-    $ans = Ask-Choice "Do you have an Anthropic account?`n(For Claude Desktop sign-in + CLI.)" "Yes, I have one" "No, create one" "Skip"
-    if ($ans -eq "No, create one") {
-        Start-Process "https://claude.ai/login"
-        Ask-Choice "Anthropic sign-in opened. Done when you've created the account.`n`nNote: Pro/Max sub unlocks Desktop Chat/Cowork/Code tabs." "Done" "Skip" | Out-Null
-    }
-    Set-State hasAnthropic "1"
-}
-
-# Repos dir
-if (-not $reposDir) {
-    $choice = Ask-Choice "Where do you want databayt org repos saved?`n(Default: home root - C:\Users\<you>\)" "Home root" "%USERPROFILE%\databayt" "Custom..."
-    switch ($choice) {
-        "Home root"             { $reposDir = $env:USERPROFILE }
-        "%USERPROFILE%\databayt" { $reposDir = "$env:USERPROFILE\databayt"; New-Item -ItemType Directory -Force -Path $reposDir | Out-Null }
-        "Custom..."             {
-            $custom = Ask-Text "Enter absolute path:" "$env:USERPROFILE\projects\databayt"
-            if (-not $custom) { $custom = $env:USERPROFILE }
-            $reposDir = $custom; New-Item -ItemType Directory -Force -Path $reposDir | Out-Null
-        }
-        default { $reposDir = $env:USERPROFILE }
-    }
-    Set-State reposDir $reposDir
-}
-
-# Role: auto-detect from existing mcp.json
+# Autofill from git config + mcp.json
+if (-not $gitName)  { $gitName  = git config --global user.name  2>$null }
+if (-not $gitEmail) { $gitEmail = git config --global user.email 2>$null }
 if (-not $role) {
     $mcp = "$env:USERPROFILE\.claude\mcp.json"
     if (Test-Path $mcp) {
         $content = Get-Content $mcp -Raw
         if ($content -match '"shadcn"') { $role = "engineer" }
-        elseif ($content -match '"linear"') { $role = "business" }
-        elseif ($content -match '"figma"') { $role = "content" }
+        elseif ($content -match '"linear"')  { $role = "business" }
+        elseif ($content -match '"figma"')   { $role = "content" }
         elseif ($content -match '"posthog"') { $role = "ops" }
     }
-    if (-not $role) {
-        $role = Ask-Role
-        if (-not $role) { Notify "Cancelled" "No role"; exit 0 }
-    }
-    Set-State role $role
 }
 
-# Git identity
-if (-not $gitName) {
-    $existingName = git config --global user.name 2>$null
-    if ($existingName) {
-        $gitName = $existingName
-        $gitEmail = git config --global user.email 2>$null
-    } else {
-        $gitName = Ask-Text "Your full name (for git commits):"
-        if (-not $gitName) { Notify "Cancelled" "No name"; exit 0 }
-        $gitEmail = Ask-Text "Your email (for git commits):"
-        if (-not $gitEmail) { Notify "Cancelled" "No email"; exit 0 }
-    }
-    Set-State gitName $gitName
-    Set-State gitEmail $gitEmail
+# Single identity dialog (or skip if everything autofilled)
+if (-not $gitName -or -not $gitEmail -or -not $role) {
+    $identity = Ask-Identity $gitName $gitEmail $role
+    if ($identity.Count -eq 0) { Notify "Cancelled" "Identity not provided"; exit 0 }
+    $gitName  = $identity[0]
+    $gitEmail = $identity[1]
+    $role     = $identity[2]
+    if (-not $gitName)  { Notify "Cancelled" "No name";  exit 0 }
+    if (-not $gitEmail) { Notify "Cancelled" "No email"; exit 0 }
+    if (-not $role) { $role = "engineer" }
 }
+Set-State gitName  $gitName
+Set-State gitEmail $gitEmail
+Set-State role     $role
 
-# Gist ID
-if (-not $gistId) {
-    $gistId = Ask-Text "Secrets Gist ID (or blank to skip):"
-    Set-State gistId $gistId
-}
-
-# Pro/Max
-if (-not $proMax) {
-    $ans = Ask-YesNo "Do you have a Claude Pro or Max subscription?`n`n(Affects Desktop Chat/Cowork/Code tabs.)"
-    if ($ans -eq "Yes") { $proMax = "1" } else { $proMax = "0" }
-    Set-State proMax $proMax
-}
-
-# Tailscale
-if (-not $withTailscale) {
-    $ans = Ask-YesNo "Enable Tailscale SSH? (Remote control from iPhone/laptop.)"
-    if ($ans -eq "Yes") { $withTailscale = "1" } else { $withTailscale = "0" }
-    Set-State withTailscale $withTailscale
-}
-
-# Hogwarts local dev — opt-in (heavy: pnpm + DB seed + build, ~10 min)
-$hogwartsDev = Get-State hogwartsDev
-if (-not $hogwartsDev) {
-    $ans = Ask-YesNo "Set up hogwarts local dev now? (pnpm + DB seed + build, ~10 min — skip if this machine won't run hogwarts locally)"
+# Hogwarts local dev - engineer-only
+if ($role -eq "engineer" -and -not $hogwartsDev) {
+    $ans = Ask-YesNo "Set up hogwarts local dev now? (pnpm + DB seed + build, ~10 min - skip if this machine won't run hogwarts locally)"
     if ($ans -eq "Yes") { $hogwartsDev = "1" } else { $hogwartsDev = "0" }
     Set-State hogwartsDev $hogwartsDev
 }
 
 # =============================================================================
-# ACT 2 - Silent batch
+# ACT 2 - Silent batch (1 unavoidable Authorize click during Phase 3)
 # =============================================================================
-Notify "Installing" "~15-20 min in terminal"
+Notify "Installing" "1 GitHub Authorize click around minute 2"
 
 $backendArgs = @("-Role", $role, "-Quiet", "-GitName", $gitName, "-GitEmail", $gitEmail)
-if ($gistId) { $backendArgs += @("-GistId", $gistId) }
-if ($reposDir -and $reposDir -ne $env:USERPROFILE) { $backendArgs += @("-ReposDir", $reposDir) }
-if ($withTailscale -eq "1") { $backendArgs += @("-WithTailscale") }
 if ($hogwartsDev -eq "1") { $backendArgs += @("-HogwartsDev") }
 
 Write-Host ""
 Write-Host "════════════════════════════════════════════════════" -ForegroundColor Cyan
-Write-Host " Databayt Setup - Silent Install in Progress"
+Write-Host " Installing - minimize this window and walk away"
+Write-Host " (one Authorize click in the browser ~2 min in)"
 Write-Host "════════════════════════════════════════════════════"
 Write-Host " Role: $role"
-Write-Host " Minimize this window and do other work."
 Write-Host "════════════════════════════════════════════════════"
 Write-Host ""
 
-# Run backend, capture stderr to filter for PROGRESS markers
 $psi = New-Object System.Diagnostics.ProcessStartInfo
 $psi.FileName = "powershell.exe"
 $psi.Arguments = "-NoProfile -ExecutionPolicy Bypass -File `"$Backend`" $($backendArgs -join ' ')"
 $psi.RedirectStandardError = $true; $psi.RedirectStandardOutput = $false
 $psi.UseShellExecute = $false; $psi.CreateNoWindow = $false
 $proc = [System.Diagnostics.Process]::Start($psi)
-# Stream stderr — fire notify on PROGRESS markers
 while (-not $proc.StandardError.EndOfStream) {
     $line = $proc.StandardError.ReadLine()
     if ($line -match '^PROGRESS:([\d/]+):(.+)$') {
@@ -328,34 +289,11 @@ if ($rc -ne 0) {
 Set-State silentBatch "done"
 
 # =============================================================================
-# ACT 3 - Manual finishing
+# ACT 3 - Done. No dialogs; auto-install what we can; list the rest.
 # =============================================================================
-Notify "Almost done" "Final clicks"
+Notify "Almost done" "Wrapping up"
 
-# 3a. Claude Desktop sign-in (Pro/Max)
-$claudeApp = "$env:LOCALAPPDATA\Programs\claude-desktop\Claude.exe"
-$claudeApp2 = "${env:ProgramFiles}\Claude\Claude.exe"
-if ($proMax -eq "1" -and ((Test-Path $claudeApp) -or (Test-Path $claudeApp2)) -and (Get-State desktopSignedIn) -ne "1") {
-    $ans = Ask-Choice "Sign in to Claude Desktop:`n`n1. Click [Open Claude]`n2. Sign in with your Anthropic account`n3. Click [Done]" "Open Claude" "Done" "Skip"
-    if ($ans -eq "Open Claude") {
-        if (Test-Path $claudeApp) { Start-Process $claudeApp } else { Start-Process $claudeApp2 }
-        $ans = Ask-Choice "Signed in?" "Done" "Skip"
-    }
-    if ($ans -eq "Done") { Set-State desktopSignedIn "1" }
-}
-
-# 3b. Computer-use toggle (Pro/Max)
-if ($proMax -eq "1" -and (Get-State computerUse) -ne "1") {
-    $ans = Ask-Choice "(Optional) Enable Claude Desktop computer-use:`n`n1. Click [Open Settings]`n2. Claude Desktop -> Settings -> General -> Toggle 'Allow Claude to use your computer'`n3. Click [Done]" "Open Settings" "Done" "Skip"
-    if ($ans -eq "Open Settings") {
-        if (Test-Path $claudeApp) { Start-Process $claudeApp } elseif (Test-Path $claudeApp2) { Start-Process $claudeApp2 }
-        Start-Process "ms-settings:easeofaccess"
-        $ans = Ask-Choice "Toggle enabled?" "Done" "Skip"
-    }
-    if ($ans -eq "Done") { Set-State computerUse "1" }
-}
-
-# 3c. VS Code Claude extension - auto-install
+# Silent: VS Code Claude extension
 $hasCode = Get-Command code -EA SilentlyContinue
 if ($hasCode -and (Get-State vsCodeExt) -ne "1") {
     $exts = code --list-extensions 2>$null
@@ -367,34 +305,27 @@ if ($hasCode -and (Get-State vsCodeExt) -ne "1") {
     }
 }
 
-# 3d. WebStorm Claude plugin (engineer)
+# Final panel: one-shot summary + optional follow-ups
+$claudeApp  = "$env:LOCALAPPDATA\Programs\claude-desktop\Claude.exe"
+$claudeApp2 = "${env:ProgramFiles}\Claude\Claude.exe"
+$hasDesktop = (Test-Path $claudeApp) -or (Test-Path $claudeApp2)
 $wsPath = "${env:ProgramFiles}\JetBrains\WebStorm*"
-if ($role -eq "engineer" -and (Test-Path $wsPath) -and (Get-State webstormPlugin) -ne "1") {
-    $ans = Ask-Choice "(Optional) Install Claude Code plugin in WebStorm:`n`n1. Click [Open WebStorm]`n2. Settings -> Plugins -> Marketplace -> 'Claude Code' -> Install`n3. Click [Done]" "Open WebStorm" "Done" "Skip"
-    if ($ans -eq "Open WebStorm") {
-        Start-Process (Get-ChildItem "$wsPath\bin\webstorm64.exe" | Select-Object -First 1).FullName 2>$null
-        $ans = Ask-Choice "Plugin installed?" "Done" "Skip"
-    }
-    if ($ans -eq "Done") { Set-State webstormPlugin "1" }
-}
+$hasWebstorm = Test-Path $wsPath
 
-# 3e. Final verify
-Notify "Verifying" "Health check"
-$healthScript = "$env:USERPROFILE\.claude\scripts\health.ps1"
-if (Test-Path $healthScript) { & $healthScript 2>&1 | Select-Object -Last 5 | Out-Host }
-
-$finalMsg = "Setup complete! Role: $role`n`n"
-$finalMsg += "Tools: git, node, pnpm, gh, claude`n"
-$finalMsg += "Repos: $env:USERPROFILE\kun"
-if ($role -eq "engineer") { $finalMsg += ", \hogwarts, \codebase, +org repos" }
-$finalMsg += "`nConfig: $env:USERPROFILE\.claude\ (agents, skills, MCP)`n`n"
+$finalMsg = "Setup complete · Role: $role`n`n"
 $finalMsg += "Next: open a new PowerShell and type 'c' to start Claude Code.`n`n"
-$finalMsg += "Mobile: install Claude on iPhone/Android with same Anthropic account."
+$finalMsg += "Optional follow-ups (do later, in any order):`n"
+if ($hasDesktop) { $finalMsg += "  • Sign in to Claude Desktop (Start-Process Claude.exe)`n" }
+if ($role -eq "engineer" -and $hasWebstorm) {
+    $finalMsg += "  • WebStorm plugin: Settings -> Plugins -> 'Claude Code'`n"
+}
+$finalMsg += "  • Secrets from Gist: & ~\kun\.claude\scripts\secrets.ps1 -GistId <ID>`n"
+$finalMsg += "  • Mobile / remote: install Claude on iOS/Android, or open claude.ai/code in any browser`n`n"
+$finalMsg += "Docs: https://kun.databayt.org/docs/onboarding"
 
-Ask-Choice $finalMsg "Done" "View Docs" | Out-Null
-
-if ((Ask-YesNo "Open onboarding docs in browser?") -eq "Yes") {
-    Start-Process "https://github.com/databayt/kun/blob/main/content/docs/onboarding.mdx"
+$result = Ask-Choice $finalMsg "Done" "Open Docs"
+if ($result -eq "Open Docs") {
+    Start-Process "https://kun.databayt.org/docs/onboarding"
 }
 
 Set-State lastStep "done"

--- a/.claude/scripts/installer.sh
+++ b/.claude/scripts/installer.sh
@@ -2,8 +2,8 @@
 # =============================================================================
 # Quiet Wizard — macOS Installer
 # =============================================================================
-# Three-act guided installer: pre-flight form, silent batch, manual finishing.
-# Wraps onboarding-mac.sh in osascript dialogs with deep-link action buttons.
+# 2 dialogs (identity, hogwarts) → silent batch with 1 unavoidable click
+# (GitHub Authorize on the auto-opened device-flow page) → done panel.
 #
 # Bootstrap:
 #   curl -fsSL https://kun.databayt.org/install | bash
@@ -37,7 +37,6 @@ json.dump(d, open(p, 'w'), indent=2)
 
 # ── osascript helpers ───────────────────────────────────────────
 ask_text() {
-    # ask_text <prompt> <default> → echoes user input or empty if cancelled
     local prompt="$1" default="${2:-}"
     osascript <<EOF 2>/dev/null
 try
@@ -49,7 +48,6 @@ end try
 EOF
 }
 ask_choice() {
-    # ask_choice <prompt> <opt1> <opt2> [opt3] → echoes chosen button or empty
     local prompt="$1" opt1="$2" opt2="$3" opt3="${4:-}"
     local buttons="{\"$opt1\", \"$opt2\""
     [[ -n "$opt3" ]] && buttons="$buttons, \"$opt3\""
@@ -70,7 +68,7 @@ ask_role() {
     osascript <<'EOF' 2>/dev/null
 set roles to {"engineer", "business", "content", "ops"}
 try
-    set r to choose from list roles with prompt "Pick your role:" default items {"engineer"} with title "Databayt Setup"
+    set r to choose from list roles with prompt "Pick your role (default: engineer):" default items {"engineer"} with title "Databayt Setup"
     if r is false then return ""
     return item 1 of r
 on error
@@ -82,16 +80,14 @@ EOF
 # ── Bootstrap: ensure git, then clone kun ───────────────────────
 # git is needed to clone the repo that installs git, so the wrapper
 # must provide it first. On macOS, git ships with the Xcode Command
-# Line Tools; detect them prompt-free via `xcode-select -p` (same as
-# the backend, onboarding-mac.sh). Without this, the clone below fails
-# with a misleading "check network" alert on a fresh Mac.
+# Line Tools; detect prompt-free via `xcode-select -p`.
 if ! xcode-select -p >/dev/null 2>&1; then
     notify "Installing developer tools" "Xcode Command Line Tools (includes git)"
     xcode-select --install >/dev/null 2>&1 || true
-    ask_choice "macOS is installing the Command Line Tools (this provides git).\n\nClick Install in the system dialog and wait for it to finish, then click Done here." "Done" "Skip" >/dev/null
+    ask_choice "macOS is installing the Command Line Tools (provides git).\n\nClick Install in the system dialog, wait for it to finish, then click Done." "Done" "Skip" >/dev/null
 fi
 if ! command -v git >/dev/null 2>&1 || ! git --version >/dev/null 2>&1; then
-    osascript -e 'display alert "Setup needs git" message "git (Xcode Command Line Tools) is required but is not ready yet.\n\nFinish the Command Line Tools install, then re-run:\n\ncurl -fsSL https://kun.databayt.org/install | bash"' 2>/dev/null
+    osascript -e 'display alert "Setup needs git" message "git (Xcode Command Line Tools) is required but not ready yet.\n\nFinish the Command Line Tools install, then re-run:\n\ncurl -fsSL https://kun.databayt.org/install | bash"' 2>/dev/null
     exit 1
 fi
 
@@ -112,143 +108,81 @@ if [[ ! -f "$BACKEND" ]]; then
 fi
 
 # =============================================================================
-# ACT 1 — Pre-flight (auto-detect, dialog only what's missing)
+# ACT 1 — Two dialogs (or fewer, after autofill)
 # =============================================================================
-WELCOME=$(ask_choice "Welcome — this sets up a fresh Mac for databayt.\n\nAbout 20 minutes (mostly silent downloads).\n\nReady?" "Start" "Cancel")
-[[ "$WELCOME" != "Start" ]] && { notify "Setup cancelled" "Run again anytime"; exit 0; }
+# Consent implied by `curl … | bash` — no welcome modal. Ctrl+C aborts.
+echo ""
+echo "════════════════════════════════════════════════════"
+echo " Databayt Setup — ~20 min · 2 dialogs · 1 click"
+echo "════════════════════════════════════════════════════"
+echo " Press Ctrl+C any time to abort. State auto-saves."
+echo "════════════════════════════════════════════════════"
+echo ""
 
-# Resume from state file if present
+# Resume from state file
 ROLE=$(state_get role)
-GIST_ID=$(state_get gistId)
 GIT_NAME_ARG=$(state_get gitName)
 GIT_EMAIL_ARG=$(state_get gitEmail)
-WITH_TAILSCALE=$(state_get withTailscale)
-PRO_MAX=$(state_get proMax)
-REPOS_DIR=$(state_get reposDir)
-HAS_GITHUB=$(state_get hasGithub)
-HAS_ANTHROPIC=$(state_get hasAnthropic)
-
-# Accounts: confirm or guide creation
-if [[ -z "$HAS_GITHUB" ]]; then
-    ANS=$(ask_choice "Do you have a GitHub account?\n\n(You'll use it to clone repos and authenticate.)" "Yes, I have one" "No, create one" "Skip")
-    case "$ANS" in
-        "No, create one")
-            open "https://github.com/join"
-            ask_choice "GitHub sign-up opened in browser.\n\nCreate the account, then come back and click Done." "Done" "Skip" >/dev/null
-            ;;
-    esac
-    state_set hasGithub "1"
-fi
-
-if [[ -z "$HAS_ANTHROPIC" ]]; then
-    ANS=$(ask_choice "Do you have an Anthropic account?\n\n(For Claude Desktop sign-in and the Claude Code CLI.)" "Yes, I have one" "No, create one" "Skip")
-    case "$ANS" in
-        "No, create one")
-            open "https://claude.ai/login"
-            ask_choice "Anthropic sign-in opened.\n\nCreate the account (or sign in), then click Done.\n\nNote: Pro/Max sub unlocks Desktop Chat/Cowork/Code tabs." "Done" "Skip" >/dev/null
-            ;;
-    esac
-    state_set hasAnthropic "1"
-fi
-
-# Repos directory: ask where to save databayt org repos
-if [[ -z "$REPOS_DIR" ]]; then
-    CHOICE=$(ask_choice "Where do you want databayt org repos saved?\n\nDefault: home root (~/kun, ~/hogwarts, ...)" "Home root (~/)" "~/databayt/" "Custom...")
-    case "$CHOICE" in
-        "Home root (~/)")   REPOS_DIR="$HOME" ;;
-        "~/databayt/")      REPOS_DIR="$HOME/databayt"; mkdir -p "$REPOS_DIR" ;;
-        "Custom...")
-            CUSTOM=$(ask_text "Enter absolute path:" "$HOME/projects/databayt")
-            [[ -z "$CUSTOM" ]] && CUSTOM="$HOME"
-            REPOS_DIR="$CUSTOM"; mkdir -p "$REPOS_DIR"
-            ;;
-        *) REPOS_DIR="$HOME" ;;
-    esac
-    state_set reposDir "$REPOS_DIR"
-fi
-
-# Role: auto-detect from existing mcp.json, else ask
-if [[ -z "$ROLE" ]]; then
-    if [[ -f "$HOME/.claude/mcp.json" ]]; then
-        if grep -q '"shadcn"' "$HOME/.claude/mcp.json" 2>/dev/null; then ROLE="engineer"
-        elif grep -q '"linear"' "$HOME/.claude/mcp.json" 2>/dev/null; then ROLE="business"
-        elif grep -q '"figma"' "$HOME/.claude/mcp.json" 2>/dev/null; then ROLE="content"
-        elif grep -q '"posthog"' "$HOME/.claude/mcp.json" 2>/dev/null; then ROLE="ops"
-        fi
-    fi
-    if [[ -z "$ROLE" ]]; then
-        ROLE=$(ask_role)
-        [[ -z "$ROLE" ]] && { notify "Cancelled" "No role selected"; exit 0; }
-    fi
-    state_set role "$ROLE"
-fi
-
-# Git identity: auto-detect, else ask
-if [[ -z "$GIT_NAME_ARG" ]]; then
-    EXISTING_NAME=$(git config --global user.name 2>/dev/null || echo "")
-    if [[ -n "$EXISTING_NAME" ]]; then
-        GIT_NAME_ARG="$EXISTING_NAME"
-        GIT_EMAIL_ARG=$(git config --global user.email 2>/dev/null || echo "")
-    else
-        GIT_NAME_ARG=$(ask_text "Your full name (for git commits):")
-        [[ -z "$GIT_NAME_ARG" ]] && { notify "Cancelled" "No name given"; exit 0; }
-        GIT_EMAIL_ARG=$(ask_text "Your email (for git commits):")
-        [[ -z "$GIT_EMAIL_ARG" ]] && { notify "Cancelled" "No email given"; exit 0; }
-    fi
-    state_set gitName "$GIT_NAME_ARG"
-    state_set gitEmail "$GIT_EMAIL_ARG"
-fi
-
-# Gist ID: ask once, persist; can skip
-if [[ -z "$GIST_ID" ]]; then
-    GIST_ID=$(ask_text "Secrets Gist ID (or leave blank to skip — you can load later):")
-    state_set gistId "$GIST_ID"
-fi
-
-# Pro/Max: affects Act 3 (Claude Desktop sign-in, computer-use toggle)
-if [[ -z "$PRO_MAX" ]]; then
-    PM_ANS=$(ask_choice "Do you have a Claude Pro or Max subscription?\n\n(Affects whether you get the Desktop Chat/Cowork/Code tabs.)" "Yes" "No")
-    [[ "$PM_ANS" == "Yes" ]] && PRO_MAX="1" || PRO_MAX="0"
-    state_set proMax "$PRO_MAX"
-fi
-
-# Tailscale: optional (default off)
-if [[ -z "$WITH_TAILSCALE" ]]; then
-    TS_ANS=$(ask_choice "Enable Tailscale SSH? (For remote control from iPhone/laptop.)\n\nCan be added later." "Yes" "No")
-    [[ "$TS_ANS" == "Yes" ]] && WITH_TAILSCALE="1" || WITH_TAILSCALE="0"
-    state_set withTailscale "$WITH_TAILSCALE"
-fi
-
-# Hogwarts local dev — opt-in (heavy: pnpm + DB seed + build, ~10 min)
 HOGWARTS_DEV=$(state_get hogwartsDev)
-if [[ -z "$HOGWARTS_DEV" ]]; then
-    HD_ANS=$(ask_choice "Set up hogwarts local dev now? (pnpm + DB seed + build, ~10 min)\n\nSkip if this machine won't run hogwarts locally — you can add it later." "Yes" "No")
+
+# ── Identity card: name + email + role ─────────────────────────
+# Autofill from git config + mcp.json. Dialog only what's missing.
+if [[ -z "$GIT_NAME_ARG" ]]; then
+    GIT_NAME_ARG=$(git config --global user.name 2>/dev/null || echo "")
+fi
+if [[ -z "$GIT_EMAIL_ARG" ]]; then
+    GIT_EMAIL_ARG=$(git config --global user.email 2>/dev/null || echo "")
+fi
+if [[ -z "$ROLE" && -f "$HOME/.claude/mcp.json" ]]; then
+    if   grep -q '"shadcn"'  "$HOME/.claude/mcp.json" 2>/dev/null; then ROLE="engineer"
+    elif grep -q '"linear"'  "$HOME/.claude/mcp.json" 2>/dev/null; then ROLE="business"
+    elif grep -q '"figma"'   "$HOME/.claude/mcp.json" 2>/dev/null; then ROLE="content"
+    elif grep -q '"posthog"' "$HOME/.claude/mcp.json" 2>/dev/null; then ROLE="ops"
+    fi
+fi
+
+# Ask for whatever wasn't auto-detected
+if [[ -z "$GIT_NAME_ARG" ]]; then
+    GIT_NAME_ARG=$(ask_text "Identity 1/3 — your full name (for git commits):")
+    [[ -z "$GIT_NAME_ARG" ]] && { notify "Cancelled" "No name given"; exit 0; }
+fi
+if [[ -z "$GIT_EMAIL_ARG" ]]; then
+    GIT_EMAIL_ARG=$(ask_text "Identity 2/3 — your email (for git commits):")
+    [[ -z "$GIT_EMAIL_ARG" ]] && { notify "Cancelled" "No email given"; exit 0; }
+fi
+if [[ -z "$ROLE" ]]; then
+    ROLE=$(ask_role)
+    [[ -z "$ROLE" ]] && ROLE="engineer"  # default — keep moving
+fi
+state_set gitName "$GIT_NAME_ARG"
+state_set gitEmail "$GIT_EMAIL_ARG"
+state_set role "$ROLE"
+
+# ── Hogwarts local dev (engineer-only, gates ~10 min) ──────────
+if [[ "$ROLE" == "engineer" && -z "$HOGWARTS_DEV" ]]; then
+    HD_ANS=$(ask_choice "Set up hogwarts local dev now? (pnpm + DB seed + build, ~10 min)\n\nSkip if this machine won't run hogwarts locally — you can add later." "Yes" "No")
     [[ "$HD_ANS" == "Yes" ]] && HOGWARTS_DEV="1" || HOGWARTS_DEV="0"
     state_set hogwartsDev "$HOGWARTS_DEV"
 fi
 
 # =============================================================================
-# ACT 2 — Silent batch (in terminal; notifications on phase transitions)
+# ACT 2 — Silent batch (1 unavoidable Authorize click during Phase 3)
 # =============================================================================
-notify "Starting install..." "~15-20 minutes"
+notify "Starting install..." "1 GitHub Authorize click around minute 2"
 
 BACKEND_ARGS=("$ROLE")
-[[ -n "$GIST_ID" ]] && BACKEND_ARGS+=("$GIST_ID")
 BACKEND_ARGS+=("--quiet" "--name" "$GIT_NAME_ARG" "--email" "$GIT_EMAIL_ARG")
-[[ -n "$REPOS_DIR" && "$REPOS_DIR" != "$HOME" ]] && BACKEND_ARGS+=("--repos-dir" "$REPOS_DIR")
-[[ "$WITH_TAILSCALE" == "1" ]] && BACKEND_ARGS+=("--with-tailscale")
 [[ "$HOGWARTS_DEV" == "1" ]] && BACKEND_ARGS+=("--hogwarts-dev")
 
 echo ""
 echo "════════════════════════════════════════════════════"
-echo " Databayt Setup — Silent Install in Progress"
+echo " Installing — minimize the terminal and walk away"
+echo " (one Authorize click in the browser ~2 min in)"
 echo "════════════════════════════════════════════════════"
 echo " Role: $ROLE"
-echo " You can minimize this terminal and do other work."
 echo "════════════════════════════════════════════════════"
 echo ""
 
-# Stream backend output to terminal, watch stderr for PROGRESS markers → notifications
 set +e
 bash "$BACKEND" "${BACKEND_ARGS[@]}" 2> >(while IFS= read -r line; do
     echo "$line" >&2
@@ -265,39 +199,16 @@ if [[ "$BACKEND_RC" -ne 0 ]]; then
     case "$RETRY" in
         Retry) exec bash "$0" ;;
         Quit)  exit "$BACKEND_RC" ;;
-        # Skip: continue to Act 3
     esac
 fi
 state_set silentBatch "done"
 
 # =============================================================================
-# ACT 3 — Manual finishing (deep-link dialogs only when human is needed)
+# ACT 3 — Done. No dialogs; auto-install what we can; list the rest.
 # =============================================================================
-notify "Almost done" "Final clicks coming up"
+notify "Almost done" "Wrapping up"
 
-# 3a. Claude Desktop sign-in (Pro/Max only)
-if [[ "$PRO_MAX" == "1" && -d "/Applications/Claude.app" ]] && [[ "$(state_get desktopSignedIn)" != "1" ]]; then
-    ANS=$(ask_choice "Sign in to Claude Desktop:\n\nClicking [Open Claude] launches the app. Sign in with your Anthropic account, then click [Done]." "Open Claude" "Done" "Skip")
-    case "$ANS" in
-        "Open Claude") open -a Claude; ANS=$(ask_choice "Signed in?" "Done" "Skip");;
-    esac
-    [[ "$ANS" == "Done" ]] && state_set desktopSignedIn "1"
-fi
-
-# 3b. Computer-use toggle (Pro/Max only)
-if [[ "$PRO_MAX" == "1" ]] && [[ "$(state_get computerUse)" != "1" ]]; then
-    ANS=$(ask_choice "(Optional) Enable Claude Desktop's computer-use:\n\n1. Click [Open Settings] below\n2. In Claude Desktop → Settings → General, toggle 'Allow Claude to use your computer'\n3. Click [Done]" "Open Settings" "Done" "Skip")
-    case "$ANS" in
-        "Open Settings")
-            open -a Claude
-            open "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility"
-            ANS=$(ask_choice "Toggle enabled?" "Done" "Skip")
-            ;;
-    esac
-    [[ "$ANS" == "Done" ]] && state_set computerUse "1"
-fi
-
-# 3c. VS Code Claude extension — auto-install if `code` on PATH
+# Silent: VS Code Claude extension
 if command -v code >/dev/null 2>&1 && [[ "$(state_get vsCodeExt)" != "1" ]]; then
     if code --list-extensions 2>/dev/null | grep -q "anthropic.claude-code"; then
         state_set vsCodeExt "1"
@@ -306,36 +217,26 @@ if command -v code >/dev/null 2>&1 && [[ "$(state_get vsCodeExt)" != "1" ]]; the
     fi
 fi
 
-# 3d. WebStorm Claude plugin (engineer)
-if [[ "$ROLE" == "engineer" && -d "/Applications/WebStorm.app" ]] && [[ "$(state_get webstormPlugin)" != "1" ]]; then
-    ANS=$(ask_choice "(Optional) Install Claude Code plugin in WebStorm:\n\n1. Click [Open WebStorm]\n2. Settings → Plugins → Marketplace → search 'Claude Code' → Install\n3. Click [Done]" "Open WebStorm" "Done" "Skip")
-    case "$ANS" in
-        "Open WebStorm") open -a WebStorm; ANS=$(ask_choice "Plugin installed?" "Done" "Skip");;
-    esac
-    [[ "$ANS" == "Done" ]] && state_set webstormPlugin "1"
-fi
-
-# 3e. Final health check
-notify "Verifying..." "Running health check"
+# Health check
 HEALTH_STATUS="(health.sh not found)"
 if [[ -f "$HOME/.claude/scripts/health.sh" ]]; then
     HEALTH_STATUS=$(bash "$HOME/.claude/scripts/health.sh" 2>&1 | head -1 || true)
 fi
 
-# Final dialog
-FINAL_MSG="Setup complete! Role: $ROLE\n\n"
-FINAL_MSG+="Config health: $HEALTH_STATUS\n\n"
-FINAL_MSG+="Tools: git, node, pnpm, gh, claude\n"
-FINAL_MSG+="Repos: ~/kun"
-[[ "$ROLE" == "engineer" ]] && FINAL_MSG+=", ~/hogwarts, ~/codebase, +org repos"
-FINAL_MSG+="\nConfig: ~/.claude/ (agents, skills, MCP, hooks)\n\n"
+# Final panel: one-shot summary + optional follow-ups
+FINAL_MSG="Setup complete · Role: $ROLE\n"
+FINAL_MSG+="Config: $HEALTH_STATUS\n\n"
 FINAL_MSG+="Next: open a new terminal and type 'c' to start Claude Code.\n\n"
-FINAL_MSG+="Mobile: install Claude on iPhone/Android with the same Anthropic account."
+FINAL_MSG+="Optional follow-ups (do later, in any order):\n"
+[[ -d "/Applications/Claude.app" ]]    && FINAL_MSG+="  • Sign in to Claude Desktop (open -a Claude)\n"
+[[ "$ROLE" == "engineer" && -d "/Applications/WebStorm.app" ]] && FINAL_MSG+="  • WebStorm plugin: Settings → Plugins → 'Claude Code'\n"
+FINAL_MSG+="  • Secrets from Gist: bash ~/kun/.claude/scripts/secrets.sh <GIST_ID>\n"
+FINAL_MSG+="  • Mobile / remote: install Claude on iOS/Android, or open claude.ai/code in any browser\n\n"
+FINAL_MSG+="Docs: https://kun.databayt.org/docs/onboarding"
 
-ask_choice "$FINAL_MSG" "Done" "View Docs" >/dev/null
-
-if [[ "$(ask_choice "Open onboarding docs?" "Open" "Skip")" == "Open" ]]; then
-    open "https://github.com/databayt/kun/blob/main/content/docs/onboarding.mdx"
+RESULT=$(ask_choice "$FINAL_MSG" "Done" "Open Docs")
+if [[ "$RESULT" == "Open Docs" ]]; then
+    open "https://kun.databayt.org/docs/onboarding"
 fi
 
 state_set lastStep "done"

--- a/.claude/scripts/lib/wizard-steps.json
+++ b/.claude/scripts/lib/wizard-steps.json
@@ -1,192 +1,113 @@
 {
   "$schema": "https://json-schema.org/draft-07/schema#",
   "title": "Databayt Quiet Wizard — Step Catalog",
-  "description": "Documentation-style catalog of every step the wrappers run. Wrappers currently hardcode these; future versions may read from this file. Source of truth for what each platform installer does.",
-  "version": 1,
+  "description": "Documentation-style catalog of every step the wrappers run. Source of truth for what each platform installer asks/does. Target shape: 2 dialogs in Act 1, 0 dialogs in Act 3, exactly 1 unavoidable browser click (GitHub device-flow Authorize).",
+  "version": 2,
   "acts": {
     "act1_preflight": {
-      "description": "Gather inputs; auto-detect existing state, dialog only what's missing",
+      "description": "Two dialogs — everything else is auto-detected or deferred.",
       "steps": [
         {
-          "id": "welcome",
-          "type": "choice",
-          "prompt": "Welcome — this sets up a fresh machine for databayt. ~20 min.",
-          "buttons": ["Start", "Cancel"]
+          "id": "identity",
+          "type": "form",
+          "prompt": "Identity card — confirm your git identity and role.",
+          "fields": [
+            { "name": "gitName",  "label": "Full name (for git commits)", "autoDetect": "git config --global user.name",  "persistAs": "gitName"  },
+            { "name": "gitEmail", "label": "Email (for git commits)",     "autoDetect": "git config --global user.email", "persistAs": "gitEmail" },
+            { "name": "role",     "label": "Role",                         "options": ["engineer", "business", "content", "ops"], "default": "engineer", "autoDetect": "Inspect ~/.claude/mcp.json: shadcn→engineer, linear→business, figma→content, posthog→ops", "persistAs": "role" }
+          ],
+          "rendering": {
+            "mac":     "two chained osascript display dialogs (name/email autofill skips dialog if git config set) + choose-from-list for role",
+            "linux":   "zenity --forms (single dialog with 3 fields) / kdialog menu / TUI fallback",
+            "windows": "WPF window with TextBox×2 + ComboBox"
+          },
+          "skipWhen": "All three values present in state file or auto-detectable"
         },
         {
-          "id": "role",
-          "type": "list",
-          "prompt": "Pick your role:",
-          "options": ["engineer", "business", "content", "ops"],
-          "autoDetect": "Inspect ~/.claude/mcp.json for shadcn/linear/figma/posthog → infer role",
-          "persistAs": "role"
-        },
-        {
-          "id": "gitName",
-          "type": "text",
-          "prompt": "Your full name (for git commits):",
-          "autoDetect": "git config --global user.name",
-          "persistAs": "gitName"
-        },
-        {
-          "id": "gitEmail",
-          "type": "text",
-          "prompt": "Your email (for git commits):",
-          "autoDetect": "git config --global user.email",
-          "persistAs": "gitEmail"
-        },
-        {
-          "id": "gistId",
-          "type": "text",
-          "prompt": "Secrets Gist ID (or blank to skip):",
-          "persistAs": "gistId",
-          "optional": true
-        },
-        {
-          "id": "proMax",
+          "id": "hogwartsDev",
           "type": "yesno",
-          "prompt": "Do you have a Claude Pro or Max subscription?",
-          "platforms": ["mac", "windows"],
-          "persistAs": "proMax",
-          "note": "Skipped on Linux (no Claude Desktop)"
-        },
-        {
-          "id": "withTailscale",
-          "type": "yesno",
-          "prompt": "Enable Tailscale SSH? (Remote control from iPhone/laptop.)",
-          "persistAs": "withTailscale"
+          "prompt": "Set up hogwarts local dev now? (pnpm + DB seed + build, ~10 min)",
+          "gate": "role == engineer",
+          "persistAs": "hogwartsDev"
         }
       ]
     },
     "act2_silentBatch": {
-      "description": "Run the 8-phase platform backend in --quiet/-Quiet mode",
+      "description": "Run the 8-phase platform backend in --quiet/-Quiet mode. One unavoidable click during Phase 3 (GitHub device-flow Authorize) — the script auto-opens the page and copies the code to clipboard.",
       "backends": {
-        "mac": ".claude/scripts/onboarding-mac.sh <role> <gist> --quiet --name --email [--with-tailscale]",
-        "linux": ".claude/scripts/onboarding-linux.sh <role> <gist> --quiet --name --email [--with-tailscale]",
-        "windows": ".claude/scripts/onboarding-windows.ps1 -Role <r> -GistId <g> -Quiet -GitName -GitEmail [-WithTailscale]"
+        "mac":     ".claude/scripts/onboarding-mac.sh <role> <gist> --quiet --name --email [--repos-dir] [--with-tailscale] [--hogwarts-dev]",
+        "linux":   ".claude/scripts/onboarding-linux.sh <role> <gist> --quiet --name --email [--repos-dir] [--with-tailscale] [--hogwarts-dev]",
+        "windows": ".claude/scripts/onboarding-windows.ps1 -Role <r> [-GistId <g>] -Quiet -GitName -GitEmail [-ReposDir] [-WithTailscale] [-HogwartsDev]"
       },
       "phases": [
         {"n": 1, "label": "System Foundation — build tools, git, Node 22, pnpm, gh CLI"},
         {"n": 2, "label": "Applications — IDEs, Chrome"},
-        {"n": 3, "label": "GitHub — SSH key, gh auth, upload key"},
-        {"n": 4, "label": "Clone Repositories — kun + (engineer: hogwarts, codebase, all org repos)"},
-        {"n": 5, "label": "Claude — Code CLI + Desktop (Mac/Win)"},
-        {"n": 6, "label": "Kun Engine — setup.sh + secrets.sh"},
-        {"n": 7, "label": "Hogwarts — pnpm install, prisma, seed, build (engineer only)"},
+        {"n": 3, "label": "GitHub — SSH key, gh auth (device-flow: 1 Authorize click), upload key", "userClick": "Authorize on github.com/login/device (code auto-copied)"},
+        {"n": 4, "label": "Clone Repositories — kun + full org (engineer)"},
+        {"n": 5, "label": "Claude — Code CLI + Desktop (Mac/Win) + VS Code extension"},
+        {"n": 6, "label": "Kun Engine — setup.sh + secrets.sh (if Gist supplied)"},
+        {"n": 7, "label": "Hogwarts — pnpm install, prisma, seed, build (hogwartsDev only)"},
         {"n": 8, "label": "Health Check"},
         {"n": "9 (opt)", "label": "Tailscale — install + 'up --ssh' (--with-tailscale)"}
       ],
-      "progressMarker": "PROGRESS:N/8:label streamed on stderr — wrappers parse for notifications"
+      "progressMarker": "PROGRESS:N/8:label streamed on stderr — wrappers parse for native notifications"
     },
-    "act3_manualFinishing": {
-      "description": "Deep-link dialogs only when human is unavoidably in the loop",
-      "steps": [
-        {
-          "id": "githubAuth",
-          "type": "auto-poll",
-          "command": "gh auth login --web",
-          "note": "Opens browser, blocks until success — no dialog needed"
-        },
-        {
-          "id": "anthropicAuth",
-          "type": "auto-poll",
-          "command": "claude (first-run opens browser)",
-          "note": "Same as GitHub — browser-based, no terminal prompt"
-        },
-        {
-          "id": "vsCodeExtension",
-          "type": "silent",
-          "command": "code --install-extension anthropic.claude-code",
-          "skip": "if extension already listed"
-        },
-        {
-          "id": "claudeDesktopSignIn",
-          "type": "dialog",
-          "platforms": ["mac", "windows"],
-          "prompt": "Sign in to Claude Desktop",
-          "buttons": ["Open Claude", "Done", "Skip"],
-          "deepLinks": {
-            "mac": "open -a Claude",
-            "windows": "Start-Process Claude.exe"
-          },
-          "gate": "proMax == 1"
-        },
-        {
-          "id": "computerUseToggle",
-          "type": "dialog",
-          "platforms": ["mac", "windows"],
-          "prompt": "Enable Claude Desktop computer-use (optional)",
-          "buttons": ["Open Settings", "Done", "Skip"],
-          "deepLinks": {
-            "mac": "open 'x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility'",
-            "windows": "Start-Process ms-settings:easeofaccess"
-          },
-          "gate": "proMax == 1"
-        },
-        {
-          "id": "webstormPlugin",
-          "type": "dialog",
-          "prompt": "Install Claude Code plugin in WebStorm (optional)",
-          "buttons": ["Open WebStorm", "Done", "Skip"],
-          "deepLinks": {
-            "mac": "open -a WebStorm",
-            "linux": "webstorm or snap run webstorm",
-            "windows": "Start-Process webstorm64.exe"
-          },
-          "gate": "role == engineer && WebStorm installed"
-        },
-        {
-          "id": "healthCheck",
-          "type": "auto",
-          "command": "bash ~/.claude/scripts/health.sh (Mac/Linux) or health.ps1 (Win)"
-        }
-      ]
+    "act3_done": {
+      "description": "No dialogs. Final 'All set' panel lists optional follow-ups with exact commands the user can run later.",
+      "panelContent": {
+        "verifyCommand": "bash ~/.claude/scripts/health.sh",
+        "optionalFollowUps": [
+          { "id": "claudeDesktopSignIn",  "label": "Sign in to Claude Desktop",         "command": "open -a Claude  /  Start-Process Claude.exe", "platforms": ["mac", "windows"], "gate": "Pro/Max sub" },
+          { "id": "webstormPlugin",       "label": "Install Claude Code plugin in WebStorm", "command": "WebStorm → Settings → Plugins → 'Claude Code'", "gate": "role == engineer && WebStorm installed" },
+          { "id": "computerUseToggle",    "label": "Enable Desktop computer-use",      "command": "Claude Desktop → Settings → General → 'Allow Claude to use your computer'", "platforms": ["mac", "windows"], "gate": "Pro/Max sub" },
+          { "id": "tailscale",            "label": "Tailscale SSH",                     "command": "bash ~/kun/.claude/scripts/onboarding-mac.sh --with-tailscale" },
+          { "id": "gistSecrets",          "label": "Load secrets from Gist",            "command": "bash ~/kun/.claude/scripts/secrets.sh <GIST_ID>" },
+          { "id": "appleNotesDispatch",   "label": "Apple Notes Dispatch folder",       "command": "Create 'Dispatch' folder in Notes — see /docs/dispatch", "platforms": ["mac"] }
+        ]
+      }
     }
+  },
+  "removedFromV1": {
+    "description": "Dialogs cut in v2 (down from 11 questions + 3 clicks to 2 questions + 1 click).",
+    "preflightCut": [
+      { "id": "welcome",      "reason": "Consent implied by curl|bash. Stderr 'Press Ctrl+C to abort' replaces dialog." },
+      { "id": "hasGithub",    "reason": "gh auth status answers; signup is inline on the device-flow page." },
+      { "id": "hasAnthropic", "reason": "Claude CLI first-run / Desktop sign-in handles account creation." },
+      { "id": "reposDir",     "reason": "Default $HOME; --repos-dir flag for the 1% who need a custom dir." },
+      { "id": "gistId",       "reason": "Deferred — surfaced as a copy-paste one-liner in the final panel." },
+      { "id": "proMax",       "reason": "Cut — final panel lists Desktop steps regardless; users skip what doesn't apply." },
+      { "id": "withTailscale","reason": "Deferred to optional follow-up (re-run with --with-tailscale)." }
+    ],
+    "act3DialogsCut": [
+      { "id": "claudeDesktopSignIn", "reason": "Moved to final-panel follow-up list. No longer blocks." },
+      { "id": "computerUseToggle",   "reason": "Niche power-user toggle. Moved to follow-up list." },
+      { "id": "webstormPlugin",      "reason": "Moved to follow-up list (silent install via JetBrains CLI is a future stretch)." }
+    ]
   },
   "stateFile": {
-    "mac": "~/Library/Application Support/Databayt/installer-state.json",
-    "linux": "${XDG_CONFIG_HOME:-~/.config}/databayt/installer-state.json",
+    "mac":     "~/Library/Application Support/Databayt/installer-state.json",
+    "linux":   "${XDG_CONFIG_HOME:-~/.config}/databayt/installer-state.json",
     "windows": "%APPDATA%\\Databayt\\installer-state.json",
     "schema": {
-      "role": "string",
-      "gitName": "string",
-      "gitEmail": "string",
-      "gistId": "string",
-      "proMax": "0|1",
-      "withTailscale": "0|1",
-      "silentBatch": "done",
-      "desktopSignedIn": "0|1",
-      "computerUse": "0|1",
-      "vsCodeExt": "0|1",
-      "webstormPlugin": "0|1",
-      "lastStep": "string",
-      "timestamp": "ISO-8601"
+      "role":         "engineer|business|content|ops",
+      "gitName":      "string",
+      "gitEmail":     "string",
+      "gistId":       "string (optional)",
+      "reposDir":     "string (optional, default $HOME)",
+      "withTailscale":"0|1 (optional, default 0)",
+      "hogwartsDev":  "0|1",
+      "silentBatch":  "done",
+      "lastStep":     "string",
+      "timestamp":    "ISO-8601"
     },
-    "behavior": "On wizard start, read state file. If present, skip already-completed steps."
+    "behavior": "On wizard start, read state file. If present, skip already-answered fields and resume from last completed phase."
   },
   "deepLinks": {
-    "accessibilitySettings": {
-      "mac": "open 'x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility'",
-      "windows": "Start-Process ms-settings:easeofaccess",
-      "linux": "gnome-control-center privacy || systemsettings5 kcm_accessibility"
-    },
-    "claudeDesktop": {
-      "mac": "open -a Claude",
-      "windows": "Start-Process Claude.exe",
-      "linux": "n/a — Claude Desktop not on Linux"
-    },
-    "vsCodeExtension": {
-      "all": "code --install-extension anthropic.claude-code || vscode:extension/anthropic.claude-code"
-    },
-    "githubDeviceFlow": {
-      "all": "gh auth login --web"
-    },
-    "anthropicConsole": {
-      "all": "https://console.anthropic.com/settings/keys"
-    },
-    "mobileApps": {
-      "iOS": "https://apps.apple.com/app/claude-by-anthropic/id6473753684",
-      "Android": "https://play.google.com/store/apps/details?id=com.anthropic.claude"
-    }
+    "githubDeviceFlow":     { "all": "https://github.com/login/device  — auto-opened, code auto-copied to clipboard" },
+    "claudeDesktop":        { "mac": "open -a Claude", "windows": "Start-Process Claude.exe", "linux": "n/a (no Claude Desktop on Linux)" },
+    "vsCodeExtension":      { "all": "code --install-extension anthropic.claude-code" },
+    "accessibilitySettings":{ "mac": "open 'x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility'", "windows": "Start-Process ms-settings:easeofaccess", "linux": "gnome-control-center privacy || systemsettings5 kcm_accessibility" },
+    "anthropicConsole":     { "all": "https://console.anthropic.com/settings/keys" },
+    "mobileApps":           { "iOS": "https://apps.apple.com/app/claude-by-anthropic/id6473753684", "Android": "https://play.google.com/store/apps/details?id=com.anthropic.claude" }
   }
 }

--- a/content/docs/onboarding.mdx
+++ b/content/docs/onboarding.mdx
@@ -1,22 +1,19 @@
 ---
 title: Onboarding
-description: Fresh machine to fully working dev environment in one paste
+description: Fresh machine to fully provisioned databayt environment in one paste
 ---
 
 # Onboarding
 
-> One paste. ~20 minutes mostly silent. ≤3 clicks at the end.
-> A fresh Mac, Windows, or Linux laptop becomes a fully provisioned databayt environment — every tool installed, every repo cloned, every Claude surface working.
+> Fresh machine → fully provisioned. **One paste. One click. ~20 minutes mostly silent.**
 
-This is the single source of truth for joining databayt. It covers every OS, every Claude surface, every dotfile, every external account.
+The single source of truth for joining databayt. Pasting the line below provisions every tool, every repo, and every Claude surface for any role on macOS, Windows, or Linux.
 
-> **Ran this on a real machine?** Hit **Report an issue** in the footer of any [kun.databayt.org](https://kun.databayt.org) page and describe what you saw — what worked, what broke, what to change. It files a GitHub issue (no account-juggling, works mid-install from the browser). See [Issue pipeline](/docs/issue).
+> **Ran it on a real machine?** Hit **Report an issue** in the footer of any [kun.databayt.org](https://kun.databayt.org) page and tell us what you saw. It files a GitHub issue from the browser — works mid-install. See [Issue pipeline](/docs/issue).
 
 ---
 
 ## The one-liner
-
-Paste in a terminal. The wizard takes over.
 
 **macOS / Linux**
 
@@ -30,459 +27,148 @@ curl -fsSL https://kun.databayt.org/install | bash
 iwr https://kun.databayt.org/install.ps1 | iex
 ```
 
-The bootstrap URL auto-detects your OS and dispatches to the right installer. No need to pick. Re-run anytime — it auto-resumes from where it left off via a state file.
+The bootstrap URL auto-detects your OS. Re-run anytime — a state file resumes from the last completed step.
 
 ---
 
-## What You Get
+## What happens
 
-Running the bootstrap line leaves your machine in this state. The deliverables, how to verify each one, how to change what's delivered, and what the baseline is for your profile.
+The wizard is **2 dialogs, 1 click, then silent**. Stay at the keyboard for ~3 minutes, then walk away.
 
-### Deliverables
-
-| Category | What |
-|---|---|
-| **Side-tools** | git, Node 22 LTS, pnpm, gh CLI, Chrome |
-| **IDEs** | WebStorm (+ Claude plugin), VS Code (+ Claude extension) |
-| **Claude** | Desktop (Chat / Cowork / Code tabs), Claude Code CLI, IDE integrations, `claude.ai/code` in browser, Mobile (iOS/Android) |
-| **Dotfiles** | SSH key (uploaded to GitHub), `~/.zshrc` / `~/.bashrc` / `$PROFILE` with `c` function, `~/.gitconfig`, `~/.ssh/config` (Keychain on Mac) |
-| **Claude config** | `~/.claude/` — agents, skills, MCP servers, hooks, rules, memory; secrets in `~/.claude/.env` |
-| **Desktop ↔ CLI parity** | `claude_desktop_config.json` symlinked to `~/.claude/mcp.json` so Desktop tabs see the same MCP fleet |
-| **Repos** | The full databayt org cloned to your chosen directory (default: `~/<repo>`) — see [Repos table below](#which-repos-you-get) |
-| **Optional** | Tailscale SSH (remote control from phone/laptop), Apple Notes Dispatch folder (Mac) |
-
-### Verify what you got
-
-Provisioning lands in six layers. Run these to confirm each — all green means fully provisioned for your profile:
-
-| Layer | Verify command | Pass looks like |
+| # | Step | Time |
 |---|---|---|
-| **Tools** | `for t in git node pnpm gh claude; do command -v $t; done` | a path prints for each |
-| **Auth** | `gh auth status && ssh -T git@github.com` | "Logged in"; "successfully authenticated" |
-| **Code** | `ls ~/kun ~/hogwarts ~/codebase` | directories exist (all org repos on every machine) |
-| **Config** | `bash ~/.claude/scripts/health.sh` | `✅ healthy` (0 errors) |
-| **Surfaces** | `claude doctor` | all checks green |
-| **Product** *(if `--hogwarts-dev`)* | `cd ~/hogwarts && pnpm dev` → open `localhost:3000` | login works (`admin@kingfahad.edu` / `1234`) |
+| 1 | **Identity card** — name, email, role (autofilled when possible) | 10 s |
+| 2 | **GitHub Authorize** — code is pre-copied; click Authorize in the opened tab | 5 s |
+| 3 | **Hogwarts local dev?** — Yes/No (engineer-only; gates ~10 min of seeding) | 5 s |
+| 4 | **8 silent phases** — minimize the terminal; native notification per phase | ~20 min |
 
-`bash ~/.claude/scripts/health.sh` is the authoritative config gate but only audits `~/.claude/` — pair it with the other rows for a complete check.
+Everything else (GitHub account check, Anthropic sign-in, Pro/Max, secrets Gist, repo location) is auto-detected or deferred to the post-install "things to do later" panel.
 
-### Modify what's delivered
+---
 
-Want a different result? Edit the source, then re-run the bootstrap (idempotent):
+## Manual fallback
 
-| To change… | Edit / flag |
-|---|---|
-| Which repos clone | Phase 4 repo list in `onboarding-{mac,linux}.sh` / `foreach` in `onboarding-windows.ps1`; or pass `--essentials-only` for just kun/hogwarts/codebase |
-| Where repos land | `--repos-dir <path>` (Mac/Linux) / `-ReposDir <path>` (Windows), or the wizard's "where to save repos" prompt |
-| Which tools install | Phase 1–2 of the `onboarding-*` backend for your OS |
-| MCP servers (universal) | edit `.claude/mcp.json` — every machine gets the full fleet |
-| Skills / commands (universal) | add/remove files in `.claude/commands/` — copied in full to every machine |
-| Agents (universal) | add/remove files in `.claude/agents/` |
-| Which keys a machine holds | scoped by the **Gist** you hand someone (`secrets.sh <GIST_ID>`), not by config |
-| hogwarts local dev | `--hogwarts-dev` / `-HogwartsDev` (default off) |
-| Tailscale on/off | `--with-tailscale` / `-WithTailscale` (default off) |
+Locked-down VM, corporate proxy, or just prefer commands? Clone kun and run the backend directly — same outcome, no wizard.
+
+```bash
+# macOS — Xcode CLT auto-prompts to install git
+git clone https://github.com/databayt/kun.git ~/kun && \
+  bash ~/kun/.claude/scripts/onboarding-mac.sh engineer
+
+# Linux (Debian/Ubuntu) — adapt the apt line for your distro
+sudo apt install -y git && \
+  git clone https://github.com/databayt/kun.git ~/kun && \
+  bash ~/kun/.claude/scripts/onboarding-linux.sh engineer
+
+# Windows (PowerShell) — winget installs git
+winget install Git.Git -e --silent
+git clone https://github.com/databayt/kun.git $HOME\kun
+& "$HOME\kun\.claude\scripts\onboarding-windows.ps1" -Role engineer
+```
+
+Swap `engineer` for `business`, `content`, or `ops`. Append your Gist ID as a second positional arg to pull secrets in the same run.
+
+Useful flags (same on all three): `--quiet` (no prompts) · `--essentials-only` (kun/hogwarts/codebase only) · `--hogwarts-dev` · `--name <name>` · `--email <email>` · `--repos-dir <path>`. PowerShell equivalents use `-PascalCase`. Run any backend with no args to print all flags.
+
+---
+
+## What you get
+
+Every machine receives the full config — the **machine, not the person, is the unit of capability**. Role is just a label + a secrets-trust tier; it doesn't limit what a box can do.
+
+| Category | What lands | Verify | Change it |
+|---|---|---|---|
+| **Side-tools** | git · Node 22 LTS · pnpm · gh · Chrome | `for t in git node pnpm gh claude; do command -v $t; done` | edit Phase 1–2 of `onboarding-{mac,linux}.sh` / `.ps1` |
+| **IDEs** | WebStorm · VS Code (+ Claude extension) | `code --list-extensions \| grep claude` | edit Phase 2 |
+| **Claude surfaces** | Code CLI · Desktop (Mac/Win) · IDE plugins · `claude.ai/code` · Mobile | `claude doctor` | — |
+| **Dotfiles** | SSH key on GitHub · `c` function · `~/.gitconfig` · `~/.ssh/config` | `gh auth status && ssh -T git@github.com` | edit `setup.sh` |
+| **Claude config** | `~/.claude/` — agents, skills, MCP, hooks, rules, memory | `bash ~/.claude/scripts/health.sh` | edit `.claude/{agents,skills,mcp.json}` in `kun` |
+| **Desktop ↔ CLI parity** | `claude_desktop_config.json` → symlink → `~/.claude/mcp.json` | open Claude Desktop · same MCP fleet | — |
+| **Repos** | Full databayt org cloned to `$HOME` (or `--repos-dir`) | `ls ~/kun ~/hogwarts ~/codebase` | `--essentials-only` for kun/hogwarts/codebase only |
+| **Secrets** | `~/.claude/.env` populated from your Gist (if provided) | `cat ~/.claude/.env \| head` | re-run `secrets.sh <GIST_ID>` |
 
 All installer scripts live in `~/kun/.claude/scripts/`. Print any backend's flags with no args (e.g. `bash ~/kun/.claude/scripts/onboarding-mac.sh`).
 
-### Every machine is a full autonomous worker
+### Caveats by environment
 
-**Config is universal — the machine, not the person, is the unit of capability.** Every machine gets all agents, all skills, the full MCP fleet, all hooks, and the entire org's repos. Any machine can run any task. Your **role** is just a label + a *secrets-trust tier* — it does not limit what your computer can do.
-
-| What | Every machine |
-|---|---|
-| Agents / skills / hooks | full set |
-| MCP servers | full fleet (~18) |
-| Repos | all of the databayt org |
-| IDEs (WebStorm + VS Code) | installed |
-| hogwarts local dev | opt-in (`--hogwarts-dev` / wizard prompt) — not role-gated |
-
-What still varies (and why):
-
-- **Secrets** — scoped, not by config but by which **Gist** you're handed. A machine only holds the keys it's trusted with; an MCP server without its key simply doesn't connect (harmless). Full config everywhere, contained blast radius.
-- **Linux**: Claude Desktop doesn't exist on Linux — surfaces are the CLI, `claude.ai/code` in the browser, and the IDE plugins. A Linux box with those is complete; don't expect the Chat/Cowork/Code tabs.
-- **No Pro/Max**: Desktop tabs are unavailable — Claude Code can still bill through an `ANTHROPIC_API_KEY`, or upgrade to Pro/Max for the Desktop surfaces.
-
----
-
-## Three paths
-
-Pick the one that fits.
-
-| Path | Time | Pro/Max needed? | Best for |
-|---|---|---|---|
-| **Wizard** (recommended) | ~5 min active, ~20 min wall | No | Anyone — guided UX, auto-resume, deep links to right OS surface |
-| **Script** | ~2 min active, ~15-20 min wall | No | Engineers who want one bash command, no dialogs |
-| **Manual** | ~60 min | No | Auditing what gets installed, or learning the parts |
-
----
-
-## The wizard — three acts
-
-The wizard runs in three acts. Most is silent; you click only when a human is unavoidably needed.
-
-### Act 1 — Pre-flight (~60 seconds, dialog burst)
-
-The wizard auto-detects what it can and only asks for what it can't:
-
-| Question | Auto-detected when |
-|---|---|
-| Welcome / start | always shown |
-| GitHub account? | always asked (opens `github.com/join` if "No") |
-| Anthropic account? | always asked (opens `claude.ai/login` if "No") |
-| Role (label + secrets-trust tier — does *not* limit config) | inferred from `~/.claude/mcp.json` if exists |
-| Full name, email (for git commits) | inferred from `git config --global` if set |
-| Secrets Gist ID | asked once, then persisted |
-| Pro/Max subscription? (affects Desktop tabs) | asked once |
-| Where to save databayt repos? | asked once: `Home root` / `~/databayt/` / `Custom...` |
-| Set up hogwarts local dev? (heavy, opt-in) | asked once |
-| Tailscale SSH? (remote control) | asked once |
-
-All answers persist in a state file. Re-runs skip questions already answered.
-
-### Act 2 — Silent batch (~15-20 minutes, progress notifications)
-
-Eight phases run in the background. You can minimize the terminal and do other work — the wizard fires native OS notifications as each phase advances.
-
-| Phase | What |
-|---|---|
-| 1 | System Foundation — build tools, git, Node 22 LTS, pnpm, gh CLI |
-| 2 | Applications — WebStorm, VS Code, Chrome (every machine) |
-| 3 | GitHub — SSH key, `gh auth login --web`, key uploaded |
-| 4 | Clone Repositories — the full databayt org (every machine) |
-| 5 | Claude — Code CLI, Desktop (Mac/Win), Desktop MCP symlink, `c` function in shell |
-| 6 | Kun Engine — `setup.sh` installs the full config (agents, skills, MCP, hooks); `secrets.sh` pulls `.env` |
-| 7 | Hogwarts — pnpm install, prisma generate + push + seed, build verify (only with `--hogwarts-dev`) |
-| 8 | Health Check — every tool / repo / config verified |
-| 9 (opt) | Tailscale — install + `up --ssh` if you opted in |
-
-Each phase emits `PROGRESS:N/8:label` to stderr; wrappers parse this and fire `osascript display notification` (Mac), `zenity --notification` (Linux), or `NotifyIcon` balloon (Windows).
-
-### Act 3 — Manual finishing (~3 clicks)
-
-What's left needs a human at the keyboard. Auto-polling OAuth means the only **manual clicks** are:
-
-| Step | Click count | Skipped when |
-|---|---|---|
-| Sign in to Claude Desktop | 1 (open + sign in) | not Pro/Max, or Linux |
-| Toggle computer-use in Desktop Settings | 1 | not Pro/Max, or Linux |
-| Install Claude Code plugin in WebStorm | 1 (if not auto) | — (WebStorm is on every machine) |
-| VS Code Claude extension | **0** | auto-installed via `code --install-extension` |
-| GitHub OAuth | **0** | `gh auth login --web` polls until done |
-| Anthropic CLI OAuth | **0** | `claude` first-run polls until done |
-
-The wizard uses **deep links** so each action button drops you exactly where you need to act:
-
-| Action | Mac | Windows | Linux |
-|---|---|---|---|
-| Accessibility settings | `open "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility"` | `Start-Process ms-settings:easeofaccess` | `gnome-control-center privacy` |
-| Claude Desktop | `open -a Claude` | `Start-Process "Claude.exe"` | n/a (no Linux app) |
-| WebStorm | `open -a WebStorm` | `Start-Process webstorm64.exe` | `webstorm` or `snap run webstorm` |
-| GitHub device flow | `open "https://github.com/login/device"` | `Start-Process` | `xdg-open` |
+- **Linux** has no Claude Desktop — surfaces are CLI + browser + IDE plugins.
+- **No Pro/Max** — Desktop tabs are unavailable; Claude Code can still bill via `ANTHROPIC_API_KEY`.
+- **Secrets blast radius** — a machine only holds the keys in the Gist it was handed; an MCP server without its key just doesn't connect (harmless).
 
 ---
 
 ## Before you sit down — admin checklist
 
-What the inviter needs to grant or hand over before paste-time:
+What the inviter grants out-of-band before paste-time:
 
 - [ ] **GitHub** — invite to the `databayt` org
-- [ ] **Anthropic account** — Pro/Max sub for the full Desktop + CLI experience
-- [ ] **Anthropic API key** — only if not on Pro/Max (Claude Code can bill via API key)
-- [ ] **Secrets Gist ID** — handed over out-of-band (Signal, Notes, 1Password)
+- [ ] **Anthropic** — Pro/Max sub (or API key if not on Pro/Max)
+- [ ] **Secrets Gist ID** — handed over via Signal / Notes / 1Password
 - [ ] **Slack** — invite to `hogwarts-wve9301`
-- [ ] **AWS IAM** — `hogwarts-s3-uploader` keys (engineer role only)
-- [ ] **Vercel** — team invite (engineer role only)
+- [ ] **AWS IAM** — `hogwarts-s3-uploader` keys (engineer only)
+- [ ] **Vercel** — team invite (engineer only)
 
-If something's missing the wizard skips that step and lists it under "things to do later" at the end.
-
----
-
-## Which repos you get
-
-**Every machine clones the full databayt org** to your chosen directory (`~/`, `~/databayt/`, or custom) — any machine can touch any repo:
-
-`kun` (engine config), `hogwarts` (multi-tenant LMS), `codebase` (patterns, agents, blocks), `shadcn` (UI library), `radix` (UI primitives), `souq` (e-commerce), `mkan` (rentals), `shifa` (medical), `swift-app` (iOS/Swift), `distributed-computer` (infra), `marketing` (landing pages).
-
-When you pick a custom directory, the wizard symlinks `~/kun`, `~/hogwarts`, etc. back to it so all existing tooling that hard-codes `~/kun` keeps working.
-
-To clone only the essentials (kun, hogwarts, codebase): pass `--essentials-only` (Mac/Linux) or `-EssentialsOnly` (Windows).
+Anything missing → the wizard skips that step and lists it in the final "things to do later" panel.
 
 ---
 
 ## The seven Claude surfaces
 
-After install you have **seven Claude surfaces**, each with a sweet spot:
+After install you have seven surfaces sharing the same `~/.claude/` brain:
 
-| Surface | When to use |
+| Surface | Sweet spot |
 |---|---|
 | **Desktop Chat** | Quick question, no tools. Fastest reply. |
 | **Desktop Cowork** | Plan, research, strategize. Cloud agents — runs while you do other things. |
-| **Desktop Code** | Drive your own machine (install apps, fill forms, screenshots). Local computer-use. |
-| **Claude Code CLI** (`claude` / `c`) | Build, deploy, fix code in terminal. Full kun config — agents, MCP, hooks, memory. |
-| **VS Code extension** | Inline AI in your editor. `Cmd+Shift+P` → "Claude". |
+| **Desktop Code** | Drive your own machine (install apps, fill forms, screenshots). |
+| **Claude Code CLI** (`claude` / `c`) | Build, deploy, fix in terminal. Full kun config — agents, MCP, hooks, memory. |
+| **VS Code extension** | Inline AI in editor. `Cmd+Shift+P` → "Claude". |
 | **WebStorm plugin** | Inline AI in WebStorm. `Cmd+Esc` opens panel. |
-| **claude.ai/code** | Mobile, web, or shared link. Same projects as the CLI, no install needed. |
+| **claude.ai/code** | Mobile / web / shared link. Same projects as the CLI. |
 
-Cowork and Claude Code share `~/.claude/` — same brain, two modes. Handoff happens via `~/.claude/bridge.md` and GitHub Issues. See [Cowork ↔ Code bridge](/docs/cowork).
-
-Claude Desktop's three tabs share the same MCP fleet as the CLI because the wizard symlinks `claude_desktop_config.json` to `~/.claude/mcp.json`.
+Cowork and Code share `~/.claude/` and hand off via `~/.claude/bridge.md` — see [Cowork ↔ Code bridge](/docs/cowork). Desktop tabs see the same MCP fleet as the CLI via the symlinked config.
 
 ---
 
-## Mobile (iOS + Android)
+## After install (optional)
 
-After Claude Desktop is signed in, install the Claude mobile app and sign in with the same Anthropic account — your projects, conversations, and Cowork sessions are available everywhere.
+Each is a one-line follow-up, surfaced in the wizard's final panel:
 
-| Store | Link |
-|---|---|
-| iOS | https://apps.apple.com/app/claude-by-anthropic/id6473753684 |
-| Android | https://play.google.com/store/apps/details?id=com.anthropic.claude |
+- **Sign in to Claude Desktop** — open the app and sign in once (Mac/Win only, Pro/Max only).
+- **WebStorm Claude plugin** — Settings → Plugins → Marketplace → "Claude Code" → Install (engineer only).
+- **Mobile / remote** — [iOS](https://apps.apple.com/app/claude-by-anthropic/id6473753684) · [Android](https://play.google.com/store/apps/details?id=com.anthropic.claude) · [claude.ai/code](https://claude.ai/code) in any browser. Drive Claude from anywhere with the same account — no VPN, no tunnel.
+- **WebStorm Settings Sync** — sign in to JetBrains account → Settings → Backup and Sync → Enable; share team code-style across machines.
+- **Computer-use in Desktop** (Pro/Max) — Settings → General → "Allow Claude to use your computer".
+- **Secrets** — `bash ~/kun/.claude/scripts/secrets.sh <GIST_ID>` if you didn't supply one at install.
 
-Mobile is read-friendly for reviewing Cowork output on the go. For driving anything (typing prompts, kicking off agents), the desktop surfaces are still best.
-
----
-
-## WebStorm Settings Sync
-
-To share team-standardized editor settings (code style, keymaps, inspection profiles, file templates):
-
-1. Open WebStorm → top-right account icon → **Sign in to your JetBrains Account**
-2. Sign in (your personal JetBrains account, or use the team account if you have one)
-3. Settings → **Backup and Sync** → **Enable Settings Sync** → choose what to sync
-
-Your settings then follow you to any machine where you sign in to the same JetBrains account. The team uses this for consistent code style across reviews — no need to re-configure per machine.
-
-Recommended sync scope: Code style, Inspection profiles, Live templates, Plugins, Keymaps. Skip system settings (per-machine).
-
----
-
-## Remote control via Tailscale (optional)
-
-If you opt in (`--with-tailscale` / `-WithTailscale`), the wizard installs Tailscale and runs `tailscale up --ssh`. Once on the tailnet, you can:
-
-- SSH into your dev box from any device: `ssh you@<tailscale-name>`
-- Drive your laptop from your phone via Tailscale SSH + tmux
-- Run `claude` remotely as if you were at your desk
-
-Setup details: [Self-hosting — Tailscale / tmux / Docker](/docs/self-hosting).
-
----
-
-## Apple Notes Dispatch (Mac only)
-
-The wizard creates a `Dispatch` folder in Apple Notes so `dispatch.sh` has somewhere to write captain-status notes. These sync to your iPhone via iCloud — you can read captain summaries on the go without opening Claude.
-
-See [Dispatch — Apple Notes bridge](/docs/dispatch).
-
----
-
-## Script path (engineer)
-
-If you'd rather skip the wizard and run the silent backend directly:
-
-```bash
-# Mac
-git clone https://github.com/databayt/kun.git ~/kun && \
-  bash ~/kun/.claude/scripts/onboarding-mac.sh engineer <GIST_ID>
-
-# Linux
-git clone https://github.com/databayt/kun.git ~/kun && \
-  bash ~/kun/.claude/scripts/onboarding-linux.sh engineer <GIST_ID>
-
-# Windows (PowerShell)
-git clone https://github.com/databayt/kun.git $env:USERPROFILE\kun
-& $env:USERPROFILE\kun\.claude\scripts\onboarding-windows.ps1 -Role engineer -GistId <GIST_ID>
-```
-
-Useful backend flags (Mac + Linux):
-
-| Flag | Purpose |
-|---|---|
-| `--quiet` | Skip terminal prompts (wrapper/CI use) |
-| `--name <name>` / `--email <email>` | Pre-supply git identity |
-| `--repos-dir <path>` | Where to save databayt repos (default: `$HOME`) |
-| `--essentials-only` | Skip optional org repos (just kun/hogwarts/codebase) |
-| `--with-tailscale` | Install Tailscale + `up --ssh` |
-
-PowerShell equivalents: `-Quiet`, `-GitName`, `-GitEmail`, `-ReposDir`, `-EssentialsOnly`, `-WithTailscale`.
-
-Re-run anytime; idempotent.
-
----
-
-## Path B — Script-driven (engineer-friendly)
-
-For learning what the wizard does, or if both other paths fail. Pick your OS.
-
-### macOS
-
-```bash
-# Side-tools
-brew install git node pnpm gh
-brew install --cask google-chrome webstorm visual-studio-code claude
-
-# Claude Code CLI
-curl -fsSL https://claude.ai/install.sh | sh
-
-# Shell helpers
-cat >> ~/.zshrc <<'EOF'
-# Claude Code
-function c  { claude --dangerously-skip-permissions "$@"; }
-function cc { claude "$@"; }
-export PATH="$HOME/.local/bin:$PATH"
-[ -f "$HOME/.claude/.env" ] && set -a && . "$HOME/.claude/.env" && set +a
-EOF
-. ~/.zshrc
-
-# GitHub auth + SSH
-ssh-keygen -t ed25519 -C "you@databayt"
-gh auth login -p ssh -w
-gh ssh-key add ~/.ssh/id_ed25519.pub --title "databayt-$(hostname -s)"
-
-# Repos
-git clone git@github.com:databayt/kun.git ~/kun
-git clone git@github.com:databayt/hogwarts.git ~/hogwarts
-git clone git@github.com:databayt/codebase.git ~/codebase
-
-# Kun config + secrets
-cd ~/kun && bash .claude/scripts/setup.sh engineer
-bash ~/kun/.claude/scripts/secrets.sh <GIST_ID>
-
-# Desktop MCP parity
-ln -sf ~/.claude/mcp.json "$HOME/Library/Application Support/Claude/claude_desktop_config.json"
-
-# Verify
-claude doctor
-bash ~/.claude/scripts/health.sh
-```
-
-### Linux (Debian/Ubuntu shown — adapt for your distro)
-
-```bash
-# Side-tools
-sudo apt update && sudo apt install -y git curl build-essential ca-certificates
-
-# Node 22 via nvm
-curl -fsSL https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.1/install.sh | bash
-export NVM_DIR="$HOME/.nvm"; . "$NVM_DIR/nvm.sh"
-nvm install --lts && nvm use --lts
-npm install -g pnpm
-
-# GitHub CLI (Debian/Ubuntu)
-curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg
-echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list
-sudo apt update && sudo apt install -y gh
-
-# IDEs (snap)
-sudo snap install code --classic
-sudo snap install webstorm --classic
-
-# Claude Code CLI (Claude Desktop NOT available on Linux)
-curl -fsSL https://claude.ai/install.sh | sh
-
-# Shell helpers
-cat >> ~/.bashrc <<'EOF'
-# Claude Code
-function c  { claude --dangerously-skip-permissions "$@"; }
-function cc { claude "$@"; }
-export PATH="$HOME/.local/bin:$PATH"
-[ -f "$HOME/.claude/.env" ] && set -a && . "$HOME/.claude/.env" && set +a
-EOF
-. ~/.bashrc
-
-# GitHub auth + SSH
-ssh-keygen -t ed25519 -C "you@databayt"
-gh auth login -p ssh -w
-gh ssh-key add ~/.ssh/id_ed25519.pub --title "databayt-$(hostname -s)"
-
-# Repos
-git clone git@github.com:databayt/kun.git ~/kun
-git clone git@github.com:databayt/hogwarts.git ~/hogwarts
-git clone git@github.com:databayt/codebase.git ~/codebase
-
-# Kun config + secrets
-cd ~/kun && bash .claude/scripts/setup.sh engineer
-bash ~/kun/.claude/scripts/secrets.sh <GIST_ID>
-
-# Verify (no Claude Desktop on Linux — CLI + browser + IDE plugins)
-claude doctor
-bash ~/.claude/scripts/health.sh
-```
-
-### Windows (PowerShell)
-
-```powershell
-# Side-tools
-winget install Git.Git OpenJS.NodeJS.LTS GitHub.cli Microsoft.PowerShell Google.Chrome
-winget install JetBrains.WebStorm Microsoft.VisualStudioCode
-npm install -g pnpm
-
-# Claude Code CLI (official)
-winget install Anthropic.ClaudeCode
-claude    # browser sign-in
-
-# Shell helpers — append to $PROFILE
-@'
-
-# Claude Code
-function c  { claude --dangerously-skip-permissions $args }
-function cc { claude $args }
-if (Test-Path "$env:USERPROFILE\.claude\.env") {
-    Get-Content "$env:USERPROFILE\.claude\.env" | ForEach-Object {
-        if ($_ -and -not $_.StartsWith("#")) {
-            $parts = $_ -split "=", 2
-            if ($parts.Length -eq 2) {
-                [Environment]::SetEnvironmentVariable($parts[0], $parts[1], "Process")
-            }
-        }
-    }
-}
-$env:Path = "$env:USERPROFILE\.claude\bin;" + $env:Path
-'@ | Add-Content $PROFILE
-. $PROFILE
-
-# GitHub auth + SSH
-ssh-keygen -t ed25519 -C "you@databayt"
-gh auth login -p ssh -w
-gh ssh-key add "$env:USERPROFILE\.ssh\id_ed25519.pub" --title "databayt-$env:COMPUTERNAME"
-
-# Repos
-git clone git@github.com:databayt/kun.git $env:USERPROFILE\kun
-git clone git@github.com:databayt/hogwarts.git $env:USERPROFILE\hogwarts
-git clone git@github.com:databayt/codebase.git $env:USERPROFILE\codebase
-
-# Kun config + secrets
-cd $env:USERPROFILE\kun; & .\.claude\scripts\setup.ps1 -Role engineer
-& $env:USERPROFILE\kun\.claude\scripts\secrets.ps1 -GistId <GIST_ID>
-
-# Desktop MCP parity (needs admin or Developer Mode for the symlink; falls back to copy)
-New-Item -ItemType SymbolicLink -Path "$env:APPDATA\Claude\claude_desktop_config.json" -Target "$env:USERPROFILE\.claude\mcp.json" -Force
-
-# Verify
-claude doctor
-& $env:USERPROFILE\.claude\scripts\health.ps1
-```
-
-For hogwarts, your team contact shares the `.env` out-of-band — there is no `.env.example`.
+Repos cloned: `kun` · `hogwarts` · `codebase` · `shadcn` · `radix` · `souq` · `mkan` · `shifa` · `swift-app` · `distributed-computer` · `marketing`. Full map: [Repositories](/docs/repositories).
 
 ---
 
 ## Verify everything
 
 ```bash
-# Kun config (cross-platform, ~5 sec)
-bash ~/.claude/scripts/health.sh         # Mac/Linux
+bash ~/.claude/scripts/health.sh                  # Mac/Linux  →  ✅ healthy
 & $env:USERPROFILE\.claude\scripts\health.ps1     # Windows
-
-# Claude CLI
-claude doctor
-
-# Hogwarts (engineer)
-cd ~/hogwarts && pnpm dev
-# Open http://localhost:3000 — login: admin@kingfahad.edu / 1234
+claude doctor                                     # all surfaces green
+cd ~/hogwarts && pnpm dev                         # engineer only — login admin@kingfahad.edu / 1234
 ```
 
 `health.sh --report` posts your config status to a shared GitHub issue (`databayt/kun`, label `config-health`) so the team can see drift across machines.
+
+---
+
+## Auto-resume
+
+Every choice persists to a state file. Re-runs skip completed steps.
+
+| OS | State file |
+|---|---|
+| macOS | `~/Library/Application Support/Databayt/installer-state.json` |
+| Linux | `${XDG_CONFIG_HOME:-~/.config}/databayt/installer-state.json` |
+| Windows | `%APPDATA%\Databayt\installer-state.json` |
+
+To start fresh: delete the file, then re-run the one-liner.
 
 ---
 
@@ -490,32 +176,13 @@ cd ~/hogwarts && pnpm dev
 
 | Action | How |
 |--------|-----|
-| Open Claude in WebStorm | `Cmd+Esc` (Mac) · `Ctrl+Esc` or `Alt+Shift+C` (Windows/Linux) |
-| Open Claude in VS Code | `Cmd+Shift+P` → `Claude: Chat` |
 | Start Claude in any terminal | `c` |
-| Synthesize company status | `c "/captain"` |
-| Capture an idea | `c "/idea <description>"` |
+| Open in WebStorm | `Cmd+Esc` (Mac) · `Alt+Shift+C` (Win/Linux) |
+| Open in VS Code | `Cmd+Shift+P` → `Claude: Chat` |
 | Run the full feature pipeline | `c "/feature <name> [product]"` |
-| Send a note to the team | `c "/dispatch <message>"` |
-| Open a GitHub issue | `c "/issue"` |
-| Verify a production deploy | `c "/watch"` |
 | Mobile / browser | https://claude.ai/code |
 
-Full keyword list: [keywords](/docs/keywords).
-
----
-
-## Auto-resume
-
-The wizard persists every choice to a state file so re-runs skip what's done:
-
-| OS | State file path |
-|---|---|
-| macOS | `~/Library/Application Support/Databayt/installer-state.json` |
-| Linux | `${XDG_CONFIG_HOME:-~/.config}/databayt/installer-state.json` |
-| Windows | `%APPDATA%\Databayt\installer-state.json` |
-
-To reset and start fresh: delete the state file, then re-run the bootstrap.
+Full vocabulary: [keywords](/docs/keywords).
 
 ---
 
@@ -523,44 +190,37 @@ To reset and start fresh: delete the state file, then re-run the bootstrap.
 
 | Symptom | Fix |
 |---|---|
-| "command not found: c" | Restart shell or `source ~/.zshrc` (Mac/Linux), `. $PROFILE` (Windows) |
+| `command not found: c` | Restart shell, or `source ~/.zshrc` / `. $PROFILE` |
 | `claude doctor` red | Re-run `claude` to re-auth; check `~/.claude/settings.json` exists |
-| Hogwarts won't build | Confirm `.env` is present; re-run `secrets.sh <GIST_ID>` |
-| Claude Desktop tabs missing MCP servers | Check `claude_desktop_config.json` is a symlink to `~/.claude/mcp.json`; if not, fix manually |
-| GitHub clone fails on private repos | Run `gh auth login -p ssh -w` again, confirm the SSH key is on your GitHub account |
-| Wizard dialogs not appearing on Linux | Install `zenity` (`sudo apt install zenity`) or pass `--no-gui` for terminal mode |
-| Windows: "running scripts is disabled" | Bootstrap uses `Set-ExecutionPolicy Bypass -Scope Process` automatically; for direct invocations: `powershell -ExecutionPolicy Bypass -File <script>` |
+| Hogwarts won't build | Confirm `.env` present; re-run `secrets.sh <GIST_ID>` |
+| Desktop tabs missing MCP | Check `claude_desktop_config.json` is a symlink to `~/.claude/mcp.json` |
+| Private clone fails | `gh auth login -p ssh -w` again; confirm SSH key on GitHub |
+| Linux: no dialogs | `sudo apt install zenity`, or re-run with `--no-gui` |
+| Windows: "running scripts is disabled" | Bootstrap sets `Bypass` automatically; for direct: `powershell -ExecutionPolicy Bypass -File <script>` |
 
-For anything else, file an issue at https://github.com/databayt/kun/issues.
+Anything else: [github.com/databayt/kun/issues](https://github.com/databayt/kun/issues).
 
 ---
 
 ## Where to go next
 
-This page is the front door. Once your machine is provisioned, branch out from here:
-
 **Set up & verify**
-- [Claude Code](/docs/claude-code) — CLI install detail + config
-- [MCP](/docs/mcp) — the server fleet + `/mcp-doctor` browser recovery
-- [Secrets](/docs/secrets) — Gist-based provisioning (which keys your machine holds)
-- [Self-hosting](/docs/self-hosting) — Tailscale / tmux / Docker (optional)
+- [Claude Code](/docs/claude-code) — shell config (`c` function, env autoload), MCP server reference, keyword vocabulary
+- [MCP](/docs/mcp) — the server fleet + `/mcp-doctor` recovery
+- [Secrets](/docs/secrets) — Gist-based provisioning, which keys your machine holds
 
 **Daily use**
-- [Keywords](/docs/keywords) — the full vocabulary, one word → a workflow
+- [Keywords](/docs/keywords) — full vocabulary, one word → a workflow
 - [Captain](/docs/captain) — decisions, delegation, the weekly rhythm
-- [Cowork ↔ Code](/docs/cowork) — same brain, two modes
-- [Dispatch](/docs/dispatch) — Apple Notes bridge for async updates
+- [Cowork ↔ Code](/docs/cowork) — same brain, two modes; async handoff via `~/.claude/bridge.md` + GitHub issues
 
 **Understand the engine**
 - [Configuration](/docs/configuration) — universal-config blueprint
 - [Architecture](/docs/architecture) — the 5 layers
-- [Agents](/docs/agents) — the 40-agent fleet
+- [Agents](/docs/agents) — the agent fleet
 - [Team](/docs/team) — the 6 humans + roles
 
 **Contribute**
-- [Issue pipeline](/docs/issue) — "Report an issue" (footer) → GitHub → optional auto-fix
+- [Issue pipeline](/docs/issue) — Report-an-issue → GitHub → optional auto-fix
 - [Repositories](/docs/repositories) — full org map
 - [Contributing](https://github.com/databayt/kun/blob/main/.claude/rules/github-workflow.md) — issue → branch → PR → merge
-
-**External**
-- [Apps — Claude in Slack/Figma/Asana](/docs/apps) · [Connectors — MCP catalog](/docs/connectors) · [Anthropic Directory](https://claude.ai/directory)

--- a/tests/onboarding/README.md
+++ b/tests/onboarding/README.md
@@ -1,0 +1,47 @@
+# Onboarding test suite
+
+Validates the kun onboarding wizard + doc — installer scripts, the step manifest, and `content/docs/onboarding.mdx`.
+
+## Run
+
+```bash
+bash tests/onboarding/run.sh                # all suites
+bash tests/onboarding/run.sh lint           # just lint
+bash tests/onboarding/run.sh behavior parity
+```
+
+Exits 0 on full pass, 1 on any failure.
+
+## Suites
+
+| Suite | What it asserts |
+|---|---|
+| `lint` | `shellcheck` clean on `.sh` installers · `wizard-steps.json` parses · doc ≤300 lines · no stale Tailscale/Apple Notes references |
+| `behavior` | `state_get`/`state_set` round-trips · git-config autofill · `mcp.json` → role mapping · `BACKEND_ARGS` shape |
+| `parity` | All three installers expose the same flags · parallel final-panel bullets · matching state-file schema |
+| `links` | Every `/docs/<x>` link in `onboarding.mdx` resolves to a real file · anchor targets exist when used |
+
+## Dependencies
+
+- `bash` 4+ (for `mapfile`)
+- `shellcheck` (`brew install shellcheck`)
+- `python3` (ships with macOS)
+- `node` (already required by the kun app)
+
+No npm packages; no test framework. The suite is self-contained.
+
+## Add a test
+
+Drop a new `<name>.test.sh` file in this directory. The orchestrator auto-discovers it. Skeleton:
+
+```bash
+# shellcheck source=lib.sh
+source "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+suite_name "my new suite"
+
+assert_eq "expected" "$(some-command)" "some-command returns expected"
+
+suite_summary
+```
+
+See `lib.sh` for the full assertion API.

--- a/tests/onboarding/behavior.test.sh
+++ b/tests/onboarding/behavior.test.sh
@@ -1,0 +1,142 @@
+#!/bin/bash
+# Behavior tests: source installer.sh's helpers in a sandbox and exercise:
+#   - state_get / state_set round-trip
+#   - git-config autofill (name + email)
+#   - mcp.json → role detection
+#   - BACKEND_ARGS construction shape
+#
+# Strategy: copy installer.sh into a temp dir with everything past Act 1 stripped,
+# override interactive helpers to return canned values, run in a sandboxed HOME.
+
+suite_name "behavior — state, autofill, args"
+
+# Sandbox dir cleaned at the END of the suite (NOT via trap RETURN —
+# in bash 3.2, sourcing the sandbox would trigger the trap mid-test).
+# HOME saved + restored so subsequent suites don't inherit a deleted path.
+TMP=$(mktemp -d)
+ORIGINAL_HOME="$HOME"
+
+ORIGINAL="$PWD/.claude/scripts/installer.sh"
+SANDBOX="$TMP/installer-sandbox.sh"
+
+# Build a sandboxed version: keep everything BEFORE the bootstrap block (state_get, state_set, ask_*),
+# stop right before the `if ! xcode-select` line so we don't try to clone kun or invoke osascript.
+# Then we can source it and call the helpers directly.
+awk '
+    /^# ── Bootstrap:/ { exit }
+    { print }
+' "$ORIGINAL" > "$SANDBOX"
+
+# Sandboxed HOME so state files land in $TMP, never the real ~/Library/...
+export HOME="$TMP/home"
+mkdir -p "$HOME"
+
+# shellcheck source=/dev/null
+source "$SANDBOX"
+# installer.sh starts with `set -e` — that leaks into the orchestrator and would
+# make later `grep -c` calls (count == 0 → exit 1) abort subsequent suites.
+set +e
+
+# ── state_get / state_set ──────────────────────────────────────
+state_set role engineer
+assert_eq "engineer" "$(state_get role)" "state_set then state_get returns same value"
+
+state_set gitName "Test User"
+state_set gitEmail "test@example.com"
+assert_eq "Test User"          "$(state_get gitName)"  "state persists multi-key writes (name)"
+assert_eq "test@example.com"   "$(state_get gitEmail)" "state persists multi-key writes (email)"
+
+# Missing key → empty string, not error
+assert_eq "" "$(state_get nonexistentKey)" "state_get unknown key returns empty"
+
+# Values with spaces survive round-trip
+state_set complexValue "value with spaces and commas, etc."
+assert_eq "value with spaces and commas, etc." "$(state_get complexValue)" "round-trip with spaces"
+
+# State file is valid JSON after multiple writes
+STATE_FILE_PATH="$HOME/Library/Application Support/Databayt/installer-state.json"
+assert_file_exists "$STATE_FILE_PATH" "state file written"
+assert_cmd_succeeds "state file is valid JSON" \
+    python3 -c "import json; json.load(open('$STATE_FILE_PATH'))"
+
+# ── git-config autofill ──────────────────────────────────────────
+# The installer reads `git config --global user.name`. Point HOME's gitconfig at fixtures.
+cat > "$HOME/.gitconfig" <<'EOF'
+[user]
+    name = Fixture Name
+    email = fixture@databayt.org
+EOF
+
+# git's --global respects $HOME — confirm it reads our fixture
+detected_name=$(git config --global user.name 2>/dev/null)
+detected_email=$(git config --global user.email 2>/dev/null)
+assert_eq "Fixture Name"         "$detected_name"  "git config --global user.name reads sandbox HOME"
+assert_eq "fixture@databayt.org" "$detected_email" "git config --global user.email reads sandbox HOME"
+
+# ── mcp.json → role detection ────────────────────────────────────
+# The installer does: grep -q '"shadcn"' → engineer, '"linear"' → business, etc.
+mkdir -p "$HOME/.claude"
+
+detect_role() {
+    local mcp="$HOME/.claude/mcp.json"
+    local role=""
+    if [[ -f "$mcp" ]]; then
+        if   grep -q '"shadcn"'  "$mcp" 2>/dev/null; then role="engineer"
+        elif grep -q '"linear"'  "$mcp" 2>/dev/null; then role="business"
+        elif grep -q '"figma"'   "$mcp" 2>/dev/null; then role="content"
+        elif grep -q '"posthog"' "$mcp" 2>/dev/null; then role="ops"
+        fi
+    fi
+    echo "$role"
+}
+
+# engineer fixture
+echo '{"mcpServers":{"shadcn":{}}}' > "$HOME/.claude/mcp.json"
+assert_eq "engineer" "$(detect_role)" "mcp.json with shadcn → engineer"
+
+echo '{"mcpServers":{"linear":{}}}' > "$HOME/.claude/mcp.json"
+assert_eq "business" "$(detect_role)" "mcp.json with linear → business"
+
+echo '{"mcpServers":{"figma":{}}}' > "$HOME/.claude/mcp.json"
+assert_eq "content" "$(detect_role)" "mcp.json with figma → content"
+
+echo '{"mcpServers":{"posthog":{}}}' > "$HOME/.claude/mcp.json"
+assert_eq "ops" "$(detect_role)" "mcp.json with posthog → ops"
+
+# No fixture present → empty
+rm -f "$HOME/.claude/mcp.json"
+assert_eq "" "$(detect_role)" "missing mcp.json → empty role"
+
+# ── BACKEND_ARGS construction ────────────────────────────────────
+# Replicate the construction logic from installer.sh:194-197.
+build_args() {
+    local role="$1" name="$2" email="$3" hogwarts_dev="$4"
+    local args=("$role")
+    args+=("--quiet" "--name" "$name" "--email" "$email")
+    [[ "$hogwarts_dev" == "1" ]] && args+=("--hogwarts-dev")
+    printf '%s\n' "${args[@]}"
+}
+
+# engineer with hogwarts on
+got=$(build_args engineer "Test User" "test@example.com" 1 | tr '\n' '|')
+exp="engineer|--quiet|--name|Test User|--email|test@example.com|--hogwarts-dev|"
+assert_eq "$exp" "$got" "BACKEND_ARGS: engineer + hogwarts-dev"
+
+# business with hogwarts off
+got=$(build_args business "Biz Person" "biz@example.com" 0 | tr '\n' '|')
+exp="business|--quiet|--name|Biz Person|--email|biz@example.com|"
+assert_eq "$exp" "$got" "BACKEND_ARGS: business + no hogwarts-dev"
+
+# Args always start with role
+got=$(build_args ops "X Y" "x@y.z" 1 | head -1)
+assert_eq "ops" "$got" "BACKEND_ARGS first arg is role"
+
+# --quiet always present
+build_args engineer N E 0 | grep -q -- "--quiet"
+assert_cmd_succeeds "BACKEND_ARGS always includes --quiet (engineer)" \
+    bash -c "$(declare -f build_args); build_args engineer N E 0 | grep -q -- --quiet"
+
+rm -rf "$TMP"
+export HOME="$ORIGINAL_HOME"
+unset TMP SANDBOX ORIGINAL STATE_FILE_PATH ORIGINAL_HOME
+suite_summary

--- a/tests/onboarding/lib.sh
+++ b/tests/onboarding/lib.sh
@@ -1,0 +1,169 @@
+#!/bin/bash
+# shellcheck disable=SC2034
+# (C_YELLOW reserved for future use; no truly-unused-var warning is interesting here.)
+#
+# Tiny assertion library for the onboarding test suite.
+# Source this file at the top of every *.test.sh.
+#
+# Exposes:
+#   pass <msg>                  — record a passing assertion
+#   fail <msg>                  — record a failing assertion (with caller line)
+#   assert_eq <exp> <got> [msg]
+#   assert_ne <unexp> <got> [msg]
+#   assert_match <regex> <str> [msg]
+#   assert_no_match <regex> <str> [msg]
+#   assert_file_exists <path> [msg]
+#   assert_file_missing <path> [msg]
+#   assert_contains <needle> <file> [msg]
+#   assert_not_contains <needle> <file> [msg]
+#   assert_lt <n> <max> [msg]
+#   assert_cmd_succeeds <cmd…> — runs cmd, asserts exit 0
+#   assert_cmd_fails <cmd…>    — runs cmd, asserts non-zero exit
+#   suite_name <name>          — call once per test file
+#   suite_summary              — call at end; prints suite tallies
+#
+# Counters are exported so the orchestrator can roll them up.
+
+# Colors (skip if not a TTY)
+if [[ -t 1 ]]; then
+    C_GREEN=$'\033[32m'; C_RED=$'\033[31m'; C_YELLOW=$'\033[33m'
+    C_DIM=$'\033[2m';   C_BOLD=$'\033[1m'; C_RESET=$'\033[0m'
+else
+    C_GREEN=""; C_RED=""; C_YELLOW=""; C_DIM=""; C_BOLD=""; C_RESET=""
+fi
+
+export TOTAL_PASS=${TOTAL_PASS:-0}
+export TOTAL_FAIL=${TOTAL_FAIL:-0}
+SUITE_PASS=0
+SUITE_FAIL=0
+SUITE_NAME=""
+
+suite_name() {
+    SUITE_NAME="$1"
+    SUITE_PASS=0
+    SUITE_FAIL=0
+    printf '\n%s── %s ──%s\n' "$C_BOLD" "$SUITE_NAME" "$C_RESET"
+}
+
+suite_summary() {
+    local total=$((SUITE_PASS + SUITE_FAIL))
+    if [[ "$SUITE_FAIL" -eq 0 ]]; then
+        printf '%s✓ %s — %d/%d passed%s\n' "$C_GREEN" "$SUITE_NAME" "$SUITE_PASS" "$total" "$C_RESET"
+    else
+        printf '%s✗ %s — %d/%d passed (%d failed)%s\n' "$C_RED" "$SUITE_NAME" "$SUITE_PASS" "$total" "$SUITE_FAIL" "$C_RESET"
+    fi
+    TOTAL_PASS=$((TOTAL_PASS + SUITE_PASS))
+    TOTAL_FAIL=$((TOTAL_FAIL + SUITE_FAIL))
+    export TOTAL_PASS TOTAL_FAIL
+}
+
+pass() {
+    SUITE_PASS=$((SUITE_PASS + 1))
+    printf '  %s✓%s %s\n' "$C_GREEN" "$C_RESET" "$1"
+}
+
+fail() {
+    SUITE_FAIL=$((SUITE_FAIL + 1))
+    local where="${BASH_SOURCE[2]:-?}:${BASH_LINENO[1]:-?}"
+    printf '  %s✗%s %s %s(%s)%s\n' "$C_RED" "$C_RESET" "$1" "$C_DIM" "$where" "$C_RESET"
+    [[ -n "${2:-}" ]] && printf '      %s%s%s\n' "$C_DIM" "$2" "$C_RESET"
+}
+
+assert_eq() {
+    local exp="$1" got="$2" msg="${3:-equals}"
+    if [[ "$exp" == "$got" ]]; then
+        pass "$msg"
+    else
+        fail "$msg" "expected: '$exp'  got: '$got'"
+    fi
+}
+
+assert_ne() {
+    local unexp="$1" got="$2" msg="${3:-not equals}"
+    if [[ "$unexp" != "$got" ]]; then
+        pass "$msg"
+    else
+        fail "$msg" "expected NOT: '$unexp'  got: '$got'"
+    fi
+}
+
+assert_match() {
+    local regex="$1" str="$2" msg="${3:-matches regex}"
+    if [[ "$str" =~ $regex ]]; then
+        pass "$msg"
+    else
+        fail "$msg" "regex: '$regex'  str: '$str'"
+    fi
+}
+
+assert_no_match() {
+    local regex="$1" str="$2" msg="${3:-no match}"
+    if [[ ! "$str" =~ $regex ]]; then
+        pass "$msg"
+    else
+        fail "$msg" "regex: '$regex' MATCHED str: '$str'"
+    fi
+}
+
+assert_file_exists() {
+    local path="$1" msg="${2:-file exists: $1}"
+    if [[ -f "$path" ]]; then
+        pass "$msg"
+    else
+        fail "$msg" "missing: $path"
+    fi
+}
+
+assert_file_missing() {
+    local path="$1" msg="${2:-file missing: $1}"
+    if [[ ! -e "$path" ]]; then
+        pass "$msg"
+    else
+        fail "$msg" "should not exist: $path"
+    fi
+}
+
+assert_contains() {
+    local needle="$1" file="$2" msg="${3:-file contains needle}"
+    if grep -qF -- "$needle" "$file" 2>/dev/null; then
+        pass "$msg"
+    else
+        fail "$msg" "'$needle' not found in $file"
+    fi
+}
+
+assert_not_contains() {
+    local needle="$1" file="$2" msg="${3:-file does not contain needle}"
+    if ! grep -qF -- "$needle" "$file" 2>/dev/null; then
+        pass "$msg"
+    else
+        fail "$msg" "'$needle' unexpectedly found in $file"
+    fi
+}
+
+assert_lt() {
+    local n="$1" max="$2" msg="${3:-$1 < $2}"
+    if [[ "$n" -lt "$max" ]]; then
+        pass "$msg ($n < $max)"
+    else
+        fail "$msg" "$n is not < $max"
+    fi
+}
+
+assert_cmd_succeeds() {
+    local msg="$1"; shift
+    if "$@" >/dev/null 2>&1; then
+        pass "$msg"
+    else
+        fail "$msg" "command failed (exit $?): $*"
+    fi
+}
+
+assert_cmd_fails() {
+    local msg="$1"; shift
+    if ! "$@" >/dev/null 2>&1; then
+        pass "$msg"
+    else
+        fail "$msg" "command unexpectedly succeeded: $*"
+    fi
+}

--- a/tests/onboarding/links.test.sh
+++ b/tests/onboarding/links.test.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+# Every internal link in onboarding.mdx must resolve.
+# Catches: dead /docs/<x> links + anchor drift (e.g. #tailscale vs #tailscale-vpn).
+
+suite_name "links — /docs/<x> resolution"
+
+ONBOARDING="$PWD/content/docs/onboarding.mdx"
+DOCS_DIR="$PWD/content/docs"
+
+assert_file_exists "$ONBOARDING" "onboarding.mdx present"
+
+# Extract every (/docs/<slug>[#anchor]) link in the file.
+# Tolerates trailing parens by stopping at )" or space or ].
+LINKS=()
+while IFS= read -r line; do
+    LINKS+=("$line")
+done < <(grep -oE '\(/docs/[a-z0-9_/-]+(#[a-z0-9-]+)?\)' "$ONBOARDING" \
+    | sed -E 's/^\(|\)$//g' \
+    | sort -u)
+
+if [[ ${#LINKS[@]} -eq 0 ]]; then
+    fail "no /docs/* links found in onboarding.mdx" "regex extracted nothing"
+fi
+
+# Each link's <slug> must map to content/docs/<slug>.mdx
+for link in "${LINKS[@]}"; do
+    path="${link#/docs/}"
+    slug="${path%#*}"
+    anchor="${path#*#}"
+    [[ "$anchor" == "$path" ]] && anchor=""   # no '#' present
+    target="$DOCS_DIR/$slug.mdx"
+
+    if [[ -f "$target" ]]; then
+        pass "link target exists: /docs/$slug"
+
+        if [[ -n "$anchor" ]]; then
+            # GitHub-flavored anchor: lowercase, spaces → -, strip punctuation
+            # Build the set of headings in the target file, slugify each, compare.
+            anchor_found=0
+            while IFS= read -r heading; do
+                slugified=$(echo "$heading" \
+                    | tr '[:upper:]' '[:lower:]' \
+                    | sed -E 's/[^a-z0-9 -]//g' \
+                    | tr -s ' ' '-' \
+                    | sed -E 's/^-+|-+$//g')
+                if [[ "$slugified" == "$anchor" ]]; then
+                    anchor_found=1
+                    break
+                fi
+            done < <(grep -E '^#{1,6} ' "$target" | sed -E 's/^#+\s+//')
+
+            if [[ "$anchor_found" -eq 1 ]]; then
+                pass "anchor resolves: /docs/$slug#$anchor"
+            else
+                fail "anchor missing: /docs/$slug#$anchor" "no matching heading in $target"
+            fi
+        fi
+    else
+        fail "link target missing: /docs/$slug" "expected: $target"
+    fi
+done
+
+# External GitHub link sanity (just shape, not network reachability)
+GH=()
+while IFS= read -r line; do
+    GH+=("$line")
+done < <(grep -oE 'https://github\.com/databayt/[^)" ]+' "$ONBOARDING" | sort -u)
+for url in "${GH[@]}"; do
+    # Must point at databayt org repo, sane path
+    assert_match '^https://github\.com/databayt/[a-z0-9-]+(/blob/main/.+|/issues)?' "$url" \
+        "external GH URL well-formed: $url"
+done
+
+# Mobile-app links present and well-formed
+assert_contains "apps.apple.com/app/claude-by-anthropic" "$ONBOARDING" "iOS app link present"
+assert_contains "play.google.com/store/apps/details" "$ONBOARDING" "Android app link present"
+
+# Anti-regression: we should never re-introduce broken /docs/self-hosting or /docs/dispatch links
+# (Tailscale + Apple Notes Dispatch were intentionally removed.)
+# These targets still exist as files but the onboarding journey shouldn't link to them.
+self_hosting_links=$(grep -cE '\(/docs/self-hosting' "$ONBOARDING" || true)
+dispatch_links=$(grep -cE '\(/docs/dispatch' "$ONBOARDING" || true)
+assert_eq "0" "$self_hosting_links" "no /docs/self-hosting links in onboarding"
+assert_eq "0" "$dispatch_links"      "no /docs/dispatch links in onboarding"
+
+suite_summary

--- a/tests/onboarding/lint.test.sh
+++ b/tests/onboarding/lint.test.sh
@@ -1,0 +1,96 @@
+#!/bin/bash
+# Static checks: shellcheck, JSON validity, doc structure, no stale references.
+# Sourced by run.sh — assumes cwd is repo root and lib.sh is already loaded.
+
+suite_name "lint — static checks"
+
+INSTALLER_SH="$PWD/.claude/scripts/installer.sh"
+INSTALLER_LINUX="$PWD/.claude/scripts/installer-linux.sh"
+INSTALLER_PS1="$PWD/.claude/scripts/installer.ps1"
+STEPS_JSON="$PWD/.claude/scripts/lib/wizard-steps.json"
+ONBOARDING_MDX="$PWD/content/docs/onboarding.mdx"
+
+# Files exist
+assert_file_exists "$INSTALLER_SH"      "installer.sh exists"
+assert_file_exists "$INSTALLER_LINUX"   "installer-linux.sh exists"
+assert_file_exists "$INSTALLER_PS1"     "installer.ps1 exists"
+assert_file_exists "$STEPS_JSON"        "wizard-steps.json exists"
+assert_file_exists "$ONBOARDING_MDX"    "onboarding.mdx exists"
+
+# Shellcheck: both bash installers + test runner
+if command -v shellcheck >/dev/null 2>&1; then
+    assert_cmd_succeeds "shellcheck installer.sh" shellcheck "$INSTALLER_SH"
+    assert_cmd_succeeds "shellcheck installer-linux.sh" shellcheck "$INSTALLER_LINUX"
+    assert_cmd_succeeds "shellcheck run.sh" shellcheck "$PWD/tests/onboarding/run.sh"
+    assert_cmd_succeeds "shellcheck lib.sh"  shellcheck "$PWD/tests/onboarding/lib.sh"
+else
+    fail "shellcheck not installed" "brew install shellcheck"
+fi
+
+# JSON parses
+assert_cmd_succeeds "wizard-steps.json parses as JSON" \
+    python3 -c "import json,sys; json.load(open('$STEPS_JSON'))"
+
+# Bash installers have correct shebang
+first_sh=$(head -1 "$INSTALLER_SH")
+first_lx=$(head -1 "$INSTALLER_LINUX")
+assert_eq "#!/bin/bash" "$first_sh" "installer.sh starts with #!/bin/bash"
+assert_eq "#!/bin/bash" "$first_lx" "installer-linux.sh starts with #!/bin/bash"
+
+# Doc line-count cap (≤300, current target)
+lines=$(wc -l < "$ONBOARDING_MDX" | tr -d ' ')
+assert_lt "$lines" 300 "onboarding.mdx under 300 lines"
+
+# Doc must have a frontmatter title
+head_block=$(head -5 "$ONBOARDING_MDX")
+assert_match '^---' "$head_block" "onboarding.mdx starts with frontmatter"
+assert_match 'title: Onboarding' "$head_block" "frontmatter has Onboarding title"
+
+# Doc must mention the one-liner URL and the .ps1 variant
+assert_contains "kun.databayt.org/install"     "$ONBOARDING_MDX"  "doc mentions install URL"
+assert_contains "kun.databayt.org/install.ps1" "$ONBOARDING_MDX"  "doc mentions install.ps1 URL"
+
+# Manual fallback section is present and includes all three OSes
+assert_contains "## Manual fallback" "$ONBOARDING_MDX" "Manual fallback section present"
+assert_contains "onboarding-mac.sh engineer"        "$ONBOARDING_MDX" "manual: macOS backend invocation"
+assert_contains "onboarding-linux.sh engineer"      "$ONBOARDING_MDX" "manual: Linux backend invocation"
+assert_contains "onboarding-windows.ps1"            "$ONBOARDING_MDX" "manual: Windows backend invocation"
+
+# Stale references — must be gone post-cleanup
+assert_not_contains "Tailscale"   "$ONBOARDING_MDX" "no Tailscale references"
+assert_not_contains "Apple Notes" "$ONBOARDING_MDX" "no Apple Notes references"
+assert_not_contains "Dispatch fol" "$ONBOARDING_MDX" "no 'Dispatch folder' references"
+
+# Installer final panels also drop those
+assert_not_contains "tailscale" "$INSTALLER_SH"    "installer.sh: no tailscale mentions in UI"
+assert_not_contains "tailscale" "$INSTALLER_LINUX" "installer-linux.sh: no tailscale mentions in UI"
+assert_not_contains "Tailscale" "$INSTALLER_PS1"   "installer.ps1: no Tailscale mentions in UI"
+
+# Pre-flight collapse: 11 → 2 dialogs in Act 1. Count actual dialog calls (not function defs).
+sh_calls=$(awk '/^# ACT 1/,/^# ACT 2/' "$INSTALLER_SH" \
+    | grep -cE '\$\(ask_(text|choice|yesno|role|identity)\b')
+linux_calls=$(awk '/^# ACT 1/,/^# ACT 2/' "$INSTALLER_LINUX" \
+    | grep -cE '\$\(ask_(text|choice|yesno|role|identity)\b')
+ps1_calls=$(awk '/^# ACT 1/,/^# ACT 2/' "$INSTALLER_PS1" \
+    | grep -cE 'Ask-(Text|Choice|YesNo|Role|Identity)\b')
+
+# macOS: up to 3 chained identity prompts + 1 hogwarts = 4 max (autofill skips most)
+assert_lt "$sh_calls" 6     "installer.sh Act 1 dialog calls ≤ 5"
+# Linux: 1 ask_identity + 1 ask_yesno hogwarts = 2 max
+assert_lt "$linux_calls" 4  "installer-linux.sh Act 1 dialog calls ≤ 3"
+# Windows: 1 Ask-Identity + 1 Ask-YesNo = 2 max
+assert_lt "$ps1_calls" 4    "installer.ps1 Act 1 dialog calls ≤ 3"
+
+# Act 3: 0 round-trip dialogs (final panel ≤ 1 acknowledge-only dialog allowed)
+sh_act3=$(awk '/^# ACT 3/,/^$/' "$INSTALLER_SH" \
+    | grep -cE '\$\(ask_(text|choice|yesno|role|identity)\b')
+linux_act3=$(awk '/^# ACT 3/,/^$/' "$INSTALLER_LINUX" \
+    | grep -cE '\$\(ask_(text|choice|yesno|role|identity)\b')
+ps1_act3=$(awk '/^# ACT 3/,/^$/' "$INSTALLER_PS1" \
+    | grep -cE 'Ask-(Text|Choice|YesNo|Role|Identity)\b')
+
+assert_lt "$sh_act3" 2      "installer.sh Act 3 dialogs ≤ 1 (final panel only)"
+assert_lt "$linux_act3" 2   "installer-linux.sh Act 3 dialogs ≤ 1"
+assert_lt "$ps1_act3" 2     "installer.ps1 Act 3 dialogs ≤ 1"
+
+suite_summary

--- a/tests/onboarding/parity.test.sh
+++ b/tests/onboarding/parity.test.sh
@@ -1,0 +1,100 @@
+#!/bin/bash
+# Parity tests: all three installers (mac, linux, windows) must expose the
+# same surface — same flags, same state-file keys, same final-panel bullets.
+
+suite_name "parity — cross-OS consistency"
+
+SH="$PWD/.claude/scripts/installer.sh"
+LX="$PWD/.claude/scripts/installer-linux.sh"
+PS="$PWD/.claude/scripts/installer.ps1"
+
+# ── Backend flag parity ──────────────────────────────────────────
+# The shell wrappers pass --quiet --name --email; PowerShell uses pascal-cased equivalents.
+for flag in "--quiet" "--name" "--email"; do
+    assert_contains "$flag" "$SH" "installer.sh forwards $flag"
+    assert_contains "$flag" "$LX" "installer-linux.sh forwards $flag"
+done
+for flag in "-Quiet" "-GitName" "-GitEmail"; do
+    assert_contains "$flag" "$PS" "installer.ps1 forwards $flag"
+done
+
+# Hogwarts flag — same shape across OSes
+assert_contains "--hogwarts-dev" "$SH" "installer.sh forwards --hogwarts-dev"
+assert_contains "--hogwarts-dev" "$LX" "installer-linux.sh forwards --hogwarts-dev"
+assert_contains "-HogwartsDev"   "$PS" "installer.ps1 forwards -HogwartsDev"
+
+# ── State-file key parity ────────────────────────────────────────
+# After the simplification, all three should persist the same keys:
+# gitName, gitEmail, role, hogwartsDev, silentBatch.
+for key in gitName gitEmail role hogwartsDev silentBatch; do
+    assert_contains "$key" "$SH" "installer.sh persists state key '$key'"
+    assert_contains "$key" "$LX" "installer-linux.sh persists state key '$key'"
+    assert_contains "$key" "$PS" "installer.ps1 persists state key '$key'"
+done
+
+# ── Cut state keys must NOT appear in any installer ──────────────
+# These were removed when we collapsed the wizard from 11 questions to 2.
+for cut_key in withTailscale gistId proMax reposDir hasGithub hasAnthropic; do
+    if grep -q "$cut_key" "$SH"; then
+        fail "installer.sh still references removed key '$cut_key'"
+    else
+        pass "installer.sh: removed key '$cut_key' is gone"
+    fi
+    if grep -q "$cut_key" "$LX"; then
+        fail "installer-linux.sh still references removed key '$cut_key'"
+    else
+        pass "installer-linux.sh: removed key '$cut_key' is gone"
+    fi
+    if grep -q "$cut_key" "$PS"; then
+        fail "installer.ps1 still references removed key '$cut_key'"
+    else
+        pass "installer.ps1: removed key '$cut_key' is gone"
+    fi
+done
+
+# ── Cut Act 3 dialog keys ────────────────────────────────────────
+# desktopSignedIn, computerUse, webstormPlugin — these dialogs were cut.
+for cut_dialog in desktopSignedIn computerUse webstormPlugin; do
+    assert_not_contains "$cut_dialog" "$SH" "installer.sh: Act 3 dialog '$cut_dialog' cut"
+    assert_not_contains "$cut_dialog" "$LX" "installer-linux.sh: Act 3 dialog '$cut_dialog' cut"
+    assert_not_contains "$cut_dialog" "$PS" "installer.ps1: Act 3 dialog '$cut_dialog' cut"
+done
+
+# ── Final panel parity ───────────────────────────────────────────
+# All three final panels should mention secrets-from-gist + mobile.
+for installer_file in "$SH" "$LX" "$PS"; do
+    assert_contains "secrets" "$installer_file"  "$(basename "$installer_file"): final panel mentions secrets"
+    assert_contains "claude.ai/code" "$installer_file" "$(basename "$installer_file"): final panel mentions claude.ai/code"
+done
+
+# ── Docs URL parity ──────────────────────────────────────────────
+# All three should point users at the same docs URL.
+DOCS_URL="kun.databayt.org/docs/onboarding"
+assert_contains "$DOCS_URL" "$SH" "installer.sh points to canonical docs URL"
+assert_contains "$DOCS_URL" "$LX" "installer-linux.sh points to canonical docs URL"
+assert_contains "$DOCS_URL" "$PS" "installer.ps1 points to canonical docs URL"
+
+# ── Bootstrap consistency ────────────────────────────────────────
+# All three clone kun from the same canonical URL.
+KUN_REPO="github.com/databayt/kun.git"
+assert_contains "$KUN_REPO" "$SH" "installer.sh clones from $KUN_REPO"
+assert_contains "$KUN_REPO" "$LX" "installer-linux.sh clones from $KUN_REPO"
+assert_contains "$KUN_REPO" "$PS" "installer.ps1 clones from $KUN_REPO"
+
+# ── State-file location format ───────────────────────────────────
+assert_contains "Application Support/Databayt" "$SH" "installer.sh uses macOS state dir"
+assert_contains "databayt" "$LX"                    "installer-linux.sh uses XDG state dir"
+assert_contains "APPDATA\\Databayt" "$PS"           "installer.ps1 uses Windows state dir"
+
+# ── Wizard-steps.json describes both removed-from-v1 lists ───────
+STEPS_JSON="$PWD/.claude/scripts/lib/wizard-steps.json"
+assert_cmd_succeeds "wizard-steps.json has preflightCut entries" \
+    python3 -c "import json; d=json.load(open('$STEPS_JSON')); assert len(d['removedFromV1']['preflightCut']) >= 5"
+assert_cmd_succeeds "wizard-steps.json has act3DialogsCut entries" \
+    python3 -c "import json; d=json.load(open('$STEPS_JSON')); assert len(d['removedFromV1']['act3DialogsCut']) >= 3"
+
+# ── Step manifest version bumped ─────────────────────────────────
+assert_cmd_succeeds "wizard-steps.json version is 2 (post-simplification)" \
+    python3 -c "import json; d=json.load(open('$STEPS_JSON')); assert d['version'] == 2"
+
+suite_summary

--- a/tests/onboarding/run.sh
+++ b/tests/onboarding/run.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+# Orchestrator for the onboarding test suite.
+# Discovers tests/onboarding/*.test.sh, runs them in order, prints summary,
+# exits non-zero on any failure.
+#
+# Usage:
+#   bash tests/onboarding/run.sh                # run all suites
+#   bash tests/onboarding/run.sh lint behavior  # run only matching suites
+#
+# Suites currently shipped:
+#   lint     — static checks (shellcheck, JSON parse, doc structure)
+#   behavior — state file + autofill + backend args logic
+#   parity   — cross-OS installer consistency
+#   links    — /docs/<x> link resolution
+
+set -u  # error on unset vars; do NOT use -e so individual asserts can fail without aborting
+
+cd "$(dirname "$0")/../.." || { echo "could not cd to repo root"; exit 2; }
+TESTS_DIR="tests/onboarding"
+
+# shellcheck source=tests/onboarding/lib.sh
+# shellcheck disable=SC1091
+source "$TESTS_DIR/lib.sh"
+
+filter=("$@")
+match_suite() {
+    [[ ${#filter[@]} -eq 0 ]] && return 0
+    local name="$1"
+    for f in "${filter[@]}"; do
+        [[ "$name" == *"$f"* ]] && return 0
+    done
+    return 1
+}
+
+start=$(date +%s)
+
+# Discover *.test.sh in stable order (bash 3.2 compatible — no mapfile)
+SUITES=()
+while IFS= read -r line; do
+    SUITES+=("$line")
+done < <(find "$TESTS_DIR" -maxdepth 1 -type f -name "*.test.sh" | sort)
+
+if [[ ${#SUITES[@]} -eq 0 ]]; then
+    printf '%sNo test suites found in %s%s\n' "$C_RED" "$TESTS_DIR" "$C_RESET"
+    exit 2
+fi
+
+printf '%sOnboarding test run%s — %d suites discovered (bash %s)\n' "$C_BOLD" "$C_RESET" "${#SUITES[@]}" "${BASH_VERSION%%.*}"
+
+for suite in "${SUITES[@]}"; do
+    name=$(basename "$suite" .test.sh)
+    if ! match_suite "$name"; then
+        printf '%s- skipping %s (filter)%s\n' "$C_DIM" "$name" "$C_RESET"
+        continue
+    fi
+    # shellcheck source=/dev/null
+    source "$suite"
+done
+
+elapsed=$(($(date +%s) - start))
+
+printf '\n%s═════════════════════════════════════════%s\n' "$C_BOLD" "$C_RESET"
+total=$((TOTAL_PASS + TOTAL_FAIL))
+if [[ "$TOTAL_FAIL" -eq 0 ]]; then
+    printf '%s✓ ALL GREEN — %d/%d assertions passed in %ds%s\n' "$C_GREEN" "$TOTAL_PASS" "$total" "$elapsed" "$C_RESET"
+    exit 0
+else
+    printf '%s✗ FAILURES — %d/%d passed, %d failed in %ds%s\n' "$C_RED" "$TOTAL_PASS" "$total" "$TOTAL_FAIL" "$elapsed" "$C_RESET"
+    exit 1
+fi


### PR DESCRIPTION
## Summary

- **Wizard:** 11 pre-flight questions → 2 dialogs; 3 Act-3 round-trip dialogs → 0. Total user touches **15 → 3** (identity card · GitHub Authorize · Hogwarts Y/N).
- **Doc:** `content/docs/onboarding.mdx` 566 → 226 lines (-60%), with a new "Manual fallback" section (2-3 commands per OS) replacing 155 lines of duplicated Path-B blocks.
- **Tests:** 143 assertions across 4 suites under `tests/onboarding/`, full green in ~1s with no extra deps.

## Wizard changes

| Surface | Before | After |
|---|---|---|
| Pre-flight questions | 11 | **2** (identity card + Hogwarts Y/N, engineer-only) |
| Act-3 round-trip dialogs | 3 (Desktop sign-in, computer-use, WebStorm) | **0** — deferred to final "Optional follow-ups" panel |
| External clicks | 1 hidden inside "silent" batch | **1** named upfront ("Authorize at ~2 min") |

- Auto-detect aggressively: git name/email from `git config --global`, role from existing `~/.claude/mcp.json` (shadcn → engineer, linear → business, figma → content, posthog → ops). When everything autofills, Act 1 is just the Hogwarts Y/N for engineers, or zero dialogs for non-engineers.
- Cut + deferred: Welcome, Has-GitHub, Has-Anthropic, Repos-dir, Pro/Max, Tailscale, Gist-ID. Anything still relevant surfaces as a command snippet in the final panel.
- Linux uses `zenity --forms` for a true single-window identity card; Windows uses WPF (TextBox×2 + ComboBox); macOS chains autofill-aware prompts (1/3, 2/3, 3/3) only for fields not in `git config` or `mcp.json`.
- Honest messaging: wrapper banner now reads "Installing — minimize the terminal and walk away (one Authorize click in the browser ~2 min in)" instead of claiming pure silence.

## Doc changes (`content/docs/onboarding.mdx`)

- New "What happens" 4-row table replaces the three-acts narrative (62 → 8 lines).
- Deliverables + Verify + Modify collapsed into one matrix.
- **Manual fallback** added — clone kun, run the backend directly (2 commands on macOS, 3 on Linux/Windows). Replaces 155 lines of duplicated install steps that linked out to `claude-code.mdx`.
- Dropped Tailscale + Apple Notes Dispatch — use Anthropic's native remote (`claude.ai/code` from mobile/web) and the Cowork ↔ Code bridge instead.

## Tests (`tests/onboarding/`)

| Suite | Asserts | Validates |
|---|---|---|
| `lint` | 33 | shellcheck clean · `wizard-steps.json` parses · doc ≤300 lines · Manual fallback present with all 3 OSes · no stale Tailscale / Apple Notes refs · Act 1 ≤ {macOS 5, Linux 3, Win 3} · Act 3 ≤ 1 |
| `behavior` | 18 | `state_get`/`state_set` round-trip · git autofill reads sandbox `$HOME` · mcp.json → role for all 4 roles · `BACKEND_ARGS` shape |
| `parity` | 72 | all 3 installers forward same flags + persist same state keys · 6 cut keys absent · 3 cut Act-3 dialogs absent · final panel parallels · same docs/kun URLs · `wizard-steps.json` version=2 |
| `links` | 20 | every `(/docs/<x>)` resolves · external GH URLs well-formed · anti-regression on self-hosting/dispatch links |
| **Total** | **143** | full pass in 1s |

No npm packages or test framework added. Pure bash + python3 + shellcheck (all already present). Bash 3.2 compatible.

## Test plan

- [ ] `bash tests/onboarding/run.sh` exits 0 with `✓ ALL GREEN — 143/143`
- [ ] `bash tests/onboarding/run.sh lint` exits 0 (filter works)
- [ ] On a clean macOS VM: `curl -fsSL https://kun.databayt.org/install | bash` shows ≤4 dialogs (identity 1/3, 2/3, 3/3, hogwarts) on a truly fresh machine; ≤2 on a machine with git config preset; exactly 1 external click (Authorize)
- [ ] Re-run the installer: state file resumes → 0 dialogs
- [ ] Linux VM (zenity): identity card shows as a single `--forms` window
- [ ] Windows VM: WPF identity window shows name + email + role combo
- [ ] Manual fallback: `git clone … && bash onboarding-mac.sh engineer` produces the same end state as the wizard

🤖 Generated with [Claude Code](https://claude.com/claude-code)