### PR TITLE
chore(repos): rename swift-app -> ios-app across kun

### DIFF
--- a/.claude/agents/captain.md
+++ b/.claude/agents/captain.md
@@ -89,7 +89,7 @@ After this 60-second load, the captain has a complete picture. Then proceed.
 | **Mission** | Excellent school operations for every Arabic-speaking community — built in the open, shared as an economy |
 | **North Star** | Active paying schools using Hogwarts |
 | **Repos** | 14 |
-| **Products** | 5 (hogwarts, souq, mkan, shifa, swift-app) + Kun (engine) |
+| **Products** | 5 (hogwarts, souq, mkan, shifa, ios-app) + Kun (engine) |
 | **Engine** | Kun — Claude Code configuration layer |
 | **Stack** | Next.js 16, React 19, Prisma 6, TypeScript 5, Tailwind 4, shadcn/ui |
 
@@ -147,7 +147,7 @@ Source of truth: `.claude/memory/team.json` and `.claude/memory/capacity.json`. 
 | **souq** | Alpha (MVP, awaiting PMF) | TBD | Commission + subscription | Abdout (TBD: Ibrahim?) |
 | **mkan** | Alpha (Phase 1 done, awaiting soft launch) | TBD | Booking commission | Abdout (TBD) |
 | **shifa** | Design (paused) | TBD | Per-clinic subscription (HIGHEST RISK product — medical PII) | — |
-| **swift-app** | Design | N/A (companion) | Bundled with products | — |
+| **ios-app** | Design | N/A (companion) | Bundled with products | — |
 | **kun** | Phase 2 (Team Engine) active | Databayt (internal) | Future: dev tool subscription / OSS sponsorship | Abdout |
 
 ---

--- a/.claude/agents/guardian.md
+++ b/.claude/agents/guardian.md
@@ -33,7 +33,7 @@ Protect databayt's code, data, and reputation. Audit security (OWASP Top 10), en
 | **souq** | Payment security (PCI awareness), vendor data isolation, injection in product listings |
 | **mkan** | Booking data, location privacy, payment processing |
 | **shifa** | **HIGHEST RISK** — Medical records, patient PII, appointment data. Saudi health data regulations |
-| **swift-app** | Mobile app security, token storage, certificate pinning |
+| **ios-app** | Mobile app security, token storage, certificate pinning |
 
 ### OWASP Top 10 Checklist
 

--- a/.claude/agents/product.md
+++ b/.claude/agents/product.md
@@ -12,7 +12,7 @@ handoff: [captain, tech-lead, analyst, revenue, growth]
 
 ## Core Responsibility
 
-Own the roadmap for hogwarts, souq, mkan, shifa, and swift-app. Write user stories, negotiate scope, prioritize features (ICE scoring), plan releases, and align cross-product patterns. You think in user outcomes, not technical implementation.
+Own the roadmap for hogwarts, souq, mkan, shifa, and ios-app. Write user stories, negotiate scope, prioritize features (ICE scoring), plan releases, and align cross-product patterns. You think in user outcomes, not technical implementation.
 
 ## Team
 
@@ -33,7 +33,7 @@ Own the roadmap for hogwarts, souq, mkan, shifa, and swift-app. Write user stori
 | **souq** | Alpha | Vendor onboarding flow | MENA e-commerce |
 | **mkan** | Alpha | Listing + booking MVP | Saudi rentals |
 | **shifa** | Design | Patient record + appointment MVP | Saudi healthcare |
-| **swift-app** | Design | iOS companion for hogwarts | Mobile |
+| **ios-app** | Design | iOS companion for hogwarts | Mobile |
 
 ### Cross-Product Patterns
 

--- a/.claude/agents/tech-lead.md
+++ b/.claude/agents/tech-lead.md
@@ -36,7 +36,7 @@ Strategic technical decisions across all databayt repositories. You don't write 
 - **souq** — E-commerce marketplace, multi-vendor
 - **mkan** — Rental marketplace, booking system
 - **shifa** — Medical platform, compliance-sensitive
-- **swift-app** — iOS companion, SwiftUI
+- **ios-app** — iOS companion, SwiftUI
 
 ### Supporting
 - **distributed-computer** — Rust P2P infrastructure

--- a/.claude/commands/issue.md
+++ b/.claude/commands/issue.md
@@ -13,7 +13,7 @@ Arguments: $ARGUMENTS (title and description, or just a topic to expand)
 | **shifa** | Medical product |
 | **codebase** | Shared patterns, components, templates |
 | **shadcn** | UI component library |
-| **swift-app** | iOS mobile app |
+| **ios-app** | iOS mobile app |
 | **marketing** | Landing pages, marketing site |
 
 ## Labels

--- a/.claude/memory/repositories.json
+++ b/.claude/memory/repositories.json
@@ -132,12 +132,12 @@
     ],
     "specialized": [
       {
-        "id": "swift-app",
-        "name": "Swift App",
-        "url": "https://github.com/databayt/swift-app",
-        "local": "/Users/abdout/oss/swift-app",
+        "id": "ios-app",
+        "name": "iOS App",
+        "url": "https://github.com/databayt/ios-app",
+        "local": "/Users/abdout/oss/ios-app",
         "description": "iOS application (Hogwarts mobile)",
-        "stack": ["Swift 5.9+", "SwiftUI", "iOS 17+"],
+        "stack": ["Swift 6", "SwiftUI", "iOS 18+"],
         "purpose": ["ios", "mobile", "swiftui"],
         "patterns": ["mvvm", "clean-architecture", "offline-sync", "bilingual"],
         "agent": null,

--- a/.claude/memory/team.json
+++ b/.claude/memory/team.json
@@ -4,7 +4,7 @@
   "company": {
     "name": "Databayt",
     "license": "SSPL",
-    "products": ["hogwarts", "souq", "mkan", "shifa", "swift-app"],
+    "products": ["hogwarts", "souq", "mkan", "shifa", "ios-app"],
     "stack": "Next.js 16, React 19, Prisma 6, TypeScript 5, Tailwind CSS 4, shadcn/ui",
     "headcount": 6
   },

--- a/.claude/scripts/onboarding-linux.sh
+++ b/.claude/scripts/onboarding-linux.sh
@@ -417,7 +417,7 @@ clone_repo "kun"; symlink_home "kun"
 clone_repo "hogwarts"; symlink_home "hogwarts"
 clone_repo "codebase"; symlink_home "codebase"
 if [[ "$ALL_REPOS" == "1" ]]; then
-    for repo in shadcn radix souq mkan shifa swift-app distributed-computer marketing; do
+    for repo in shadcn radix souq mkan shifa ios-app distributed-computer marketing; do
         clone_repo "$repo"; symlink_home "$repo"
     done
 fi

--- a/.claude/scripts/onboarding-mac.sh
+++ b/.claude/scripts/onboarding-mac.sh
@@ -341,7 +341,7 @@ clone_repo "codebase"; symlink_home "codebase"
 
 if [[ "$ALL_REPOS" == "1" ]]; then
     info "Cloning remaining databayt org repos..."
-    for repo in shadcn radix souq mkan shifa swift-app distributed-computer marketing; do
+    for repo in shadcn radix souq mkan shifa ios-app distributed-computer marketing; do
         clone_repo "$repo"; symlink_home "$repo"
     done
 fi

--- a/.claude/scripts/onboarding-windows.ps1
+++ b/.claude/scripts/onboarding-windows.ps1
@@ -312,7 +312,7 @@ Clone-Repo "codebase"; Symlink-Home "codebase"
 
 if (-not $EssentialsOnly) {
     Info "Cloning remaining databayt org repos..."
-    foreach ($repo in @("shadcn", "radix", "souq", "mkan", "shifa", "swift-app", "distributed-computer", "marketing")) {
+    foreach ($repo in @("shadcn", "radix", "souq", "mkan", "shifa", "ios-app", "distributed-computer", "marketing")) {
         Clone-Repo $repo; Symlink-Home $repo
     }
 }

--- a/.claude/scripts/sync-repos.ps1
+++ b/.claude/scripts/sync-repos.ps1
@@ -30,7 +30,7 @@ $Repos = @{
     "souq" = "$OssDir\souq"
     "mkan" = "$OssDir\mkan"
     "shifa" = "$OssDir\shifa"
-    "swift-app" = "$OssDir\swift-app"
+    "ios-app" = "$OssDir\ios-app"
     "distributed-computer" = "$OssDir\distributed-computer"
     "marketing" = "$OssDir\marketing"
 }

--- a/.claude/scripts/sync-repos.sh
+++ b/.claude/scripts/sync-repos.sh
@@ -31,7 +31,7 @@ declare -A REPOS=(
     ["souq"]="$OSS_DIR/souq"
     ["mkan"]="$OSS_DIR/mkan"
     ["shifa"]="$OSS_DIR/shifa"
-    ["swift-app"]="$OSS_DIR/swift-app"
+    ["ios-app"]="$OSS_DIR/ios-app"
     ["distributed-computer"]="$OSS_DIR/distributed-computer"
     ["marketing"]="$OSS_DIR/marketing"
 )

--- a/content/docs/architecture.mdx
+++ b/content/docs/architecture.mdx
@@ -175,7 +175,7 @@ databayt/ (14 repos)
 ├── Engine
 │   └── kun          — Configuration engine (this repo)
 ├── Mobile & Marketing
-│   ├── swift-app    — iOS app (Swift 6/SwiftUI)
+│   ├── ios-app     — iOS app (Swift 6/SwiftUI)
 │   └── marketing    — Landing pages
 └── Other
     ├── spma         — Internal tool

--- a/content/docs/claude-code.mdx
+++ b/content/docs/claude-code.mdx
@@ -326,7 +326,7 @@ Sync all organization repositories locally for deep reference:
 - `shifa` - Medical platform (appointments, patients)
 
 **Specialized** (Priority 3):
-- `swift-app` - iOS mobile
+- `ios-app` - iOS mobile
 - `distributed-computer` - Rust infrastructure
 - `marketing` - Landing pages
 

--- a/content/docs/epics.mdx
+++ b/content/docs/epics.mdx
@@ -19,7 +19,7 @@ The whole team is pointed at two bets — **PMF via school finance** and a **mob
 | Onboarding Friction Kill | 1 | Abdout / web | [hogwarts#314](https://github.com/databayt/hogwarts/issues/314) |
 | PMF Pilots | both | Mutaz / Ali | [hogwarts#316](https://github.com/databayt/hogwarts/issues/316) |
 | Mobile API Layer | 2 | Abdout + Ibrahim | [hogwarts#315](https://github.com/databayt/hogwarts/issues/315) |
-| Mobile Public Launch | 2 | Ibrahim | [swift-app#3](https://github.com/databayt/swift-app/issues/3) |
+| Mobile Public Launch | 2 | Ibrahim | [ios-app#3](https://github.com/databayt/ios-app/issues/3) |
 | Q3 master tracker | — | Abdout | [kun#76](https://github.com/databayt/kun/issues/76) |
 
 ## Bet 1 — PMF via School Finance
@@ -85,7 +85,7 @@ Backend API layer for the iOS + Android apps. Shares the finance domain with Bet
 - [ ] [#287](https://github.com/databayt/hogwarts/issues/287) guardian write actions
 - [ ] [#288](https://github.com/databayt/hogwarts/issues/288) universal search
 
-### Mobile Public Launch · [swift-app#3](https://github.com/databayt/swift-app/issues/3)
+### Mobile Public Launch · [ios-app#3](https://github.com/databayt/ios-app/issues/3)
 
 Ship the Hogwarts app to the public App Store (iOS) + Google Play (Android).
 

--- a/content/docs/issue.mdx
+++ b/content/docs/issue.mdx
@@ -244,7 +244,7 @@ issue "Add dark mode to dashboard"
 | `databayt/shifa` | Medical: appointments, patient records |
 | `databayt/codebase` | Shared: patterns, components, templates |
 | `databayt/shadcn` | UI: component library |
-| `databayt/swift-app` | Mobile: iOS app |
+| `databayt/ios-app` | Mobile: iOS app |
 | `databayt/marketing` | Marketing: landing pages |
 
 ### Labels

--- a/content/docs/onboarding.mdx
+++ b/content/docs/onboarding.mdx
@@ -201,7 +201,7 @@ If something's missing the wizard skips that step and lists it under "things to 
 
 **Every machine clones the full databayt org** to your chosen directory (`~/`, `~/databayt/`, or custom) — any machine can touch any repo:
 
-`kun` (engine config), `hogwarts` (multi-tenant LMS), `codebase` (patterns, agents, blocks), `shadcn` (UI library), `radix` (UI primitives), `souq` (e-commerce), `mkan` (rentals), `shifa` (medical), `swift-app` (iOS/Swift), `distributed-computer` (infra), `marketing` (landing pages).
+`kun` (engine config), `hogwarts` (multi-tenant LMS), `codebase` (patterns, agents, blocks), `shadcn` (UI library), `radix` (UI primitives), `souq` (e-commerce), `mkan` (rentals), `shifa` (medical), `ios-app` (iOS/Swift), `distributed-computer` (infra), `marketing` (landing pages).
 
 When you pick a custom directory, the wizard symlinks `~/kun`, `~/hogwarts`, etc. back to it so all existing tooling that hard-codes `~/kun` keeps working.
 

--- a/content/docs/repositories.mdx
+++ b/content/docs/repositories.mdx
@@ -163,12 +163,12 @@ Apple design clone for UI pattern reference.
 
 ## Mobile & Infrastructure
 
-### swift-app
+### ios-app
 
 iOS application for Hogwarts.
 
-- **URL**: [github.com/databayt/swift-app](https://github.com/databayt/swift-app)
-- **Stack**: Swift 5.9+, SwiftUI, iOS 17+
+- **URL**: [github.com/databayt/ios-app](https://github.com/databayt/ios-app)
+- **Stack**: Swift 6, SwiftUI, iOS 18+
 - **Architecture**: MVVM, Clean Architecture, atomic design
 
 **Good for reference**:

--- a/content/docs/sprint.mdx
+++ b/content/docs/sprint.mdx
@@ -74,7 +74,7 @@ c "/issue"
 | 07 | Role-aware UI sweep | Tech | — | `In Progress` | Abdout | — |
 | 08 | Translation audit | Tech | — | `In Progress` | Samia | [translation](https://ed.databayt.org/en/docs/translation) |
 | 09 | Mobile API Layer | Tech | 2 | `In Progress` | Abdout + Ibrahim | [hogwarts#315](https://github.com/databayt/hogwarts/issues/315) |
-| 10 | iOS app | Tech | 2 | `In Progress` | Ibrahim | [swift-app#3](https://github.com/databayt/swift-app/issues/3) |
+| 10 | iOS app | Tech | 2 | `In Progress` | Ibrahim | [ios-app#3](https://github.com/databayt/ios-app/issues/3) |
 | 11 | Android app | Tech | 2 | `Vaporware` | Ibrahim | `kotlin-app` *(repo TBD)* |
 | 12 | Sales & Pilots | Non-tech | both | `Built+Polish` | Mutaz / Ali | [hogwarts#316](https://github.com/databayt/hogwarts/issues/316) |
 | 13 | Fundraising | Non-tech | — | `In Progress` | Abdout | [fundraising](https://ed.databayt.org/en/docs/fundraising) |
@@ -151,7 +151,7 @@ The backend API layer the iOS + Android apps consume. Shares the finance domain 
 - [ ] P1 — grade entry, report cards, attendance, online exams, schedules, guardian write actions, universal search
 
 ### 10 — iOS app · Tech · `In Progress`
-[swift-app#3](https://github.com/databayt/swift-app/issues/3)
+[ios-app#3](https://github.com/databayt/ios-app/issues/3)
 
 Ship the Hogwarts app to the public App Store.
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -284,7 +284,7 @@ Kun coordinates 14 repositories under github.com/databayt:
 │  ├── kun (THIS — configuration engine)                          │
 │  ├── shadcn (shadcn/ui fork)                                   │
 │  ├── radix (Radix UI primitives fork)                          │
-│  ├── swift-app (iOS companion for Hogwarts)                    │
+│  ├── ios-app (iOS companion for Hogwarts)                     │
 │  ├── marketing (landing pages)                                  │
 │  ├── spma (project management, early)                          │
 │  ├── apple (design R&D)                                        │

--- a/docs/PROJECT-BRIEF.md
+++ b/docs/PROJECT-BRIEF.md
@@ -149,7 +149,7 @@ Ahmed Baha is an interested client. The pitch is partnership, not sales:
 | **[kun](./repositories/kun.md)** | Configuration engine — this project | Coordinates everything |
 | **[shadcn](./repositories/shadcn.md)** | UI component library (shadcn/ui fork) | Shared UI primitives |
 | **[radix](./repositories/radix.md)** | Radix UI primitives fork | Foundation for shadcn |
-| **[swift-app](./repositories/swift-app.md)** | iOS companion for Hogwarts | Native Swift/SwiftUI |
+| **[ios-app](./repositories/ios-app.md)** | iOS companion for Hogwarts | Native Swift/SwiftUI |
 | **[marketing](./repositories/marketing.md)** | Landing pages for all products | Company website |
 | **[spma](./repositories/spma.md)** | Project management tool | Internal use |
 | **[apple](./repositories/apple.md)** | Apple design experiments | R&D |
@@ -322,7 +322,7 @@ Email accounts: [team]@databayt.org
 | [kun](./repositories/kun.md) | Engine | Active | 2026-03-30 | This project |
 | [shadcn](./repositories/shadcn.md) | Library | Fork sync | 2025-12-01 | UI components |
 | [radix](./repositories/radix.md) | Library | Fork sync | 2025-12-07 | UI primitives |
-| [swift-app](./repositories/swift-app.md) | Mobile | Phase 2 | 2026-02-10 | iOS app |
+| [ios-app](./repositories/ios-app.md) | Mobile | Phase 2 | 2026-02-10 | iOS app |
 | [marketing](./repositories/marketing.md) | Website | Active | 2026-01-29 | Landing pages |
 | [spma](./repositories/spma.md) | Internal | Early | 2026-02-23 | Project management |
 | [apple](./repositories/apple.md) | R&D | Experiment | 2026-02-06 | Design lab |

--- a/docs/repositories/hogwarts.md
+++ b/docs/repositories/hogwarts.md
@@ -118,7 +118,7 @@ Very active — multiple commits per day. Primary development focus.
 
 ## iOS Companion
 
-The [swift-app](./swift-app.md) repository is the native iOS companion for Hogwarts, built with Swift 6/SwiftUI, following the same module structure.
+The [ios-app](./ios-app.md) repository is the native iOS companion for Hogwarts, built with Swift 6/SwiftUI, following the same module structure.
 
 ---
 

--- a/docs/repositories/ios-app.md
+++ b/docs/repositories/ios-app.md
@@ -1,6 +1,6 @@
-# Swift App — Hogwarts iOS
+# iOS App — Hogwarts Mobile Companion
 
-> **Native iOS companion for Hogwarts. Phase 2 in progress.**
+> **Native iOS companion for Hogwarts. Phase 2 in progress.** Repo was renamed from `swift-app` on 2026-05-24; old URL redirects.
 
 ---
 
@@ -8,11 +8,10 @@
 
 | Field | Value |
 |-------|-------|
-| **Repo** | [databayt/swift-app](https://github.com/databayt/swift-app) |
+| **Repo** | [databayt/ios-app](https://github.com/databayt/ios-app) |
 | **Language** | Swift |
-| **Size** | 442 KB |
 | **Created** | 2025-12-17 |
-| **Last Push** | 2026-02-10 |
+| **Sibling** | [databayt/android-app](https://github.com/databayt/android-app) (Kotlin/Compose, the lead mobile reference) |
 
 ---
 
@@ -67,9 +66,9 @@ Active development through sprints. Currently on Phase 2 — glass material desi
 
 ---
 
-## What Kun Does for Swift App
+## What Kun Does for iOS App
 
-- References swift-app patterns for iOS development
-- Coordinates with Hogwarts web for feature parity
+- References ios-app patterns for iOS development
+- Coordinates with Hogwarts web for feature parity, and mirrors android-app feature cadence
 - Primary development on macOS + iOS
 - Accessibility/VoiceOver testing on iOS


### PR DESCRIPTION
## Summary

- The GitHub repo `databayt/swift-app` was renamed to `databayt/ios-app`. Local clone now lives at `/Users/abdout/ios-app`. This PR drags every kun reference along so nothing keeps reaching for the old name.
- Aligns with the Hogwarts mobile hierarchy: web = source of truth, `android-app` = lead mobile reference, `ios-app` = mirrors android.
- Naming now matches sibling `databayt/android-app` (formerly `kotlin-app`).

## Changes

- **Scripts**: `onboarding-{mac,linux}.sh`, `onboarding-windows.ps1` (clone list), `sync-repos.{sh,ps1}` (path map)
- **Agents**: `product.md`, `tech-lead.md`, `guardian.md`, `captain.md` (product tables / portfolio rows)
- **Memory**: `team.json` products list, `repositories.json` entry (also bumps stale stack metadata: Swift 5.9+/iOS 17+ → Swift 6/iOS 18+)
- **Commands**: `issue.md` repo→purpose table
- **Docs (mdx)**: `architecture`, `sprint`, `claude-code`, `issue`, `repositories`, `epics`, `onboarding` — prose, tables, URLs, issue links
- **Docs (md)**: `ARCHITECTURE.md`, `PROJECT-BRIEF.md`, `repositories/hogwarts.md`
- **Rename**: `docs/repositories/swift-app.md` → `docs/repositories/ios-app.md` (`git mv`, history preserved; title rewritten + android-app sibling reference added)

The single remaining `swift-app` string is the deliberate rename breadcrumb in `docs/repositories/ios-app.md`. GitHub URL redirect keeps any external link to the old slug working.

## Test plan

- [ ] `grep -rln "swift-app" .` returns only the breadcrumb line in `docs/repositories/ios-app.md`
- [ ] `bash .claude/scripts/sync-repos.sh` clones into `$OSS_DIR/ios-app` (not `swift-app`)
- [ ] Onboarding scripts on all 3 platforms still list 8 repos in the optional-clone loop
- [ ] `pnpm build` / contentlayer regeneration succeeds (no broken doc links)

## Out of scope (follow-ups)

- `~/.claude/memory/repositories.json` (user-home, not kun) — still has the old slug; can be patched separately.
- Sibling `kotlin-app` → `android-app` local-folder rename mirrors this situation. Not bundled here so this PR stays clean and reversible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)