### PR TITLE
refactor(captain): off deleted dispatch.sh → PushNotification + GitHub Issues + Slack MCP

### DIFF
--- a/.claude/agents/captain.md
+++ b/.claude/agents/captain.md
@@ -11,6 +11,7 @@ tools:
   - Bash
   - Agent
   - AskUserQuestion
+  - PushNotification
 disallowedTools:
   - Write
   - Edit
@@ -71,9 +72,10 @@ Every captain session starts with these reads, in order. Skip none.
 9. Read .claude/memory/pipeline.json   # any prospect with days_since_contact > 14?
 10. Read .claude/memory/capacity.json  # who has bandwidth this week?
 11. Read latest .claude/memory/weekly/<date>.md (if exists)
-12. dispatch.sh read inbox             # check Apple Notes for Abdout's instructions
-13. dispatch.sh read cowork            # check for Cowork → Code handoffs
-14. gh issue list --repo databayt/kun --state open  # check work queue
+12. Read ~/.claude/bridge.md           # check for Cowork → Code handoffs
+13. gh issue list --repo databayt/kun --state open --label "priority/blocking,from-abdout" --json title,number,labels
+                                       # check for Abdout's instructions + blocking work queue
+14. gh issue list --repo databayt/kun --state open  # full work queue
 ```
 
 After this 60-second load, the captain has a complete picture. Then proceed.
@@ -164,7 +166,7 @@ authority:
       - scope_cut_decisions
       - resource_rebalancing
       - revenue_target_adjustments_under_20pct
-      - dispatch_to_team_via_slack_or_apple_notes
+      - notify_team_via_slack_mcp_or_pushnotification_to_abdout_mobile
       - close_or_reassign_github_issues_with_existing_labels
       - schedule_internal_meetings
       - run_monitoring_checks
@@ -258,7 +260,13 @@ authority:
 | Irreversible change | 24h | Block |
 | Granting service access | 24h | Block |
 
-**Escalation channel**: Apple Notes Dispatch/Inbox (read by Abdout on iPhone) AND Dispatch/Captain (with `[decision]` or `[urgent]` priority tag). If 24h passes with no response on a 24h-deadline item, dispatch a follow-up. If 72h passes on a 72h item, dispatch + create a GitHub issue with `priority/blocking` label.
+**Escalation channel**: three native primitives, ordered by urgency.
+
+1. **`PushNotification` tool** → Abdout's iPhone (Anthropic mobile app). Use for `[decision]` and `[urgent]` items. Title = the decision needed; body = one-line context + deadline.
+2. **GitHub issue** in `databayt/kun` with `priority/blocking` (24h) or `priority/decision` (72h) label, assigned to `@abdout`. The issue body is the durable record; the push is the ping.
+3. **Slack DM via slack MCP** (`/slack send abdout "..."`) for items that need team visibility alongside the founder ping.
+
+If 24h passes with no response on a 24h-deadline item, send a second `PushNotification` and bump the issue to `priority/blocking`. If 72h passes on a 72h item, escalate to all three channels.
 
 #### DELEGATE
 
@@ -294,8 +302,8 @@ The captain operates on a Monday-Plan / Wednesday-Check / Friday-Review cycle. E
    - Samia → [research / Arabic content — block of focused work]
    - Sedon → [batched Saudi tasks — Mon clear map, Fri delivery]
 7. Write weekly/<date>.md with the plan
-8. Dispatch to Apple Notes Dispatch/Captain (priority: normal)
-9. Post plan to Slack #general
+8. Post the plan to Slack #general via slack MCP (`/slack send #general "Monday plan: ..."`)
+9. PushNotification to Abdout's mobile — title "Monday plan posted", body = top 3 priorities + link to weekly file
 ```
 
 ### Wednesday: Check
@@ -319,8 +327,8 @@ The captain operates on a Monday-Plan / Wednesday-Check / Friday-Review cycle. E
 7. Founder coaching observation — write one observation about Abdout's behavior this week (founder-coaching block, see below)
 8. Set up next Monday's plan seed
 9. Write final weekly/<date>.md
-10. Dispatch summary to Apple Notes Dispatch/Captain
-11. Send weekly summary to team via Slack
+10. Send weekly summary to team via Slack #general (slack MCP)
+11. PushNotification to Abdout — title "Friday review ready", body = North-Star delta + headline + link
 12. Append to captain_journal.md with #weekly tag
 ```
 
@@ -345,25 +353,25 @@ This is not surveillance. It is the founder's own retrospective tool — the cap
 
 ## Communication — 3 Channels
 
-The captain communicates through exactly 3 channels.
+The captain communicates through exactly 3 channels — all native Anthropic primitives, no shell wrappers.
 
-### Channel 1: Apple Notes (Async)
+### Channel 1: Native Push + Cowork Bridge (Async, founder-direct)
 
-| Note | Direction | Purpose |
+| Surface | Direction | Purpose |
 |------|-----------|---------|
-| **Dispatch/Captain** | Captain → Abdout | Updates, decisions, summaries |
-| **Dispatch/Cowork** | Cowork ↔ Code | Bridge between thinking and doing (also `~/.claude/bridge.md`) |
-| **Dispatch/Inbox** | Abdout → Captain | Instructions, approvals, priorities |
+| **`PushNotification` tool** | Captain → Abdout's iPhone | Decisions, escalations, weekly summary pings (Anthropic mobile app receives) |
+| **`~/.claude/bridge.md`** | Cowork ↔ Code | Bridge between thinking and doing (file lives in `~/.claude/`; both modes read+write) |
+| **GitHub issues with `from-abdout` label** | Abdout → Captain | Instructions, approvals, priorities — filed via `claude.ai/code` mobile or `/issue` |
 
-```bash
-dispatch.sh captain "message" [fyi|normal|decision|urgent]  # write
-dispatch.sh read inbox                                       # read
-dispatch.sh cowork "Plan done. Issues: #1, #2"               # bridge
+```
+PushNotification(title="Decision needed", body="Hogwarts pricing change >20% — 72h deadline")
+gh issue create --label "priority/decision,from-abdout" --title "..." --body "..."
+# Cowork bridge: Edit ~/.claude/bridge.md from either side
 ```
 
-Syncs to iPhone via iCloud.
+Abdout reads on iPhone via the Anthropic mobile app (native push) and on the go via `claude.ai/code` mobile browser. No iCloud sync, no extra tools.
 
-**Escalation tagging**: every dispatch with `[decision]` or `[urgent]` priority must include a deadline. The captain follows up at the deadline if no response.
+**Escalation tagging**: every `PushNotification` for a `[decision]` or `[urgent]` item must include the deadline in the body. The captain follows up at the deadline if no response (second push + GitHub-issue priority bump).
 
 ### Channel 2: GitHub Issues (Work Items)
 
@@ -451,7 +459,9 @@ captain (you):
 ```
 captain (you):
   → Read customers.json — confirm last_contact_date
-  → Dispatch [decision] to Abdout: "King Fahad re-engagement needed. Options: (a) Ali calls, (b) Sedon WhatsApp via Saudi number, (c) Abdout direct email"
+  → PushNotification to Abdout: title="King Fahad re-engagement [decision, 24h]"
+                                 body="Options: (a) Ali calls, (b) Sedon WhatsApp, (c) Abdout direct email"
+  → File companion GitHub issue with priority/decision + from-captain labels (durable record)
   → Wait for Abdout's choice (24h deadline)
   → On response: assign owner, set next_action_due
   → Update R-006 risk status in risks.json
@@ -462,12 +472,13 @@ captain (you):
 ## Autopilot Authorization
 
 ### Captain CAN (no permission needed):
-- Read/write Apple Notes in the Databayt folder
+- Send `PushNotification` to Abdout's mobile (Anthropic app) for decisions/escalations
+- Read/write `~/.claude/bridge.md` for Cowork ↔ Code handoffs
+- Send Slack messages via slack MCP (`/slack send`) for team-wide async
 - Create/close GitHub issues in any databayt repo
 - Read GitHub repos, PRs, commits
 - Run monitoring checks (Vercel, Sentry, Neon)
 - Create scheduled tasks (routines)
-- Dispatch to Abdout via any channel
 - Research using browser
 - Update `.claude/memory/*.json` state files (runway, pipeline, capacity, north_star) when reading authoritative source data
 - Append to `captain_journal.md`, `weekly/`, `monthly/`, `quarterly/` archives

--- a/.claude/rules/cowork-bridge.md
+++ b/.claude/rules/cowork-bridge.md
@@ -1,6 +1,6 @@
 # Cowork ↔ Claude Code Bridge
 
-Cowork and Claude Code are separate sessions sharing the same `~/.claude/` directory. They do NOT share conversation history. The bridge is a file + GitHub Issues.
+Cowork and Claude Code are separate sessions sharing the same `~/.claude/` directory. They do NOT share conversation history. The bridge is a file + GitHub Issues + native push.
 
 ## How It Actually Works
 
@@ -10,7 +10,8 @@ Cowork and Claude Code are separate sessions sharing the same `~/.claude/` direc
 | Write `~/.claude/bridge.md` | Yes (filesystem MCP) | Yes (Write tool) |
 | Read `~/.claude/memory/` | Yes (filesystem MCP) | Yes (auto-loaded) |
 | GitHub issues | Yes (github MCP) | Yes (gh CLI + github MCP) |
-| Apple Notes (dispatch.sh) | No (needs bash) | Yes (osascript) |
+| `PushNotification` to Abdout's mobile | Yes (native tool) | Yes (native tool) |
+| Slack messages | Yes (slack MCP) | Yes (slack MCP) |
 | Run bash commands | No | Yes |
 | Use hooks | No | Yes |
 | Use skills (/commands) | No | Yes |
@@ -37,13 +38,13 @@ Cowork and Claude Code are separate sessions sharing the same `~/.claude/` direc
 
 ### Claude Code session
 1. Read `~/.claude/bridge.md` — check for Cowork handoffs
-2. `dispatch.sh read inbox` — check Abdout's Apple Notes instructions
-3. `gh issue list --repo databayt/kun --state open` — check work queue
+2. `gh issue list --repo databayt/kun --state open --label "from-abdout,priority/blocking" --json title,number` — check Abdout's instructions + blockers
+3. `gh issue list --repo databayt/kun --state open` — full work queue
 4. Proceed with highest priority
 
 ### Cowork session
 1. Read `~/.claude/bridge.md` via filesystem MCP — check for Code results
-2. Check GitHub issues for completed/blocked items
+2. Check GitHub issues for completed/blocked items (label `from-abdout` or `priority/blocking`)
 3. Plan next moves, update bridge.md with plan
 
 ## What's NOT Shared
@@ -59,10 +60,11 @@ Cowork has tool access via `~/Library/Application Support/Claude/claude_desktop_
 - **filesystem** — reads/writes ~/.claude/, ~/kun, ~/codebase
 - **github** — repos, issues, PRs in databayt org
 
-## Apple Notes (Code-Only)
+## Reaching Abdout asynchronously
 
-dispatch.sh requires bash/osascript — only works from Claude Code:
-- `dispatch.sh captain "update"` — write to Notes for Abdout's iPhone
-- `dispatch.sh read inbox` — read Abdout's instructions
+Both Cowork and Code reach Abdout via native primitives — no shell wrapper, no platform-specific dance:
 
-Cowork cannot use dispatch.sh. If Cowork needs to reach Abdout asynchronously, write to bridge.md or create a GitHub issue.
+- **`PushNotification`** tool → Anthropic mobile app on his iPhone (instant, attention-grabbing)
+- **GitHub issue** with `from-captain` or `priority/blocking` label, assigned `@abdout` (durable record + mobile-readable via `claude.ai/code`)
+- **`bridge.md`** for Cowork ↔ Code handoffs that don't need his attention (in-band)
+- **Slack DM via slack MCP** for team-visible async (rarely needed for direct Abdout reach)

--- a/content/docs/architecture.mdx
+++ b/content/docs/architecture.mdx
@@ -125,15 +125,15 @@ Phone (iOS) ──Dispatch──▶ Desktop App ──/teleport──▶ Termina
 
 | Channel | Medium | Direction | Purpose |
 |---------|--------|-----------|---------|
-| **Dispatch** | Apple Notes → Dispatch (Captain, Cowork, Inbox) | Async, bidirectional | Updates, decisions, handoffs |
+| **Native push + bridge** | `PushNotification` (Anthropic mobile) + `~/.claude/bridge.md` + GitHub Issues (`from-captain` / `from-abdout`) | Async, bidirectional | Updates, decisions, handoffs |
 | **GitHub Issues** | databayt/*/issues | Structured work items | Tasks with labels, milestones, assignees |
 | **Claude Native** | Code / Cowork / Voice | Real-time | Building, planning, quick decisions |
 
 ### Cowork ↔ Code Bridge
 
 ```
-Cowork (think): plan → create issues → write to Dispatch/Cowork
-Code (do):      read Dispatch/Cowork → pick up issues → execute → report back
+Cowork (think): plan → create issues → append to ~/.claude/bridge.md
+Code (do):      read bridge.md → pick up issues → execute → write results back to bridge.md
 ```
 
 Shared state: `~/.claude/` (agents, memory, settings, rules). Same brain, two modes.

--- a/content/docs/captain.mdx
+++ b/content/docs/captain.mdx
@@ -117,6 +117,6 @@ captain:
 
 Captain communicates through 3 channels:
 
-1. **Dispatch** (Apple Notes) — async updates, decisions, handoffs
-2. **GitHub Issues** — structured work items with labels and milestones
-3. **Claude Native** — real-time via Code, Cowork, or Voice
+1. **Native Push + Cowork Bridge** — `PushNotification` tool to Abdout's iPhone (Anthropic mobile app); `~/.claude/bridge.md` for Cowork ↔ Code handoffs
+2. **GitHub Issues** — structured work items with labels and milestones (`from-captain`, `priority/blocking`, `priority/decision`)
+3. **Claude Native** — real-time via Code, Cowork, Voice, or `claude.ai/code` mobile browser

--- a/content/docs/cowork.mdx
+++ b/content/docs/cowork.mdx
@@ -22,7 +22,7 @@ Both modes read and write to:
 |----------|------|---------|
 | Agents | `~/.claude/agents/` | Same 40 agents in both modes |
 | Memory | `~/.claude/memory/` | Persistent state |
-| Dispatch/Cowork | Notes → Dispatch → Cowork | Handoff note |
+| Bridge file | `~/.claude/bridge.md` | Cowork ↔ Code handoff note |
 | GitHub Issues | databayt/*/issues | Shared work queue |
 
 ## Handoff: Cowork → Code
@@ -31,8 +31,8 @@ When work starts in Cowork (planning, strategy, research):
 
 1. Cowork produces a deliverable: plan, architecture, stories
 2. Cowork creates GitHub issues for actionable items
-3. Cowork writes to Dispatch/Cowork note
-4. Code reads Cowork note at session start
+3. Cowork appends to `~/.claude/bridge.md`
+4. Code reads `bridge.md` at session start
 5. Code picks up the issues and executes
 
 ### Example
@@ -42,17 +42,17 @@ When work starts in Cowork (planning, strategy, research):
 Abdout: "Plan the hogwarts notification system"
 → Research patterns, design architecture, write stories
 → Create issues: databayt/hogwarts#10, #11, #12
-→ dispatch.sh cowork "Notification system planned. 3 issues created."
+→ Append to ~/.claude/bridge.md: "Notification system planned. Issues: #10, #11, #12."
 
 [Claude Code session]
-Captain: reads Cowork note → sees plan → starts executing #10
+Captain: reads bridge.md → sees plan → starts executing #10
 ```
 
 ## Handoff: Code → Cowork
 
 When Code finishes work that needs strategic review:
 
-1. Code writes to Dispatch/Cowork
+1. Code writes to `~/.claude/bridge.md`
 2. Code creates a GitHub issue if follow-up is needed
 3. Cowork picks up in the next Desktop session
 
@@ -86,19 +86,19 @@ When Code finishes work that needs strategic review:
 
 ### Every Cowork Session
 
-1. Check Dispatch/Cowork note for Code's output
-2. Review GitHub issues for completed/blocked items
+1. Read `~/.claude/bridge.md` for Code's latest output
+2. Review GitHub issues for completed/blocked items (label `from-code` or `priority/blocking`)
 3. Plan next moves
 
 ### Every Code Session
 
-1. `dispatch.sh read inbox` — check Abdout's instructions
-2. `dispatch.sh read cowork` — check for Cowork handoffs
-3. `gh issue list --state open` — check work queue
+1. Read `~/.claude/bridge.md` — check for Cowork handoffs
+2. `gh issue list --state open --label "from-abdout,priority/blocking"` — check Abdout's instructions + blockers
+3. `gh issue list --state open` — full work queue
 4. Proceed with highest priority
 
 ## The Key Insight
 
-Cowork doesn't need to know how to code. Claude Code doesn't need to strategize. They share a brain through files, notes, and issues.
+Cowork doesn't need to know how to code. Claude Code doesn't need to strategize. They share a brain through `bridge.md` + GitHub Issues + native push notifications.
 
 Abdout switches between them like switching between thinking and doing. Both are Captain — one thinks, one acts.

--- a/content/docs/slack.mdx
+++ b/content/docs/slack.mdx
@@ -147,14 +147,16 @@ Agents like `captain`, `ops`, and `support` can use Slack for:
 - **Support**: Customer issue updates to #hogwarts
 - **Growth**: Content announcements to #general
 
-### Dispatch Integration
+### Captain Async via Slack
 
-The dispatch system can route messages through Slack:
+For team-visible captain summaries (Friday review, Monday plan), use the slack MCP directly:
 
-```bash
-# Captain dispatch goes to both Apple Notes and Slack
-dispatch slack "Weekly: revenue at $X, 3 PRs merged, hogwarts demo Thursday"
 ```
+# Captain posts to #general via slack MCP
+/slack send #general "Weekly: revenue at $X, 3 PRs merged, hogwarts demo Thursday"
+```
+
+For founder-direct pings, the captain uses `PushNotification` (Anthropic mobile) instead — Slack for team, push for Abdout.
 
 ## Cowork Bridge
 

--- a/content/docs/tips.mdx
+++ b/content/docs/tips.mdx
@@ -84,9 +84,9 @@ Start on desktop, continue from phone:
 
 ```
 Desktop: Start feature work → gets complex → need to leave
-Phone:   Open Claude iOS → Remote Control → monitor progress
-Phone:   dispatch.sh inbox "Ship it when done"
-Desktop: Captain reads inbox → finishes and deploys
+Phone:   Open claude.ai/code in mobile browser → monitor progress
+Phone:   File a GitHub issue with the `from-abdout` label: "Ship it when done"
+Desktop: Captain checks `from-abdout` issues at session start → finishes and deploys
 ```
 
 ## Agent Teams (Experimental)

--- a/content/docs/voice.mdx
+++ b/content/docs/voice.mdx
@@ -43,11 +43,11 @@ Voice: "I'm thinking about the notification system for hogwarts.
 → Claude transcribes, structures into a plan, creates issues
 ```
 
-### Review Dispatches
+### Review Captain Summary
 
 ```
-Voice: "Read me the latest captain dispatch"
-→ dispatch.sh read captain → speaks the content
+Voice: "Read me the latest captain weekly summary"
+→ reads the latest .claude/memory/weekly/<date>.md → speaks the content
 ```
 
 ### Create Issues by Voice

--- a/content/docs/workflows.mdx
+++ b/content/docs/workflows.mdx
@@ -324,13 +324,13 @@ Cowork (Samia):
 
 ## Communication Channels
 
-### Channel 1: Dispatch (Apple Notes, Async)
+### Channel 1: Native Push + Cowork Bridge (Async)
 
-| Note | Direction | Purpose |
+| Surface | Direction | Purpose |
 |------|-----------|---------|
-| **Captain** | Captain to Abdout | Updates, decisions, summaries |
-| **Cowork** | Cowork to Code | Bridge between thinking and doing |
-| **Inbox** | Abdout to Captain | Instructions, approvals, priorities |
+| **`PushNotification` tool** | Captain → Abdout | Decisions, escalations, weekly summary pings (Anthropic mobile app receives) |
+| **`~/.claude/bridge.md`** | Cowork ↔ Code | Bridge between thinking and doing (file both modes read+write) |
+| **GitHub issue (`from-abdout` label)** | Abdout → Captain | Instructions, approvals, priorities — filed via `claude.ai/code` mobile or `/issue` |
 
 ### Channel 2: GitHub Issues (Structured Work)
 


### PR DESCRIPTION
## Why

PR #111 hard-deleted `.claude/scripts/dispatch.sh`, but `captain.md` + `cowork-bridge.md` + 7 product docs still referenced it. Captain would error at runtime when trying to dispatch. This PR completes the anthropic-native cutover.

Closes #112

## Native replacements

| Old function | Native replacement |
|---|---|
| Push to Abdout's iPhone | `PushNotification` tool → Anthropic mobile app |
| Async team comms | GitHub Issues (`priority/blocking`, `priority/decision`, `from-captain`, `from-abdout` labels) + Slack MCP (`/slack send`) |
| Cowork ↔ Code handoff | `~/.claude/bridge.md` (promoted from secondary to primary) |
| Captain weekly digest | Slack #general via slack MCP + `PushNotification` ping to Abdout |

## `.claude/agents/captain.md` — 10 edit sites

- Added `PushNotification` to `tools:` array (frontmatter)
- Session-start protocol: `dispatch.sh read inbox/cowork` → read `bridge.md` + `gh issue list --label from-abdout,priority/blocking`
- ACT items: `dispatch_to_team_via_slack_or_apple_notes` → `notify_team_via_slack_mcp_or_pushnotification_to_abdout_mobile`
- Escalation channel paragraph rewritten as 3-step native escalation:
  1. `PushNotification` to mobile (instant)
  2. GitHub issue with `priority/blocking` (24h) or `priority/decision` (72h) label
  3. Slack DM via slack MCP (team-visible)
  24h/72h follow-up cadence preserved
- Monday plan + Friday review: Apple Notes dispatch lines → Slack post + push
- Channel 1 section completely rewritten: **Native Push + Cowork Bridge** (`PushNotification` + `bridge.md` + GitHub Issues `from-abdout`)
- Autopilot CAN: dropped Apple Notes; explicit grants for `PushNotification`, `bridge.md`, Slack MCP
- Cross-agent example "Ahmed Baha re-engagement" updated: dispatch [decision] → `PushNotification(title=..., body=...)` + companion GitHub issue (durable record)

## `.claude/rules/cowork-bridge.md`

- Capability table: dropped Apple Notes row, added `PushNotification` + Slack MCP rows
- Session-start: dropped `dispatch.sh read`; added `gh issue list --label from-abdout,priority/blocking` for both Code + Cowork sessions
- "Apple Notes (Code-Only)" section → "Reaching Abdout asynchronously" with 4 native primitives

## 7 product docs swept

| File | Change |
|---|---|
| `content/docs/captain.mdx` | 3-channel summary updated |
| `content/docs/cowork.mdx` | Shared State table, handoff examples, both session-start protocols |
| `content/docs/workflows.mdx` | Channel 1 table |
| `content/docs/architecture.mdx` | 3-channel comm table + bridge flow narrative |
| `content/docs/slack.mdx` | `dispatch slack` bash snippet → `/slack send` MCP |
| `content/docs/voice.mdx` | "read latest dispatch" → "read latest weekly file" |
| `content/docs/tips.mdx` | Phone→desktop remote-control example uses GitHub issue with `from-abdout` label |

## Memory files left alone

`.claude/memory/*` (learnings.md, risks.json, 1on1/, decisions/) reference Apple Notes/dispatch historically — these are intentional record per issue #112 acceptance criteria. They document what *was*, not what *is*.

## Exit gates

\`\`\`bash
# No dispatch.sh refs outside memory/
grep -rnE 'dispatch\.sh' .claude content | grep -vE '/memory/|/legacy/'
# ✅ empty

# No Apple Notes refs outside memory/ (except the deliberate "No Apple Notes" line in onboarding.mdx)
grep -rinE 'apple notes|dispatch/(captain|cowork|inbox)' .claude content | grep -vE '/memory/'
# ✅ only onboarding.mdx:267 "No Tailscale, no Apple Notes..." (intentional)
\`\`\`

## Test plan

- [ ] Captain agent loads cleanly: `claude --agent captain` — frontmatter parses, all referenced tools present
- [ ] Mock Monday cycle: captain reads session-start sources, allocates team, posts to Slack #general (via mock), sends PushNotification (verify via Anthropic mobile app)
- [ ] Mock escalation: captain decides "King Fahad re-engagement", sends PushNotification + creates `priority/decision,from-captain` GitHub issue — both arrive
- [ ] `pnpm build` of docs site green

## Net

9 files changed, **+84 / -69** lines. Net +15 (more verbose native references replace concise bash one-liners).

🤖 Generated with [Claude Code](https://claude.com/claude-code)