### PR TITLE
chore(engine): native path-scoping, drift guards, and a safety hook

### DIFF
--- a/.claude/agents/package.md
+++ b/.claude/agents/package.md
@@ -1,7 +1,7 @@
 ---
 name: package
 description: Cross-repo dependency manager - version audit, upgrade coordination, consistency enforcement across all databayt repos
-model: opus
+model: sonnet
 version: "databayt v1.0"
 handoff: [tech-lead, build, ops, guardian]
 ---
@@ -16,19 +16,20 @@ Audit, update, and maintain package dependencies across all databayt repositorie
 
 ## Repositories
 
-| Repo | Path | Profile |
-|------|------|---------|
-| **kun** | `/Users/abdout/kun` | Config engine, docs site (39 deps) |
-| **hogwarts** | `/Users/abdout/hogwarts` | Education SaaS, heaviest (212 deps) |
-| **souq** | `/Users/abdout/souq` | E-commerce marketplace (37 deps) |
-| **mkan** | `/Users/abdout/mkan` | Rental marketplace (84 deps) |
-| **shifa** | `/Users/abdout/shifa` | Medical platform (73 deps) |
-| **codebase** | `/Users/abdout/codebase` | Pattern library (131 deps) |
-| **marketing** | `/Users/abdout/marketing` | Landing pages (68 deps) |
+| Repo          | Path                      | Profile                             |
+| ------------- | ------------------------- | ----------------------------------- |
+| **kun**       | `/Users/abdout/kun`       | Config engine, docs site (39 deps)  |
+| **hogwarts**  | `/Users/abdout/hogwarts`  | Education SaaS, heaviest (212 deps) |
+| **souq**      | `/Users/abdout/souq`      | E-commerce marketplace (37 deps)    |
+| **mkan**      | `/Users/abdout/mkan`      | Rental marketplace (84 deps)        |
+| **shifa**     | `/Users/abdout/shifa`     | Medical platform (73 deps)          |
+| **codebase**  | `/Users/abdout/codebase`  | Pattern library (131 deps)          |
+| **marketing** | `/Users/abdout/marketing` | Landing pages (68 deps)             |
 
 ## Workflow
 
 ### `package` (no args) — Full Audit
+
 1. Read `package.json` from all 7 repos
 2. Build cross-repo version matrix
 3. Check latest versions via `npm view <pkg> version`
@@ -38,12 +39,14 @@ Audit, update, and maintain package dependencies across all databayt repositorie
 7. Output structured report with priority actions
 
 ### `package audit` — Quick Health Check
+
 1. Read all `package.json` files
 2. Compare shared packages across repos
 3. Flag inconsistencies only (no npm lookups)
 4. Report in under 30 seconds
 
 ### `package update <repo>` — Update Single Repo
+
 1. Read that repo's `package.json`
 2. Check latest versions for all deps
 3. Classify: safe (patch/minor) vs breaking (major)
@@ -52,6 +55,7 @@ Audit, update, and maintain package dependencies across all databayt repositorie
 6. Report what changed
 
 ### `package update <package>` — Update Single Package Across Repos
+
 1. Find all repos using that package
 2. Check latest version
 3. Update in all repos to same version
@@ -59,12 +63,14 @@ Audit, update, and maintain package dependencies across all databayt repositorie
 5. Report results
 
 ### `package sync` — Align All Repos
+
 1. Build the "target version" for each shared package
 2. Update all repos to target versions
 3. Run `pnpm build` in each repo
 4. Report successes and failures
 
 ### `package align <package>` — Align One Package
+
 1. Find highest version of that package across repos
 2. Update all repos to that version
 3. Verify builds
@@ -74,32 +80,40 @@ Audit, update, and maintain package dependencies across all databayt repositorie
 These packages appear in 3+ repos and MUST be version-aligned:
 
 ### Core Framework (align exactly)
+
 - `next`, `react`, `react-dom`, `typescript`, `tailwindcss`
 
 ### Data Layer (align exactly)
+
 - `@prisma/client`, `prisma`, `zod`
 
 ### Auth (align exactly)
+
 - `next-auth`, `@auth/prisma-adapter`
 
 ### UI Foundation (align within minor)
+
 - `lucide-react`, `class-variance-authority`, `clsx`, `tailwind-merge`
 - `@radix-ui/*`, `framer-motion`, `cmdk`, `vaul`, `sonner`
 - `embla-carousel-react`, `input-otp`, `react-day-picker`
 
 ### Shared Utilities (align within minor)
+
 - `date-fns`, `bcryptjs`, `uuid`, `nanoid`, `react-hook-form`
 - `@hookform/resolvers`, `resend`, `geist`, `next-themes`
 
 ### Monitoring (align within minor)
+
 - `@sentry/nextjs`, `@vercel/analytics`
 
 ### Testing (align within minor)
+
 - `vitest`, `@playwright/test`, `@testing-library/react`
 
 ## Risk Detection
 
 Flag these patterns automatically:
+
 1. **`latest` tag** — Never use `latest` in production (e.g., `radix-ui: latest`)
 2. **Stale betas** — Beta deps older than 3 months
 3. **Major version split** — Same package at different major versions across repos
@@ -111,15 +125,18 @@ Flag these patterns automatically:
 ## Update Strategy
 
 ### Safe (auto-apply)
+
 - Patch versions (x.x.PATCH)
 - Minor versions within same major when no breaking changes documented
 
 ### Review (propose, don't apply)
+
 - Minor versions with known breaking changes
 - Pre-release/beta bumps
 - Packages with peer dependency constraints
 
 ### Plan (create issue, coordinate)
+
 - Major version upgrades (Next 15→16, Zod 3→4, Prisma 6→7)
 - Framework upgrades that affect multiple repos
 - Auth/payment provider upgrades (Stripe, Clerk)
@@ -160,12 +177,12 @@ Flag these patterns automatically:
 
 ## Handoffs
 
-| Situation | Hand to |
-|-----------|---------|
-| Major framework upgrade plan | `tech-lead` |
-| Build failure after update | `build` |
-| Security vulnerability in dep | `guardian` |
-| Deployment after updates | `ops` / `deploy` |
-| Breaking API change | `typescript` |
+| Situation                     | Hand to          |
+| ----------------------------- | ---------------- |
+| Major framework upgrade plan  | `tech-lead`      |
+| Build failure after update    | `build`          |
+| Security vulnerability in dep | `guardian`       |
+| Deployment after updates      | `ops` / `deploy` |
+| Breaking API change           | `typescript`     |
 
 **Rule**: Audit first. Align shared packages. Never leave repos inconsistent. Build-verify every change.

--- a/.claude/agents/quality.md
+++ b/.claude/agents/quality.md
@@ -54,7 +54,7 @@ The bridge between automated checks and human judgment.
 | 11  | `design`       | Components — ui/atom/template hierarchy              | `tailwind-v4/`                   |
 | 12  | `stack`        | Technology — versions, imports, deprecated APIs      | all `rules/<domain>/`            |
 
-> Code-side keywords cite the atomic rules under `.claude/rules/<domain>/` (frontmatter: `domain`, `severity`, `applies-to`, `since`; Good/Bad/Fix body). Report each finding as `rule-id (severity)` — e.g. `use-action-state (error)`. Full mapping: `.claude/rules/patterns.md` § Rule Corpus.
+> Code-side keywords cite the atomic rules under `.claude/rules/<domain>/` (frontmatter: `domain`, `severity`, `paths`, `since`; Good/Bad/Fix body). Report each finding as `rule-id (severity)` — e.g. `use-action-state (error)`. Full mapping: `.claude/rules/patterns.md` § Rule Corpus.
 
 ### Deep — investigation + optimization
 

--- a/.claude/engine.json
+++ b/.claude/engine.json
@@ -1,10 +1,10 @@
 {
-  "$comment": "Single source of truth for kun engine metadata. Prose/docs reference this file instead of hardcoding numbers. /health (.claude/scripts/health.sh) reads it and warns when docs or reality drift from these values. Agent frontmatter stays `model: opus` (the alias) — never pin a number there.",
+  "$comment": "Single source of truth for kun engine metadata. Prose/docs reference this file instead of hardcoding numbers. /health (.claude/scripts/health.sh) reads it and warns when docs or reality drift from these values. Agent frontmatter uses a model alias (`opus`/`sonnet`/`haiku` per `model_tiers`) — never pin a version number there.",
   "model": "claude-opus-4-8",
   "model_label": "Opus 4.8",
   "model_context": "1M",
   "engine_version": "databayt v3.1",
-  "updated": "2026-05-31",
+  "updated": "2026-06-04",
   "counts": {
     "project_agents": 18,
     "user_agents": 27,
@@ -13,8 +13,15 @@
     "user_skills": 22,
     "pattern_cards": 10,
     "project_rules": 3,
+    "domain_rules": 29,
     "project_mcp": 25,
     "user_mcp": 19
+  },
+  "model_tiers": {
+    "$comment": "Per-agent model alias by task type. The portable stack fleet (~/.claude/agents) follows this; the project fleet defaults to opus (quality-over-speed) except purely mechanical agents.",
+    "opus": "architecture, orchestration, deep reasoning, code review/fixes, and strategy/leadership agents",
+    "sonnet": "standard build agents + the mechanical project agent (package)",
+    "haiku": "routine/formatting agents (comment, git, icon, github, semantic, sse, structure)"
   },
   "commit_footer": "Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
 }

--- a/.claude/hooks/block-destructive-bash.sh
+++ b/.claude/hooks/block-destructive-bash.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# block-destructive-bash.sh — PreToolUse(Bash) safety guard for the kun engine.
+#
+# Reads the hook JSON on stdin, extracts .tool_input.command, and exits 2 — which
+# BLOCKS the tool call and surfaces stderr back to Claude — when the command
+# matches an irreversible / data-destroying pattern. Exit 0 = allow.
+#
+# This ENFORCES, as a gate, what the prisma-6 "no destructive migrations" rule and
+# the permission deny-list only advise. It is a safety net, not a sandbox: patterns
+# are intentionally narrow so routine work (rm -rf node_modules, .next, dist) is
+# never blocked — only catastrophic forms (rm -rf / , ~, *, .) and history/data
+# destruction are. Tune the PATTERNS array below if a real command is wrongly hit.
+#
+# Canonical source: .claude/hooks/. Wired into project .claude/settings.json via
+# ${CLAUDE_PROJECT_DIR}, and bundled into the kun-company plugin via
+# ${CLAUDE_PLUGIN_ROOT} so it travels with installs.
+
+set -uo pipefail
+
+json="$(cat)"
+cmd="$(printf '%s' "$json" | jq -r '.tool_input.command // empty' 2>/dev/null)"
+[ -z "$cmd" ] && cmd="$json" # fallback when jq is unavailable: scan raw payload
+
+# reason@@extended-regex  (single-quoted so every regex metachar is literal).
+# Matched case-insensitively against the command string.
+PATTERNS=(
+  'rm -rf on / , ~, *, or .  (routine targets like node_modules are allowed)@@rm[[:space:]]+-[a-z]*[rf][a-z]*[[:space:]]+(/|~|\*|\.{1,2})([[:space:]]|$)'
+  'prisma migrate reset — drops every table on the connected DB@@prisma[[:space:]]+migrate[[:space:]]+reset'
+  'prisma db push --accept-data-loss — silent column/table drops@@--accept-data-loss'
+  'git reset --hard — discards uncommitted local work@@git[[:space:]]+reset[[:space:]]+--hard'
+  'git clean -f… — deletes untracked files irrecoverably@@git[[:space:]]+clean[[:space:]]+-[a-z]*f'
+  'force push — rewrites shared history (use --force-with-lease)@@git[[:space:]]+push[[:space:]].*(--force([[:space:]]|$)|-f([[:space:]]|$))'
+  'destructive SQL — DROP/TRUNCATE destroys data@@(drop[[:space:]]+(table|database)|truncate[[:space:]]+table)'
+)
+
+for entry in "${PATTERNS[@]}"; do
+  reason="${entry%%@@*}"
+  regex="${entry##*@@}"
+  if printf '%s' "$cmd" | grep -Eiq -e "$regex"; then # -e: patterns may start with --
+    {
+      echo "⛔ kun safety hook blocked a destructive command."
+      echo "   Reason : $reason"
+      echo "   Command: $cmd"
+      echo "   If this is intentional, run it in a plain terminal or edit .claude/hooks/block-destructive-bash.sh."
+    } >&2
+    exit 2
+  fi
+done
+
+exit 0

--- a/.claude/rules/authjs/action-authz-check.md
+++ b/.claude/rules/authjs/action-authz-check.md
@@ -1,7 +1,7 @@
 ---
 domain: authjs
 severity: error
-applies-to: ["**/actions.ts", "**/actions/*.ts"]
+paths: ["**/actions.ts", "**/actions/*.ts"]
 since: "Auth.js 5.0"
 ---
 

--- a/.claude/rules/authjs/guard-at-boundary.md
+++ b/.claude/rules/authjs/guard-at-boundary.md
@@ -1,7 +1,7 @@
 ---
 domain: authjs
 severity: error
-applies-to:
+paths:
   ["**/layout.tsx", "**/page.tsx", "**/actions.ts", "**/middleware.ts"]
 since: "Auth.js 5.0"
 ---

--- a/.claude/rules/authjs/session-tenant-binding.md
+++ b/.claude/rules/authjs/session-tenant-binding.md
@@ -1,7 +1,7 @@
 ---
 domain: authjs
 severity: error
-applies-to:
+paths:
   ["**/actions.ts", "**/actions/*.ts", "**/auth.ts", "**/auth.config.ts"]
 since: "Auth.js 5.0"
 ---

--- a/.claude/rules/neon/branch-per-pr.md
+++ b/.claude/rules/neon/branch-per-pr.md
@@ -1,7 +1,7 @@
 ---
 domain: neon
 severity: info
-applies-to:
+paths:
   [
     "**/prisma/schema.prisma",
     "**/prisma/migrations/**",

--- a/.claude/rules/neon/pooled-connection-serverless.md
+++ b/.claude/rules/neon/pooled-connection-serverless.md
@@ -1,7 +1,7 @@
 ---
 domain: neon
 severity: warn
-applies-to: ["**/db.ts", "**/prisma.ts", "**/lib/db.ts", "**/actions.ts"]
+paths: ["**/db.ts", "**/prisma.ts", "**/lib/db.ts", "**/actions.ts"]
 since: "Neon"
 ---
 

--- a/.claude/rules/next-16/async-request-apis.md
+++ b/.claude/rules/next-16/async-request-apis.md
@@ -1,7 +1,7 @@
 ---
 domain: next-16
 severity: error
-applies-to:
+paths:
   [
     "**/page.tsx",
     "**/layout.tsx",

--- a/.claude/rules/next-16/minimize-client-boundary.md
+++ b/.claude/rules/next-16/minimize-client-boundary.md
@@ -1,7 +1,7 @@
 ---
 domain: next-16
 severity: warn
-applies-to: ["**/page.tsx", "**/content.tsx", "**/*.tsx"]
+paths: ["**/page.tsx", "**/content.tsx", "**/*.tsx"]
 since: "Next.js 16.0"
 ---
 

--- a/.claude/rules/next-16/revalidate-after-write.md
+++ b/.claude/rules/next-16/revalidate-after-write.md
@@ -1,7 +1,7 @@
 ---
 domain: next-16
 severity: error
-applies-to: ["**/actions.ts"]
+paths: ["**/actions.ts"]
 since: "Next.js 16.0"
 ---
 

--- a/.claude/rules/next-16/server-actions-for-mutations.md
+++ b/.claude/rules/next-16/server-actions-for-mutations.md
@@ -1,7 +1,7 @@
 ---
 domain: next-16
 severity: error
-applies-to: ["**/actions.ts", "**/form.tsx", "**/*.client.tsx"]
+paths: ["**/actions.ts", "**/form.tsx", "**/*.client.tsx"]
 since: "Next.js 16.0"
 ---
 

--- a/.claude/rules/next-16/use-cache-directive.md
+++ b/.claude/rules/next-16/use-cache-directive.md
@@ -1,7 +1,7 @@
 ---
 domain: next-16
 severity: warn
-applies-to:
+paths:
   [
     "**/actions.ts",
     "**/page.tsx",

--- a/.claude/rules/patterns.md
+++ b/.claude/rules/patterns.md
@@ -27,7 +27,7 @@ When building a new feature that involves one of these keywords:
 
 ## Rule Corpus — keyword → rule directory
 
-The code-side quality keywords (see `.claude/agents/quality.md`) cite atomic, severity-tagged rules under `.claude/rules/<domain>/`. Each rule has frontmatter (`domain`, `severity`, `applies-to`, `since`) and Good/Bad/Fix sections. When a keyword runs, read the matching domain dir(s) and cite findings as `rule-id (severity)`.
+The code-side quality keywords (see `.claude/agents/quality.md`) cite atomic, severity-tagged rules under `.claude/rules/<domain>/`. Each rule has frontmatter (`domain`, `severity`, `paths`, `since`) and Good/Bad/Fix sections. `paths` is Claude Code's native path-scoping field (quoted glob array), so each rule auto-loads only when Claude touches a matching file — the 3 cross-cutting rules at `.claude/rules/*.md` carry no `paths` and load unconditionally. When a keyword runs, read the matching domain dir(s) and cite findings as `rule-id (severity)`.
 
 | Keyword   | Rule directories                                                                                                                                |
 | --------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -38,4 +38,4 @@ The code-side quality keywords (see `.claude/agents/quality.md`) cite atomic, se
 
 Domains (29 rules total): `react-19` (5), `next-16` (5), `typescript-strict` (4), `tailwind-v4` (4), `prisma-6` (4), `authjs` (3), `neon` (2), `s3` (2).
 
-Adding a rule: drop a new `<slug>.md` in the right domain dir with the standard frontmatter + Good/Bad/Fix. No agent changes needed — the keyword reads the whole dir.
+Adding a rule: drop a new `<slug>.md` in the right domain dir with the standard frontmatter (`domain` / `severity` / `paths` glob array / `since`) + Good/Bad/Fix. No agent changes needed — the keyword reads the whole dir, and `paths` scopes the ambient auto-load.

--- a/.claude/rules/prisma-6/no-destructive-migrations-on-main.md
+++ b/.claude/rules/prisma-6/no-destructive-migrations-on-main.md
@@ -1,7 +1,7 @@
 ---
 domain: prisma-6
 severity: error
-applies-to:
+paths:
   [
     "**/schema.prisma",
     "**/package.json",

--- a/.claude/rules/prisma-6/select-not-overfetch.md
+++ b/.claude/rules/prisma-6/select-not-overfetch.md
@@ -1,7 +1,7 @@
 ---
 domain: prisma-6
 severity: warn
-applies-to:
+paths:
   ["**/actions.ts", "**/content.tsx", "**/page.tsx", "**/*.queries.ts"]
 since: "Prisma 6.0"
 ---

--- a/.claude/rules/prisma-6/tenant-scope-every-query.md
+++ b/.claude/rules/prisma-6/tenant-scope-every-query.md
@@ -1,7 +1,7 @@
 ---
 domain: prisma-6
 severity: error
-applies-to:
+paths:
   ["**/actions.ts", "**/content.tsx", "**/page.tsx", "**/*.queries.ts"]
 since: "Prisma 6.0"
 ---

--- a/.claude/rules/prisma-6/transactions-for-multistep.md
+++ b/.claude/rules/prisma-6/transactions-for-multistep.md
@@ -1,7 +1,7 @@
 ---
 domain: prisma-6
 severity: warn
-applies-to: ["**/actions.ts", "**/*.queries.ts"]
+paths: ["**/actions.ts", "**/*.queries.ts"]
 since: "Prisma 6.0"
 ---
 

--- a/.claude/rules/react-19/actions-return-not-throw.md
+++ b/.claude/rules/react-19/actions-return-not-throw.md
@@ -1,7 +1,7 @@
 ---
 domain: react-19
 severity: error
-applies-to: ["**/actions.ts", "**/actions.tsx", "**/*.action.ts"]
+paths: ["**/actions.ts", "**/actions.tsx", "**/*.action.ts"]
 since: "React 19.0"
 ---
 

--- a/.claude/rules/react-19/rsc-default.md
+++ b/.claude/rules/react-19/rsc-default.md
@@ -1,7 +1,7 @@
 ---
 domain: react-19
 severity: warn
-applies-to:
+paths:
   ["**/page.tsx", "**/layout.tsx", "**/content.tsx", "**/components/**/*.tsx"]
 since: "React 19.0"
 ---

--- a/.claude/rules/react-19/use-action-state.md
+++ b/.claude/rules/react-19/use-action-state.md
@@ -1,7 +1,7 @@
 ---
 domain: react-19
 severity: error
-applies-to: ["**/form.tsx", "**/*-form.tsx", "**/components/**/form/*.tsx"]
+paths: ["**/form.tsx", "**/*-form.tsx", "**/components/**/form/*.tsx"]
 since: "React 19.0"
 ---
 

--- a/.claude/rules/react-19/use-hook-for-promises.md
+++ b/.claude/rules/react-19/use-hook-for-promises.md
@@ -1,7 +1,7 @@
 ---
 domain: react-19
 severity: info
-applies-to: ["**/*.tsx", "**/components/**/*.tsx"]
+paths: ["**/*.tsx", "**/components/**/*.tsx"]
 since: "React 19.0"
 ---
 

--- a/.claude/rules/react-19/use-optimistic.md
+++ b/.claude/rules/react-19/use-optimistic.md
@@ -1,7 +1,7 @@
 ---
 domain: react-19
 severity: info
-applies-to: ["**/content.tsx", "**/*-list.tsx", "**/form.tsx"]
+paths: ["**/content.tsx", "**/*-list.tsx", "**/form.tsx"]
 since: "React 19.0"
 ---
 

--- a/.claude/rules/s3/presigned-urls.md
+++ b/.claude/rules/s3/presigned-urls.md
@@ -1,7 +1,7 @@
 ---
 domain: s3
 severity: error
-applies-to: ["**/actions.ts", "**/upload/**/*.ts", "**/lib/s3.ts"]
+paths: ["**/actions.ts", "**/upload/**/*.ts", "**/lib/s3.ts"]
 since: "AWS S3"
 ---
 

--- a/.claude/rules/s3/serve-via-cloudfront.md
+++ b/.claude/rules/s3/serve-via-cloudfront.md
@@ -1,7 +1,7 @@
 ---
 domain: s3
 severity: warn
-applies-to: ["**/actions.ts", "**/content.tsx", "**/page.tsx", "**/columns.tsx"]
+paths: ["**/actions.ts", "**/content.tsx", "**/page.tsx", "**/columns.tsx"]
 since: "AWS S3"
 ---
 

--- a/.claude/rules/tailwind-v4/logical-properties-rtl.md
+++ b/.claude/rules/tailwind-v4/logical-properties-rtl.md
@@ -1,7 +1,7 @@
 ---
 domain: tailwind-v4
 severity: error
-applies-to:
+paths:
   ["**/*.tsx", "**/page.tsx", "**/content.tsx", "**/form.tsx", "**/*.css"]
 since: "Tailwind 4.0"
 ---

--- a/.claude/rules/tailwind-v4/no-hardcoded-colors.md
+++ b/.claude/rules/tailwind-v4/no-hardcoded-colors.md
@@ -1,7 +1,7 @@
 ---
 domain: tailwind-v4
 severity: warn
-applies-to:
+paths:
   ["**/*.tsx", "**/page.tsx", "**/content.tsx", "**/form.tsx", "**/table.tsx"]
 since: "Tailwind 4.0"
 ---

--- a/.claude/rules/tailwind-v4/oklch-colors.md
+++ b/.claude/rules/tailwind-v4/oklch-colors.md
@@ -1,7 +1,7 @@
 ---
 domain: tailwind-v4
 severity: warn
-applies-to: ["**/*.css", "**/globals.css", "**/theme.css"]
+paths: ["**/*.css", "**/globals.css", "**/theme.css"]
 since: "Tailwind 4.0"
 ---
 

--- a/.claude/rules/tailwind-v4/theme-directive-tokens.md
+++ b/.claude/rules/tailwind-v4/theme-directive-tokens.md
@@ -1,7 +1,7 @@
 ---
 domain: tailwind-v4
 severity: error
-applies-to:
+paths:
   ["**/*.css", "**/globals.css", "**/theme.css", "**/tailwind.config.*"]
 since: "Tailwind 4.0"
 ---

--- a/.claude/rules/typescript-strict/derive-types-from-source.md
+++ b/.claude/rules/typescript-strict/derive-types-from-source.md
@@ -1,7 +1,7 @@
 ---
 domain: typescript-strict
 severity: info
-applies-to:
+paths:
   [
     "**/validation.ts",
     "**/actions.ts",

--- a/.claude/rules/typescript-strict/explicit-public-return-types.md
+++ b/.claude/rules/typescript-strict/explicit-public-return-types.md
@@ -1,7 +1,7 @@
 ---
 domain: typescript-strict
 severity: warn
-applies-to: ["**/actions.ts", "**/lib/**/*.ts", "**/data/**/*.ts", "**/*.ts"]
+paths: ["**/actions.ts", "**/lib/**/*.ts", "**/data/**/*.ts", "**/*.ts"]
 since: "TypeScript 5.0"
 ---
 

--- a/.claude/rules/typescript-strict/no-any.md
+++ b/.claude/rules/typescript-strict/no-any.md
@@ -1,7 +1,7 @@
 ---
 domain: typescript-strict
 severity: error
-applies-to: ["**/actions.ts", "**/validation.ts", "**/*.ts", "**/*.tsx"]
+paths: ["**/actions.ts", "**/validation.ts", "**/*.ts", "**/*.tsx"]
 since: "TypeScript 5.0"
 ---
 

--- a/.claude/rules/typescript-strict/strict-tsconfig.md
+++ b/.claude/rules/typescript-strict/strict-tsconfig.md
@@ -1,7 +1,7 @@
 ---
 domain: typescript-strict
 severity: error
-applies-to: ["tsconfig.json", "**/tsconfig.json", ".github/workflows/*.yml"]
+paths: ["tsconfig.json", "**/tsconfig.json", ".github/workflows/*.yml"]
 since: "TypeScript 5.0"
 ---
 

--- a/.claude/scripts/build-plugin.sh
+++ b/.claude/scripts/build-plugin.sh
@@ -73,6 +73,14 @@ for f in "$ROOT"/.claude/rules/*/*.md; do
   rel="${f#$ROOT/.claude/rules/}"
   copy_one "$f" "$CO/rules/$rel"
 done
+# Safety hooks — bundle the destructive-bash guard so kun-company installs get it
+# too (the project .claude/settings.json wires the same canonical script in-repo).
+# Only the script syncs from source; hooks/hooks.json is a stable committed asset.
+[ "$CHECK" = 0 ] && mkdir -p "$CO/hooks"
+for f in "$ROOT"/.claude/hooks/*.sh; do
+  [ -e "$f" ] || continue
+  copy_one "$f" "$CO/hooks/$(basename "$f")"
+done
 
 # ── Secret guard — plugin files must carry placeholders only ────────
 if grep -REn 'sk-[A-Za-z0-9]{16}|ghp_[A-Za-z0-9]{16}|AKIA[A-Z0-9]{12}' "$ROOT/plugins" 2>/dev/null | grep -v '\${'; then

--- a/.claude/scripts/health.sh
+++ b/.claude/scripts/health.sh
@@ -128,16 +128,19 @@ if [ -f "$ENGINE_JSON" ] && command -v jq &> /dev/null; then
     EC_CMDS=$(jq -r '.counts.commands' "$ENGINE_JSON")
     EC_CARDS=$(jq -r '.counts.pattern_cards' "$ENGINE_JSON")
     EC_RULES=$(jq -r '.counts.project_rules' "$ENGINE_JSON")
+    EC_DOMAIN_RULES=$(jq -r '.counts.domain_rules' "$ENGINE_JSON")
     EC_MCP=$(jq -r '.counts.project_mcp' "$ENGINE_JSON")
     ER_AGENTS=$(find "$KUN_ROOT/.claude/agents" -maxdepth 1 -name '*.md' ! -name '_index*' 2>/dev/null | wc -l | tr -d ' ')
     ER_CMDS=$(find "$KUN_ROOT/.claude/commands" -maxdepth 1 -name '*.md' 2>/dev/null | wc -l | tr -d ' ')
     ER_CARDS=$(find "$KUN_ROOT/.claude/patterns/cards" -maxdepth 1 -name '*.md' 2>/dev/null | wc -l | tr -d ' ')
     ER_RULES=$(find "$KUN_ROOT/.claude/rules" -maxdepth 1 -name '*.md' 2>/dev/null | wc -l | tr -d ' ')
+    ER_DOMAIN_RULES=$(find "$KUN_ROOT/.claude/rules" -mindepth 2 -name '*.md' 2>/dev/null | wc -l | tr -d ' ')
     ER_MCP=$(jq '.mcpServers | length' "$KUN_ROOT/.claude/mcp.json" 2>/dev/null || echo "?")
     [ "$EC_AGENTS" = "$ER_AGENTS" ] && check pass "engine agents" "$ER_AGENTS" || check warn "engine agents" "engine.json=$EC_AGENTS actual=$ER_AGENTS"
     [ "$EC_CMDS" = "$ER_CMDS" ] && check pass "engine commands" "$ER_CMDS" || check warn "engine commands" "engine.json=$EC_CMDS actual=$ER_CMDS"
     [ "$EC_CARDS" = "$ER_CARDS" ] && check pass "engine cards" "$ER_CARDS" || check warn "engine cards" "engine.json=$EC_CARDS actual=$ER_CARDS"
     [ "$EC_RULES" = "$ER_RULES" ] && check pass "engine rules" "$ER_RULES" || check warn "engine rules" "engine.json=$EC_RULES actual=$ER_RULES"
+    [ "$EC_DOMAIN_RULES" = "$ER_DOMAIN_RULES" ] && check pass "engine domain-rules" "$ER_DOMAIN_RULES" || check warn "engine domain-rules" "engine.json=$EC_DOMAIN_RULES actual=$ER_DOMAIN_RULES"
     [ "$EC_MCP" = "$ER_MCP" ] && check pass "engine mcp" "$ER_MCP" || check warn "engine mcp" "engine.json=$EC_MCP actual=$ER_MCP"
     if grep -rq "Opus 4\.6\|Opus 4\.7\|claude-opus-4-6\|claude-opus-4-7" "$KUN_ROOT/docs" "$KUN_ROOT/.claude/CLAUDE.md" 2>/dev/null; then
         check warn "engine model refs" "stale Opus 4.6/4.7 in docs"

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -18,6 +18,15 @@
             "command": "lsof -ti:3000 | xargs kill -9 2>/dev/null; exit 0"
           }
         ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PROJECT_DIR}/.claude/hooks/block-destructive-bash.sh\""
+          }
+        ]
       }
     ],
     "PostToolUse": [

--- a/.github/workflows/config-drift.yml
+++ b/.github/workflows/config-drift.yml
@@ -1,0 +1,28 @@
+name: config-drift
+
+# Keeps the kun plugin trees (plugins/) in sync with their canonical sources in
+# .claude/. build-plugin.sh --check fully verifies the kun-company plugin (its
+# sources live in the repo) and gracefully skips kun-stack (whose sources live in
+# ~/.claude, absent in CI — verify that one locally before pushing).
+#
+# health.sh is intentionally NOT run here: it audits the whole local Claude Code
+# environment (~/.claude, MCP servers, team configs) and is a developer tool, not
+# a CI gate. The script is also non-destructive in --check mode (no rm -rf).
+
+on:
+  pull_request:
+    paths:
+      - ".claude/**"
+      - "plugins/**"
+      - ".github/workflows/config-drift.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  drift:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Verify plugins are in sync with .claude/ sources
+        run: bash .claude/scripts/build-plugin.sh --check

--- a/docs/CONFIG-BENCHMARK.md
+++ b/docs/CONFIG-BENCHMARK.md
@@ -1,0 +1,76 @@
+# Config Benchmark — kun vs. the best public Claude Code setups
+
+> Consolidated 2026-06-04. Counts and the model live in `.claude/engine.json` (the
+> single source of truth); this doc captures _decisions and rationale_, not numbers.
+
+We surveyed the strongest public Claude Code configurations — Anthropic's own docs and
+example plugins, the AGENTS.md ecosystem (Vercel `next.js`, OpenAI `codex`, Supabase), and
+the high-signal community collections (subagent fleets, hook kits, statusline tools) — then
+**verified every load-bearing claim against the official docs** before adopting anything. The
+raw research carried errors we discarded (subagents _can_ use MCP via `mcpServers`; the
+`allowManaged*` settings keys don't exist; `/output-style` is deprecated in favor of `/config`;
+no repo's star count was taken at face value). What follows is the verified picture.
+
+## Verified Claude Code feature surface (2026)
+
+| Capability        | Status               | What's actually true                                                                                                                                                                                                     |
+| ----------------- | -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Path-scoped rules | ✅ native            | `.claude/rules/*.md` with a `paths:` glob frontmatter load **only** when Claude touches a match; no `paths` = always-on. Quote globs (`["**/*.tsx"]`); `globs:` is a fallback alias; injection is most reliable on Read. |
+| `AGENTS.md`       | ⚠️ not read natively | Only via `@AGENTS.md` import in `CLAUDE.md` or a symlink; `/init` folds an existing one in. The cross-tool standard (Codex/Cursor/Copilot read it directly).                                                             |
+| Hooks             | ✅ 28 events         | `PreToolUse` exiting **2 blocks** the tool (stderr → Claude); handler types `command \| http \| mcp_tool \| prompt \| agent`; plugins bundle `hooks/hooks.json` (auto-discovered).                                       |
+| Subagents         | ✅ rich frontmatter  | `model` (`opus\|sonnet\|haiku\|inherit`), `tools`, `disallowedTools`, `permissionMode`, `skills`, **`mcpServers`** (MCP _is_ available), `memory`, `isolation: worktree`.                                                |
+| Skills            | ✅                   | `context: fork` + `agent: <type>` run a skill in a forked subagent; `allowed-tools`, `paths`, and `` !`cmd` `` dynamic injection are real.                                                                               |
+| Plugins/market    | ✅                   | `.claude-plugin/marketplace.json` catalog + per-plugin `plugin.json`; `${CLAUDE_PLUGIN_ROOT}` for bundled scripts (exec-form `args`).                                                                                    |
+| Settings          | ✅                   | Precedence managed → CLI → local → project → user; `allow/deny/ask`. Real managed keys: `claudeMd`, `forceLoginOrgUUID`.                                                                                                 |
+| Output styles     | ✅                   | `~/.claude/output-styles/*.md`; set via `/config` (the `/output-style` command was removed).                                                                                                                             |
+
+## Where kun already leads (kept as-is)
+
+- **Two-plugin marketplace built from canonical sources** (`build-plugin.sh`) with a `--check`
+  drift mode _and_ a literal-secret guard — most public repos hand-maintain their plugin trees.
+- **`engine.json` as a single source of truth** + `/health` drift detection.
+- A real **idea→ship pipeline** with human gates and keyword routing.
+- The Good/Bad/Fix **rule corpus** and an **already-tiered portable agent fleet** (opus for
+  architecture/orchestration, sonnet for build agents, haiku for routine ones) — the community
+  best-practice we'd otherwise have had to adopt.
+
+## What this benchmark changed
+
+1. **Path-scoped the rule corpus.** The 29 domain rules used a custom `applies-to:` field Claude
+   Code ignores, so all of them loaded into _every_ session. Renamed to the native `paths:` —
+   each rule now auto-loads only when Claude touches a matching file. Explicit reads by the
+   quality agent / `/check` are unaffected; we only shed the redundant always-on context cost.
+2. **Closed drift gaps.** Added a `domain_rules` count to `engine.json` (the rule corpus was
+   untracked by `/health`, which only counted top-level files) and a `config-drift` CI workflow
+   that runs `build-plugin.sh --check` on PRs touching `.claude/**` or `plugins/**`.
+3. **Shipped a safety guard as a hook.** `block-destructive-bash.sh` (PreToolUse, exit-2-blocks)
+   enforces what the prisma-6 rule and the deny-list only advise — `rm -rf /`, `prisma migrate
+reset`, `--accept-data-loss`, `git reset --hard`, force-push, `DROP/TRUNCATE`. Narrow by
+   design: routine `rm -rf node_modules` and `--force-with-lease` pass. Wired in project settings
+   _and_ bundled into the kun-company plugin so it travels with installs.
+4. **Confirmed model tiering.** The portable fleet was already textbook-tiered; only the project
+   fleet was uniformly opus. Downtiered `package` (mechanical dep audit) to sonnet and codified
+   the policy in `engine.json` → `model_tiers`.
+
+## Model-tiering policy
+
+See `engine.json` → `model_tiers`. In short: **opus** for architecture, orchestration, deep
+reasoning, code review/fixes, and strategy/leadership; **sonnet** for standard build agents and
+mechanical project agents; **haiku** for routine/formatting agents. `report` stays on **opus**
+despite being a "loop" agent — it performs real code fixes, and quality-over-speed wins over the
+negligible cost saving on a non-hot-path agent.
+
+## Why Claude-native (not AGENTS.md)
+
+`AGENTS.md` is the emerging cross-tool standard, but Claude Code doesn't read it natively (only via
+`@import`/symlink), and kun is deliberately Anthropic-native — it _configures_ the Claude Code
+harness (skills, hooks, plugins, output styles) rather than targeting a lowest-common-denominator
+file. Adopting `AGENTS.md` would add a sync surface for capabilities other tools can't act on. If
+the databayt stack is ever driven by Cursor/Codex at scale, the cheap bridge is a generated
+`AGENTS.md` that `CLAUDE.md` `@import`s — revisit then, not now.
+
+## Sources
+
+Official: `code.claude.com/docs/en/{memory,hooks,skills,sub-agents,settings,plugins-reference,output-styles}`.
+Ecosystem: `agents.md`; `vercel/next.js`, `openai/codex`, `supabase/agent-skills` AGENTS.md files;
+community subagent/hook/statusline collections (used for convergent patterns, not verbatim).

--- a/plugins/kun-company/agents/package.md
+++ b/plugins/kun-company/agents/package.md
@@ -1,7 +1,7 @@
 ---
 name: package
 description: Cross-repo dependency manager - version audit, upgrade coordination, consistency enforcement across all databayt repos
-model: opus
+model: sonnet
 version: "databayt v1.0"
 handoff: [tech-lead, build, ops, guardian]
 ---
@@ -16,19 +16,20 @@ Audit, update, and maintain package dependencies across all databayt repositorie
 
 ## Repositories
 
-| Repo | Path | Profile |
-|------|------|---------|
-| **kun** | `/Users/abdout/kun` | Config engine, docs site (39 deps) |
-| **hogwarts** | `/Users/abdout/hogwarts` | Education SaaS, heaviest (212 deps) |
-| **souq** | `/Users/abdout/souq` | E-commerce marketplace (37 deps) |
-| **mkan** | `/Users/abdout/mkan` | Rental marketplace (84 deps) |
-| **shifa** | `/Users/abdout/shifa` | Medical platform (73 deps) |
-| **codebase** | `/Users/abdout/codebase` | Pattern library (131 deps) |
-| **marketing** | `/Users/abdout/marketing` | Landing pages (68 deps) |
+| Repo          | Path                      | Profile                             |
+| ------------- | ------------------------- | ----------------------------------- |
+| **kun**       | `/Users/abdout/kun`       | Config engine, docs site (39 deps)  |
+| **hogwarts**  | `/Users/abdout/hogwarts`  | Education SaaS, heaviest (212 deps) |
+| **souq**      | `/Users/abdout/souq`      | E-commerce marketplace (37 deps)    |
+| **mkan**      | `/Users/abdout/mkan`      | Rental marketplace (84 deps)        |
+| **shifa**     | `/Users/abdout/shifa`     | Medical platform (73 deps)          |
+| **codebase**  | `/Users/abdout/codebase`  | Pattern library (131 deps)          |
+| **marketing** | `/Users/abdout/marketing` | Landing pages (68 deps)             |
 
 ## Workflow
 
 ### `package` (no args) — Full Audit
+
 1. Read `package.json` from all 7 repos
 2. Build cross-repo version matrix
 3. Check latest versions via `npm view <pkg> version`
@@ -38,12 +39,14 @@ Audit, update, and maintain package dependencies across all databayt repositorie
 7. Output structured report with priority actions
 
 ### `package audit` — Quick Health Check
+
 1. Read all `package.json` files
 2. Compare shared packages across repos
 3. Flag inconsistencies only (no npm lookups)
 4. Report in under 30 seconds
 
 ### `package update <repo>` — Update Single Repo
+
 1. Read that repo's `package.json`
 2. Check latest versions for all deps
 3. Classify: safe (patch/minor) vs breaking (major)
@@ -52,6 +55,7 @@ Audit, update, and maintain package dependencies across all databayt repositorie
 6. Report what changed
 
 ### `package update <package>` — Update Single Package Across Repos
+
 1. Find all repos using that package
 2. Check latest version
 3. Update in all repos to same version
@@ -59,12 +63,14 @@ Audit, update, and maintain package dependencies across all databayt repositorie
 5. Report results
 
 ### `package sync` — Align All Repos
+
 1. Build the "target version" for each shared package
 2. Update all repos to target versions
 3. Run `pnpm build` in each repo
 4. Report successes and failures
 
 ### `package align <package>` — Align One Package
+
 1. Find highest version of that package across repos
 2. Update all repos to that version
 3. Verify builds
@@ -74,32 +80,40 @@ Audit, update, and maintain package dependencies across all databayt repositorie
 These packages appear in 3+ repos and MUST be version-aligned:
 
 ### Core Framework (align exactly)
+
 - `next`, `react`, `react-dom`, `typescript`, `tailwindcss`
 
 ### Data Layer (align exactly)
+
 - `@prisma/client`, `prisma`, `zod`
 
 ### Auth (align exactly)
+
 - `next-auth`, `@auth/prisma-adapter`
 
 ### UI Foundation (align within minor)
+
 - `lucide-react`, `class-variance-authority`, `clsx`, `tailwind-merge`
 - `@radix-ui/*`, `framer-motion`, `cmdk`, `vaul`, `sonner`
 - `embla-carousel-react`, `input-otp`, `react-day-picker`
 
 ### Shared Utilities (align within minor)
+
 - `date-fns`, `bcryptjs`, `uuid`, `nanoid`, `react-hook-form`
 - `@hookform/resolvers`, `resend`, `geist`, `next-themes`
 
 ### Monitoring (align within minor)
+
 - `@sentry/nextjs`, `@vercel/analytics`
 
 ### Testing (align within minor)
+
 - `vitest`, `@playwright/test`, `@testing-library/react`
 
 ## Risk Detection
 
 Flag these patterns automatically:
+
 1. **`latest` tag** — Never use `latest` in production (e.g., `radix-ui: latest`)
 2. **Stale betas** — Beta deps older than 3 months
 3. **Major version split** — Same package at different major versions across repos
@@ -111,15 +125,18 @@ Flag these patterns automatically:
 ## Update Strategy
 
 ### Safe (auto-apply)
+
 - Patch versions (x.x.PATCH)
 - Minor versions within same major when no breaking changes documented
 
 ### Review (propose, don't apply)
+
 - Minor versions with known breaking changes
 - Pre-release/beta bumps
 - Packages with peer dependency constraints
 
 ### Plan (create issue, coordinate)
+
 - Major version upgrades (Next 15→16, Zod 3→4, Prisma 6→7)
 - Framework upgrades that affect multiple repos
 - Auth/payment provider upgrades (Stripe, Clerk)
@@ -160,12 +177,12 @@ Flag these patterns automatically:
 
 ## Handoffs
 
-| Situation | Hand to |
-|-----------|---------|
-| Major framework upgrade plan | `tech-lead` |
-| Build failure after update | `build` |
-| Security vulnerability in dep | `guardian` |
-| Deployment after updates | `ops` / `deploy` |
-| Breaking API change | `typescript` |
+| Situation                     | Hand to          |
+| ----------------------------- | ---------------- |
+| Major framework upgrade plan  | `tech-lead`      |
+| Build failure after update    | `build`          |
+| Security vulnerability in dep | `guardian`       |
+| Deployment after updates      | `ops` / `deploy` |
+| Breaking API change           | `typescript`     |
 
 **Rule**: Audit first. Align shared packages. Never leave repos inconsistent. Build-verify every change.

--- a/plugins/kun-company/agents/quality.md
+++ b/plugins/kun-company/agents/quality.md
@@ -54,7 +54,7 @@ The bridge between automated checks and human judgment.
 | 11  | `design`       | Components — ui/atom/template hierarchy              | `tailwind-v4/`                   |
 | 12  | `stack`        | Technology — versions, imports, deprecated APIs      | all `rules/<domain>/`            |
 
-> Code-side keywords cite the atomic rules under `.claude/rules/<domain>/` (frontmatter: `domain`, `severity`, `applies-to`, `since`; Good/Bad/Fix body). Report each finding as `rule-id (severity)` — e.g. `use-action-state (error)`. Full mapping: `.claude/rules/patterns.md` § Rule Corpus.
+> Code-side keywords cite the atomic rules under `.claude/rules/<domain>/` (frontmatter: `domain`, `severity`, `paths`, `since`; Good/Bad/Fix body). Report each finding as `rule-id (severity)` — e.g. `use-action-state (error)`. Full mapping: `.claude/rules/patterns.md` § Rule Corpus.
 
 ### Deep — investigation + optimization
 

--- a/plugins/kun-company/hooks/block-destructive-bash.sh
+++ b/plugins/kun-company/hooks/block-destructive-bash.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# block-destructive-bash.sh — PreToolUse(Bash) safety guard for the kun engine.
+#
+# Reads the hook JSON on stdin, extracts .tool_input.command, and exits 2 — which
+# BLOCKS the tool call and surfaces stderr back to Claude — when the command
+# matches an irreversible / data-destroying pattern. Exit 0 = allow.
+#
+# This ENFORCES, as a gate, what the prisma-6 "no destructive migrations" rule and
+# the permission deny-list only advise. It is a safety net, not a sandbox: patterns
+# are intentionally narrow so routine work (rm -rf node_modules, .next, dist) is
+# never blocked — only catastrophic forms (rm -rf / , ~, *, .) and history/data
+# destruction are. Tune the PATTERNS array below if a real command is wrongly hit.
+#
+# Canonical source: .claude/hooks/. Wired into project .claude/settings.json via
+# ${CLAUDE_PROJECT_DIR}, and bundled into the kun-company plugin via
+# ${CLAUDE_PLUGIN_ROOT} so it travels with installs.
+
+set -uo pipefail
+
+json="$(cat)"
+cmd="$(printf '%s' "$json" | jq -r '.tool_input.command // empty' 2>/dev/null)"
+[ -z "$cmd" ] && cmd="$json" # fallback when jq is unavailable: scan raw payload
+
+# reason@@extended-regex  (single-quoted so every regex metachar is literal).
+# Matched case-insensitively against the command string.
+PATTERNS=(
+  'rm -rf on / , ~, *, or .  (routine targets like node_modules are allowed)@@rm[[:space:]]+-[a-z]*[rf][a-z]*[[:space:]]+(/|~|\*|\.{1,2})([[:space:]]|$)'
+  'prisma migrate reset — drops every table on the connected DB@@prisma[[:space:]]+migrate[[:space:]]+reset'
+  'prisma db push --accept-data-loss — silent column/table drops@@--accept-data-loss'
+  'git reset --hard — discards uncommitted local work@@git[[:space:]]+reset[[:space:]]+--hard'
+  'git clean -f… — deletes untracked files irrecoverably@@git[[:space:]]+clean[[:space:]]+-[a-z]*f'
+  'force push — rewrites shared history (use --force-with-lease)@@git[[:space:]]+push[[:space:]].*(--force([[:space:]]|$)|-f([[:space:]]|$))'
+  'destructive SQL — DROP/TRUNCATE destroys data@@(drop[[:space:]]+(table|database)|truncate[[:space:]]+table)'
+)
+
+for entry in "${PATTERNS[@]}"; do
+  reason="${entry%%@@*}"
+  regex="${entry##*@@}"
+  if printf '%s' "$cmd" | grep -Eiq -e "$regex"; then # -e: patterns may start with --
+    {
+      echo "⛔ kun safety hook blocked a destructive command."
+      echo "   Reason : $reason"
+      echo "   Command: $cmd"
+      echo "   If this is intentional, run it in a plain terminal or edit .claude/hooks/block-destructive-bash.sh."
+    } >&2
+    exit 2
+  fi
+done
+
+exit 0

--- a/plugins/kun-company/hooks/hooks.json
+++ b/plugins/kun-company/hooks/hooks.json
@@ -1,0 +1,17 @@
+{
+  "$comment": "Auto-discovered when kun-company is installed. Bundles the destructive-bash safety guard so it travels with installs (the project .claude/settings.json wires the same canonical script for in-repo work). Exec form per the plugins reference: ${CLAUDE_PLUGIN_ROOT} is passed as an args element, not interpolated into a shell string.",
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash",
+            "args": ["${CLAUDE_PLUGIN_ROOT}/hooks/block-destructive-bash.sh"]
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/kun-company/rules/authjs/action-authz-check.md
+++ b/plugins/kun-company/rules/authjs/action-authz-check.md
@@ -1,7 +1,7 @@
 ---
 domain: authjs
 severity: error
-applies-to: ["**/actions.ts", "**/actions/*.ts"]
+paths: ["**/actions.ts", "**/actions/*.ts"]
 since: "Auth.js 5.0"
 ---
 

--- a/plugins/kun-company/rules/authjs/guard-at-boundary.md
+++ b/plugins/kun-company/rules/authjs/guard-at-boundary.md
@@ -1,7 +1,7 @@
 ---
 domain: authjs
 severity: error
-applies-to:
+paths:
   ["**/layout.tsx", "**/page.tsx", "**/actions.ts", "**/middleware.ts"]
 since: "Auth.js 5.0"
 ---

--- a/plugins/kun-company/rules/authjs/session-tenant-binding.md
+++ b/plugins/kun-company/rules/authjs/session-tenant-binding.md
@@ -1,7 +1,7 @@
 ---
 domain: authjs
 severity: error
-applies-to:
+paths:
   ["**/actions.ts", "**/actions/*.ts", "**/auth.ts", "**/auth.config.ts"]
 since: "Auth.js 5.0"
 ---

--- a/plugins/kun-company/rules/neon/branch-per-pr.md
+++ b/plugins/kun-company/rules/neon/branch-per-pr.md
@@ -1,7 +1,7 @@
 ---
 domain: neon
 severity: info
-applies-to:
+paths:
   [
     "**/prisma/schema.prisma",
     "**/prisma/migrations/**",

--- a/plugins/kun-company/rules/neon/pooled-connection-serverless.md
+++ b/plugins/kun-company/rules/neon/pooled-connection-serverless.md
@@ -1,7 +1,7 @@
 ---
 domain: neon
 severity: warn
-applies-to: ["**/db.ts", "**/prisma.ts", "**/lib/db.ts", "**/actions.ts"]
+paths: ["**/db.ts", "**/prisma.ts", "**/lib/db.ts", "**/actions.ts"]
 since: "Neon"
 ---
 

--- a/plugins/kun-company/rules/next-16/async-request-apis.md
+++ b/plugins/kun-company/rules/next-16/async-request-apis.md
@@ -1,7 +1,7 @@
 ---
 domain: next-16
 severity: error
-applies-to:
+paths:
   [
     "**/page.tsx",
     "**/layout.tsx",

--- a/plugins/kun-company/rules/next-16/minimize-client-boundary.md
+++ b/plugins/kun-company/rules/next-16/minimize-client-boundary.md
@@ -1,7 +1,7 @@
 ---
 domain: next-16
 severity: warn
-applies-to: ["**/page.tsx", "**/content.tsx", "**/*.tsx"]
+paths: ["**/page.tsx", "**/content.tsx", "**/*.tsx"]
 since: "Next.js 16.0"
 ---
 

--- a/plugins/kun-company/rules/next-16/revalidate-after-write.md
+++ b/plugins/kun-company/rules/next-16/revalidate-after-write.md
@@ -1,7 +1,7 @@
 ---
 domain: next-16
 severity: error
-applies-to: ["**/actions.ts"]
+paths: ["**/actions.ts"]
 since: "Next.js 16.0"
 ---
 

--- a/plugins/kun-company/rules/next-16/server-actions-for-mutations.md
+++ b/plugins/kun-company/rules/next-16/server-actions-for-mutations.md
@@ -1,7 +1,7 @@
 ---
 domain: next-16
 severity: error
-applies-to: ["**/actions.ts", "**/form.tsx", "**/*.client.tsx"]
+paths: ["**/actions.ts", "**/form.tsx", "**/*.client.tsx"]
 since: "Next.js 16.0"
 ---
 

--- a/plugins/kun-company/rules/next-16/use-cache-directive.md
+++ b/plugins/kun-company/rules/next-16/use-cache-directive.md
@@ -1,7 +1,7 @@
 ---
 domain: next-16
 severity: warn
-applies-to:
+paths:
   [
     "**/actions.ts",
     "**/page.tsx",

--- a/plugins/kun-company/rules/patterns.md
+++ b/plugins/kun-company/rules/patterns.md
@@ -27,7 +27,7 @@ When building a new feature that involves one of these keywords:
 
 ## Rule Corpus — keyword → rule directory
 
-The code-side quality keywords (see `.claude/agents/quality.md`) cite atomic, severity-tagged rules under `.claude/rules/<domain>/`. Each rule has frontmatter (`domain`, `severity`, `applies-to`, `since`) and Good/Bad/Fix sections. When a keyword runs, read the matching domain dir(s) and cite findings as `rule-id (severity)`.
+The code-side quality keywords (see `.claude/agents/quality.md`) cite atomic, severity-tagged rules under `.claude/rules/<domain>/`. Each rule has frontmatter (`domain`, `severity`, `paths`, `since`) and Good/Bad/Fix sections. `paths` is Claude Code's native path-scoping field (quoted glob array), so each rule auto-loads only when Claude touches a matching file — the 3 cross-cutting rules at `.claude/rules/*.md` carry no `paths` and load unconditionally. When a keyword runs, read the matching domain dir(s) and cite findings as `rule-id (severity)`.
 
 | Keyword   | Rule directories                                                                                                                                |
 | --------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -38,4 +38,4 @@ The code-side quality keywords (see `.claude/agents/quality.md`) cite atomic, se
 
 Domains (29 rules total): `react-19` (5), `next-16` (5), `typescript-strict` (4), `tailwind-v4` (4), `prisma-6` (4), `authjs` (3), `neon` (2), `s3` (2).
 
-Adding a rule: drop a new `<slug>.md` in the right domain dir with the standard frontmatter + Good/Bad/Fix. No agent changes needed — the keyword reads the whole dir.
+Adding a rule: drop a new `<slug>.md` in the right domain dir with the standard frontmatter (`domain` / `severity` / `paths` glob array / `since`) + Good/Bad/Fix. No agent changes needed — the keyword reads the whole dir, and `paths` scopes the ambient auto-load.

--- a/plugins/kun-company/rules/prisma-6/no-destructive-migrations-on-main.md
+++ b/plugins/kun-company/rules/prisma-6/no-destructive-migrations-on-main.md
@@ -1,7 +1,7 @@
 ---
 domain: prisma-6
 severity: error
-applies-to:
+paths:
   [
     "**/schema.prisma",
     "**/package.json",

--- a/plugins/kun-company/rules/prisma-6/select-not-overfetch.md
+++ b/plugins/kun-company/rules/prisma-6/select-not-overfetch.md
@@ -1,7 +1,7 @@
 ---
 domain: prisma-6
 severity: warn
-applies-to:
+paths:
   ["**/actions.ts", "**/content.tsx", "**/page.tsx", "**/*.queries.ts"]
 since: "Prisma 6.0"
 ---

--- a/plugins/kun-company/rules/prisma-6/tenant-scope-every-query.md
+++ b/plugins/kun-company/rules/prisma-6/tenant-scope-every-query.md
@@ -1,7 +1,7 @@
 ---
 domain: prisma-6
 severity: error
-applies-to:
+paths:
   ["**/actions.ts", "**/content.tsx", "**/page.tsx", "**/*.queries.ts"]
 since: "Prisma 6.0"
 ---

--- a/plugins/kun-company/rules/prisma-6/transactions-for-multistep.md
+++ b/plugins/kun-company/rules/prisma-6/transactions-for-multistep.md
@@ -1,7 +1,7 @@
 ---
 domain: prisma-6
 severity: warn
-applies-to: ["**/actions.ts", "**/*.queries.ts"]
+paths: ["**/actions.ts", "**/*.queries.ts"]
 since: "Prisma 6.0"
 ---
 

--- a/plugins/kun-company/rules/react-19/actions-return-not-throw.md
+++ b/plugins/kun-company/rules/react-19/actions-return-not-throw.md
@@ -1,7 +1,7 @@
 ---
 domain: react-19
 severity: error
-applies-to: ["**/actions.ts", "**/actions.tsx", "**/*.action.ts"]
+paths: ["**/actions.ts", "**/actions.tsx", "**/*.action.ts"]
 since: "React 19.0"
 ---
 

--- a/plugins/kun-company/rules/react-19/rsc-default.md
+++ b/plugins/kun-company/rules/react-19/rsc-default.md
@@ -1,7 +1,7 @@
 ---
 domain: react-19
 severity: warn
-applies-to:
+paths:
   ["**/page.tsx", "**/layout.tsx", "**/content.tsx", "**/components/**/*.tsx"]
 since: "React 19.0"
 ---

--- a/plugins/kun-company/rules/react-19/use-action-state.md
+++ b/plugins/kun-company/rules/react-19/use-action-state.md
@@ -1,7 +1,7 @@
 ---
 domain: react-19
 severity: error
-applies-to: ["**/form.tsx", "**/*-form.tsx", "**/components/**/form/*.tsx"]
+paths: ["**/form.tsx", "**/*-form.tsx", "**/components/**/form/*.tsx"]
 since: "React 19.0"
 ---
 

--- a/plugins/kun-company/rules/react-19/use-hook-for-promises.md
+++ b/plugins/kun-company/rules/react-19/use-hook-for-promises.md
@@ -1,7 +1,7 @@
 ---
 domain: react-19
 severity: info
-applies-to: ["**/*.tsx", "**/components/**/*.tsx"]
+paths: ["**/*.tsx", "**/components/**/*.tsx"]
 since: "React 19.0"
 ---
 

--- a/plugins/kun-company/rules/react-19/use-optimistic.md
+++ b/plugins/kun-company/rules/react-19/use-optimistic.md
@@ -1,7 +1,7 @@
 ---
 domain: react-19
 severity: info
-applies-to: ["**/content.tsx", "**/*-list.tsx", "**/form.tsx"]
+paths: ["**/content.tsx", "**/*-list.tsx", "**/form.tsx"]
 since: "React 19.0"
 ---
 

--- a/plugins/kun-company/rules/s3/presigned-urls.md
+++ b/plugins/kun-company/rules/s3/presigned-urls.md
@@ -1,7 +1,7 @@
 ---
 domain: s3
 severity: error
-applies-to: ["**/actions.ts", "**/upload/**/*.ts", "**/lib/s3.ts"]
+paths: ["**/actions.ts", "**/upload/**/*.ts", "**/lib/s3.ts"]
 since: "AWS S3"
 ---
 

--- a/plugins/kun-company/rules/s3/serve-via-cloudfront.md
+++ b/plugins/kun-company/rules/s3/serve-via-cloudfront.md
@@ -1,7 +1,7 @@
 ---
 domain: s3
 severity: warn
-applies-to: ["**/actions.ts", "**/content.tsx", "**/page.tsx", "**/columns.tsx"]
+paths: ["**/actions.ts", "**/content.tsx", "**/page.tsx", "**/columns.tsx"]
 since: "AWS S3"
 ---
 

--- a/plugins/kun-company/rules/tailwind-v4/logical-properties-rtl.md
+++ b/plugins/kun-company/rules/tailwind-v4/logical-properties-rtl.md
@@ -1,7 +1,7 @@
 ---
 domain: tailwind-v4
 severity: error
-applies-to:
+paths:
   ["**/*.tsx", "**/page.tsx", "**/content.tsx", "**/form.tsx", "**/*.css"]
 since: "Tailwind 4.0"
 ---

--- a/plugins/kun-company/rules/tailwind-v4/no-hardcoded-colors.md
+++ b/plugins/kun-company/rules/tailwind-v4/no-hardcoded-colors.md
@@ -1,7 +1,7 @@
 ---
 domain: tailwind-v4
 severity: warn
-applies-to:
+paths:
   ["**/*.tsx", "**/page.tsx", "**/content.tsx", "**/form.tsx", "**/table.tsx"]
 since: "Tailwind 4.0"
 ---

--- a/plugins/kun-company/rules/tailwind-v4/oklch-colors.md
+++ b/plugins/kun-company/rules/tailwind-v4/oklch-colors.md
@@ -1,7 +1,7 @@
 ---
 domain: tailwind-v4
 severity: warn
-applies-to: ["**/*.css", "**/globals.css", "**/theme.css"]
+paths: ["**/*.css", "**/globals.css", "**/theme.css"]
 since: "Tailwind 4.0"
 ---
 

--- a/plugins/kun-company/rules/tailwind-v4/theme-directive-tokens.md
+++ b/plugins/kun-company/rules/tailwind-v4/theme-directive-tokens.md
@@ -1,7 +1,7 @@
 ---
 domain: tailwind-v4
 severity: error
-applies-to:
+paths:
   ["**/*.css", "**/globals.css", "**/theme.css", "**/tailwind.config.*"]
 since: "Tailwind 4.0"
 ---

--- a/plugins/kun-company/rules/typescript-strict/derive-types-from-source.md
+++ b/plugins/kun-company/rules/typescript-strict/derive-types-from-source.md
@@ -1,7 +1,7 @@
 ---
 domain: typescript-strict
 severity: info
-applies-to:
+paths:
   [
     "**/validation.ts",
     "**/actions.ts",

--- a/plugins/kun-company/rules/typescript-strict/explicit-public-return-types.md
+++ b/plugins/kun-company/rules/typescript-strict/explicit-public-return-types.md
@@ -1,7 +1,7 @@
 ---
 domain: typescript-strict
 severity: warn
-applies-to: ["**/actions.ts", "**/lib/**/*.ts", "**/data/**/*.ts", "**/*.ts"]
+paths: ["**/actions.ts", "**/lib/**/*.ts", "**/data/**/*.ts", "**/*.ts"]
 since: "TypeScript 5.0"
 ---
 

--- a/plugins/kun-company/rules/typescript-strict/no-any.md
+++ b/plugins/kun-company/rules/typescript-strict/no-any.md
@@ -1,7 +1,7 @@
 ---
 domain: typescript-strict
 severity: error
-applies-to: ["**/actions.ts", "**/validation.ts", "**/*.ts", "**/*.tsx"]
+paths: ["**/actions.ts", "**/validation.ts", "**/*.ts", "**/*.tsx"]
 since: "TypeScript 5.0"
 ---
 

--- a/plugins/kun-company/rules/typescript-strict/strict-tsconfig.md
+++ b/plugins/kun-company/rules/typescript-strict/strict-tsconfig.md
@@ -1,7 +1,7 @@
 ---
 domain: typescript-strict
 severity: error
-applies-to: ["tsconfig.json", "**/tsconfig.json", ".github/workflows/*.yml"]
+paths: ["tsconfig.json", "**/tsconfig.json", ".github/workflows/*.yml"]
 since: "TypeScript 5.0"
 ---
 


### PR DESCRIPTION
## Summary
Consolidates verified best-in-class Claude Code config patterns into the kun engine. Every load-bearing claim was checked against the official docs (via the `claude-code-guide`) before adoption — unverified research (subagent-MCP myth, fabricated `allowManaged*` keys, headline star counts) was discarded. Full benchmark + rationale: `docs/CONFIG-BENCHMARK.md`.

> **Stacked PR** — based on `chore/command-frontmatter` (its 19 commits aren't in `main` yet). Retarget to `main` once that merges; the diff here is only this work's 73 files.

## Changes
- **A — Path-scope the rule corpus.** All 29 domain rules: custom `applies-to:` (which Claude Code ignores) → native `paths:`. They were loading into *every* session; now each loads only when Claude touches a matching file. `patterns.md` + `quality.md` references updated. Audit coverage unchanged (quality agent / `/check` read the dirs explicitly).
- **B — Drift guards.** `engine.json` gains `domain_rules: 29` + a `/health` check (the corpus was untracked — `/health` only counted top-level files). New `.github/workflows/config-drift.yml` runs `build-plugin.sh --check` on PRs touching `.claude/**` or `plugins/**` (the repo's first CI workflow).
- **C — Safety hook.** `block-destructive-bash.sh` (PreToolUse, exit-2-blocks) enforces what the prisma-6 rule + deny-list only advise: `rm -rf /`, `prisma migrate reset`, `--accept-data-loss`, `git reset --hard`, force-push, `DROP/TRUNCATE`. Narrow by design — routine `rm -rf node_modules`, `.next`, `--force-with-lease` pass. Wired into project `settings.json` and bundled into the kun-company plugin (`hooks/hooks.json`) so it travels with installs.
- **D — Model tiering.** Downtier the mechanical `package` agent → sonnet; codify `model_tiers` in `engine.json`. The portable stack fleet was already textbook-tiered. `report` intentionally **kept opus** (it performs real code fixes; quality-over-speed) — flagging since the plan listed both; one-line change if you'd rather downtier it.
- **Decision:** stayed **Claude-native** — no AGENTS.md (it isn't read natively; kun configures the harness directly).

## Test plan
- [x] `build-plugin.sh --check` → in sync (plugins rebuilt from sources)
- [x] `/health` engine checks pass, incl. new `engine domain-rules 29`
- [x] guard self-test **22/22** — blocks catastrophic forms, allows routine ones
- [x] 29 plugin rules path-scoped (0 `applies-to` left); `engine.json` valid JSON
- [ ] post-merge: fresh session `/memory` shows domain rules absent until a matching file is opened (then react-19/next-16 rules re-appear on a `page.tsx`)

## Housekeeping (not in this PR)
- Excluded an unrelated `plugins/kun-stack/skills/test/SKILL.md` change (pre-existing drift in the shared `~/.claude/skills/test` source — rebuild it separately when ready).
- The main working tree has a leftover untracked `plugins/kun-core/` dir (already removed from tracking before this branch's base) — safe to `rm -rf plugins/kun-core`.

Closes #131

🤖 Generated with [Claude Code](https://claude.com/claude-code)